### PR TITLE
build(api-worker): add S0-06 live startup, health and worker skeleton

### DIFF
--- a/src/App.Api/Middleware/GlobalExceptionHandlingMiddleware.cs
+++ b/src/App.Api/Middleware/GlobalExceptionHandlingMiddleware.cs
@@ -1,0 +1,41 @@
+using System.Diagnostics;
+
+using BuildingBlocks.Contracts.Common;
+
+namespace App.Api.Middleware;
+
+public sealed class GlobalExceptionHandlingMiddleware(
+    RequestDelegate next,
+    ILogger<GlobalExceptionHandlingMiddleware> logger)
+{
+    public async Task InvokeAsync(HttpContext context)
+    {
+        try
+        {
+            await next(context);
+        }
+        catch (Exception exception)
+        {
+            var traceId = Activity.Current?.Id ?? context.TraceIdentifier;
+
+            logger.LogError(
+                exception,
+                "Unhandled exception in App.Api pipeline. TraceId={TraceId}",
+                traceId);
+
+            if (context.Response.HasStarted)
+            {
+                throw;
+            }
+
+            context.Response.Clear();
+            context.Response.StatusCode = StatusCodes.Status500InternalServerError;
+            context.Response.ContentType = "application/json";
+
+            await context.Response.WriteAsJsonAsync(new ApiErrorDto(
+                Code: "unhandled_error",
+                Message: "Unhandled server error.",
+                TraceId: traceId));
+        }
+    }
+}

--- a/src/App.Api/Program.cs
+++ b/src/App.Api/Program.cs
@@ -1,6 +1,89 @@
+using System.Linq;
+using System.Runtime.InteropServices;
+
+using App.Api.Middleware;
+
+using BuildingBlocks.Infrastructure.AssemblyMetadata;
+
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+var startedAtUtc = DateTimeOffset.UtcNow;
+
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Logging.ClearProviders();
+builder.Logging.AddJsonConsole(options =>
+{
+    options.IncludeScopes = true;
+});
+
+builder.Services.AddProblemDetails();
+builder.Services.AddHealthChecks()
+    .AddCheck(
+        "self",
+        () => HealthCheckResult.Healthy("App.Api self-check passed."),
+        tags: ["ready"]);
+
 var app = builder.Build();
 
-app.MapGet("/", () => "Hello World!");
+app.UseMiddleware<GlobalExceptionHandlingMiddleware>();
+
+app.MapGet(
+    "/",
+    () => Results.Ok(new
+    {
+        service = "App.Api",
+        status = "ok"
+    }));
+
+app.MapGet(
+    "/health/live",
+    (HttpContext context) => Results.Ok(new
+    {
+        status = "live",
+        service = "App.Api",
+        traceId = context.TraceIdentifier
+    }));
+
+app.MapHealthChecks(
+    "/health/ready",
+    new HealthCheckOptions
+    {
+        Predicate = registration => registration.Tags.Contains("ready"),
+        ResponseWriter = async (context, report) =>
+        {
+            context.Response.ContentType = "application/json";
+
+            await context.Response.WriteAsJsonAsync(new
+            {
+                status = report.Status.ToString().ToLowerInvariant(),
+                totalDurationMs = report.TotalDuration.TotalMilliseconds,
+                checks = report.Entries.Select(entry => new
+                {
+                    name = entry.Key,
+                    status = entry.Value.Status.ToString().ToLowerInvariant(),
+                    description = entry.Value.Description
+                })
+            });
+        }
+    });
+
+app.MapGet(
+    "/api/system/version",
+    (IHostEnvironment environment) => Results.Ok(new
+    {
+        service = environment.ApplicationName,
+        environmentName = environment.EnvironmentName,
+        version = ApplicationVersionReader.GetVersion<Program>(),
+        framework = RuntimeInformation.FrameworkDescription,
+        assemblyVersion = typeof(Program).Assembly.GetName().Version?.ToString(),
+        startedAtUtc
+    }));
+
+app.Logger.LogInformation(
+    "App.Api started. Environment={Environment} StartedAtUtc={StartedAtUtc}",
+    app.Environment.EnvironmentName,
+    startedAtUtc);
 
 app.Run();

--- a/src/App.Worker/Program.cs
+++ b/src/App.Worker/Program.cs
@@ -1,7 +1,22 @@
-using App.Worker;
+using App.Worker.Queues;
 
 var builder = Host.CreateApplicationBuilder(args);
-builder.Services.AddHostedService<Worker>();
+
+builder.Logging.ClearProviders();
+builder.Logging.AddJsonConsole(options =>
+{
+    options.IncludeScopes = true;
+});
+
+builder.Services.Configure<HostOptions>(options =>
+{
+    options.BackgroundServiceExceptionBehavior = BackgroundServiceExceptionBehavior.StopHost;
+});
+
+builder.Services.AddSingleton<IBackgroundCommandQueue, InMemoryBackgroundCommandQueue>();
+builder.Services.AddHostedService<global::App.Worker.StartupQueueSeeder>();
+builder.Services.AddHostedService<global::App.Worker.Worker>();
 
 var host = builder.Build();
+
 host.Run();

--- a/src/App.Worker/Queues/IBackgroundCommandQueue.cs
+++ b/src/App.Worker/Queues/IBackgroundCommandQueue.cs
@@ -1,0 +1,7 @@
+namespace App.Worker.Queues;
+
+public interface IBackgroundCommandQueue
+{
+    ValueTask EnqueueAsync(string commandName, CancellationToken cancellationToken = default);
+    ValueTask<string> DequeueAsync(CancellationToken cancellationToken);
+}

--- a/src/App.Worker/Queues/InMemoryBackgroundCommandQueue.cs
+++ b/src/App.Worker/Queues/InMemoryBackgroundCommandQueue.cs
@@ -1,0 +1,20 @@
+using System.Threading.Channels;
+
+namespace App.Worker.Queues;
+
+public sealed class InMemoryBackgroundCommandQueue : IBackgroundCommandQueue
+{
+    private readonly Channel<string> _channel = Channel.CreateUnbounded<string>();
+
+    public ValueTask EnqueueAsync(
+        string commandName,
+        CancellationToken cancellationToken = default)
+    {
+        return _channel.Writer.WriteAsync(commandName, cancellationToken);
+    }
+
+    public ValueTask<string> DequeueAsync(CancellationToken cancellationToken)
+    {
+        return _channel.Reader.ReadAsync(cancellationToken);
+    }
+}

--- a/src/App.Worker/StartupQueueSeeder.cs
+++ b/src/App.Worker/StartupQueueSeeder.cs
@@ -1,0 +1,23 @@
+using App.Worker.Queues;
+
+namespace App.Worker;
+
+public sealed class StartupQueueSeeder(
+    IBackgroundCommandQueue queue,
+    ILogger<StartupQueueSeeder> logger) : IHostedService
+{
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        await queue.EnqueueAsync("bootstrap-noop", cancellationToken);
+
+        logger.LogInformation(
+            "Queued bootstrap background command for App.Worker.");
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Startup queue seeder stopped.");
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/App.Worker/Worker.cs
+++ b/src/App.Worker/Worker.cs
@@ -1,16 +1,36 @@
+using System.Collections.Generic;
+
+using App.Worker.Queues;
+
 namespace App.Worker;
 
-public class Worker(ILogger<Worker> logger) : BackgroundService
+public sealed class Worker(
+    ILogger<Worker> logger,
+    IBackgroundCommandQueue queue) : BackgroundService
 {
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        while (!stoppingToken.IsCancellationRequested)
+        logger.LogInformation("App.Worker execution loop started.");
+
+        try
         {
-            if (logger.IsEnabled(LogLevel.Information))
+            while (!stoppingToken.IsCancellationRequested)
             {
-                logger.LogInformation("Worker running at: {time}", DateTimeOffset.Now);
+                var commandName = await queue.DequeueAsync(stoppingToken);
+
+                using var _ = logger.BeginScope(new Dictionary<string, object?>
+                {
+                    ["CommandName"] = commandName
+                });
+
+                logger.LogInformation("Dequeued background command.");
+                await Task.Delay(TimeSpan.FromSeconds(1), stoppingToken);
+                logger.LogInformation("Background command processed.");
             }
-            await Task.Delay(1000, stoppingToken);
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            logger.LogInformation("App.Worker stopping by cancellation.");
         }
     }
 }

--- a/src/BuildingBlocks/Infrastructure/AssemblyMetadata/ApplicationVersionReader.cs
+++ b/src/BuildingBlocks/Infrastructure/AssemblyMetadata/ApplicationVersionReader.cs
@@ -1,0 +1,15 @@
+using System.Reflection;
+
+namespace BuildingBlocks.Infrastructure.AssemblyMetadata;
+
+public static class ApplicationVersionReader
+{
+    public static string GetVersion<TMarker>()
+    {
+        var assembly = typeof(TMarker).Assembly;
+
+        return assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+            ?? assembly.GetName().Version?.ToString()
+            ?? "0.0.0";
+    }
+}

--- a/src/BuildingBlocks/Infrastructure/Class1.cs
+++ b/src/BuildingBlocks/Infrastructure/Class1.cs
@@ -1,6 +1,0 @@
-﻿namespace BuildingBlocks.Infrastructure;
-
-public class Class1
-{
-
-}


### PR DESCRIPTION
Closes #9

## Goal
Complete S0-06 by turning App.Api and App.Worker into live startup skeletons.

## Included in this PR
- App.Api startup pipeline
- /health/live
- /health/ready
- /api/system/version
- global exception handling middleware
- structured logging baseline
- App.Worker queue skeleton
- worker startup seeding
- worker execution loop baseline

## Manual verification
- local dotnet restore passed
- local dotnet build passed
- App.Api smoke endpoints responded
- App.Worker process started and processed bootstrap queue item