### PR TITLE
platform(runtime): add S0-10 feature flags, options validation and internal events foundation

### DIFF
--- a/docs/engineering/feature-flags-options-events-foundation.md
+++ b/docs/engineering/feature-flags-options-events-foundation.md
@@ -1,0 +1,31 @@
+# Feature flags, options and internal events foundation
+
+## Status
+- Stage: Sprint 0 / S0-10
+- Scope: platform runtime foundation
+
+## Feature flag naming convention
+Use:
+- Modules.<ModuleName>.<CapabilityName>Enabled
+
+Current baseline flags:
+- Modules.Auth.DevelopmentBootstrapEnabled
+- Modules.Devices.DeviceRegistrationEnabled
+
+## Options rules
+- every module has its own configuration section
+- every module has its own options class
+- validation runs on startup
+- invalid configuration must fail startup before runtime traffic
+
+## Internal event rules
+- use internal events for cross-module reactions instead of hidden direct coupling
+- event names stay explicit and business-readable
+
+Current baseline event:
+- DeviceRegistrationUpsertedInternalEvent
+
+## First working path
+- device registration publishes DeviceRegistrationUpsertedInternalEvent
+- logging handler consumes it
+- device registration can be disabled by feature flag

--- a/src/App.Api/Program.cs
+++ b/src/App.Api/Program.cs
@@ -7,6 +7,7 @@ using BuildingBlocks.Contracts.Auth;
 using BuildingBlocks.Contracts.Devices;
 using BuildingBlocks.Infrastructure.AssemblyMetadata;
 using BuildingBlocks.Infrastructure.Persistence;
+using BuildingBlocks.Infrastructure.PlatformRuntime;
 
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
@@ -14,8 +15,6 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Modules.Auth;
 using Modules.Auth.Services;
 using Modules.Devices;
-using Modules.Devices;
-using Modules.GroupTree;
 using Modules.GroupTree;
 
 var startedAtUtc = DateTimeOffset.UtcNow;
@@ -41,6 +40,7 @@ var databaseOptions = new DatabaseOptions
 };
 
 builder.Services.AddProblemDetails();
+builder.Services.AddPlatformRuntimeFoundation(builder.Configuration);
 builder.Services.AddPlatformPersistence(databaseOptions);
 builder.Services.AddAuthModule(builder.Configuration, builder.Environment);
 builder.Services.AddGroupTreeModule(builder.Configuration, builder.Environment);
@@ -115,6 +115,22 @@ app.MapGet(
         startedAtUtc
     }));
 
+app.MapGet(
+    "/api/system/platform-foundation",
+    (IFeatureFlagService featureFlags) => Results.Ok(new
+    {
+        featureFlags = new
+        {
+            authDevelopmentBootstrapEnabled = featureFlags.IsEnabled(PlatformFeatureFlags.AuthDevelopmentBootstrapEnabled),
+            devicesDeviceRegistrationEnabled = featureFlags.IsEnabled(PlatformFeatureFlags.DevicesDeviceRegistrationEnabled)
+        },
+        optionsValidation = "ValidateOnStart",
+        internalEvents = new[]
+        {
+            "DeviceRegistrationUpsertedInternalEvent"
+        }
+    }));
+
 app.MapPost(
     "/api/auth/sign-in",
     async Task<IResult> (
@@ -166,8 +182,19 @@ app.MapPost(
         IDeviceRegistrationService service,
         CancellationToken cancellationToken) =>
     {
-        var result = await service.UpsertAsync(request, cancellationToken);
-        return Results.Ok(result);
+        try
+        {
+            var result = await service.UpsertAsync(request, cancellationToken);
+            return Results.Ok(result);
+        }
+        catch (FeatureDisabledException ex)
+        {
+            return Results.Conflict(new
+            {
+                error = "feature_disabled",
+                featureFlag = ex.FlagName
+            });
+        }
     });
 
 app.Logger.LogInformation(

--- a/src/App.Api/appsettings.json
+++ b/src/App.Api/appsettings.json
@@ -21,10 +21,24 @@
       "OfflineRestrictedModeEnabled": true
     },
     "GroupTree": {
-      "DevelopmentBootstrapAdminLogin": "platform-owner"
+      "DevelopmentBootstrapAdminLogin": "platform-owner",
+      "RootNodeCode": "root",
+      "BranchNodeCode": "branch-a",
+      "SubBranchNodeCode": "branch-a-sub"
     },
     "Devices": {
-      "AllowTrustedRegistration": true
+      "AllowTrustedRegistration": true,
+      "DeviceSeenRetentionDays": 365
+    }
+  },
+  "FeatureFlags": {
+    "Modules": {
+      "Auth": {
+        "DevelopmentBootstrapEnabled": true
+      },
+      "Devices": {
+        "DeviceRegistrationEnabled": true
+      }
     }
   }
 }

--- a/src/BuildingBlocks/Infrastructure/BuildingBlocks.Infrastructure.csproj
+++ b/src/BuildingBlocks/Infrastructure/BuildingBlocks.Infrastructure.csproj
@@ -15,6 +15,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.4" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
   </ItemGroup>
 </Project>

--- a/src/BuildingBlocks/Infrastructure/PlatformRuntime/PlatformRuntimeFoundation.cs
+++ b/src/BuildingBlocks/Infrastructure/PlatformRuntime/PlatformRuntimeFoundation.cs
@@ -1,0 +1,160 @@
+using System.ComponentModel.DataAnnotations;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace BuildingBlocks.Infrastructure.PlatformRuntime;
+
+public static class PlatformFeatureFlags
+{
+    public const string AuthDevelopmentBootstrapEnabled = "Modules.Auth.DevelopmentBootstrapEnabled";
+    public const string DevicesDeviceRegistrationEnabled = "Modules.Devices.DeviceRegistrationEnabled";
+
+    public static readonly IReadOnlyCollection<string> All =
+    [
+        AuthDevelopmentBootstrapEnabled,
+        DevicesDeviceRegistrationEnabled
+    ];
+}
+
+public interface IFeatureFlagService
+{
+    bool IsEnabled(string flagName);
+}
+
+public sealed class FeatureDisabledException(string flagName)
+    : InvalidOperationException($"Feature flag '{flagName}' is disabled.")
+{
+    public string FlagName { get; } = flagName;
+}
+
+public interface IInternalEvent
+{
+    DateTimeOffset OccurredAtUtc { get; }
+}
+
+public interface IInternalEventHandler<in TEvent>
+    where TEvent : class, IInternalEvent
+{
+    Task HandleAsync(TEvent internalEvent, CancellationToken cancellationToken);
+}
+
+public interface IInternalEventPublisher
+{
+    Task PublishAsync<TEvent>(TEvent internalEvent, CancellationToken cancellationToken)
+        where TEvent : class, IInternalEvent;
+}
+
+public static class PlatformRuntimeServiceCollectionExtensions
+{
+    public static IServiceCollection AddPlatformRuntimeFoundation(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        services.AddSingleton<IFeatureFlagService, ConfigurationFeatureFlagService>();
+        services.AddHostedService<FeatureFlagStartupValidationService>();
+        services.AddScoped<IInternalEventPublisher, InProcessInternalEventPublisher>();
+
+        return services;
+    }
+
+    public static OptionsBuilder<TOptions> AddValidatedModuleOptions<TOptions>(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        string sectionPath)
+        where TOptions : class, new()
+    {
+        return services.AddOptions<TOptions>()
+            .Bind(configuration.GetSection(sectionPath))
+            .Validate(
+                options => TryValidate(options),
+                $"Invalid configuration for section '{sectionPath}'.")
+            .ValidateOnStart();
+    }
+
+    private static bool TryValidate<TOptions>(TOptions options)
+    {
+        var context = new ValidationContext(options!);
+        var results = new List<ValidationResult>();
+
+        return Validator.TryValidateObject(
+            options!,
+            context,
+            results,
+            validateAllProperties: true);
+    }
+}
+
+internal sealed class ConfigurationFeatureFlagService(IConfiguration configuration) : IFeatureFlagService
+{
+    public bool IsEnabled(string flagName)
+    {
+        var rawValue = configuration[$"FeatureFlags:{flagName.Replace('.', ':')}"];
+
+        if (string.IsNullOrWhiteSpace(rawValue))
+        {
+            return false;
+        }
+
+        return bool.TryParse(rawValue, out var enabled) && enabled;
+    }
+}
+
+internal sealed class FeatureFlagStartupValidationService(
+    IConfiguration configuration,
+    ILogger<FeatureFlagStartupValidationService> logger) : IHostedService
+{
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        foreach (var flagName in PlatformFeatureFlags.All)
+        {
+            var rawValue = configuration[$"FeatureFlags:{flagName.Replace('.', ':')}"];
+
+            if (!string.IsNullOrWhiteSpace(rawValue) && !bool.TryParse(rawValue, out _))
+            {
+                throw new OptionsValidationException(
+                    nameof(PlatformFeatureFlags),
+                    typeof(PlatformFeatureFlags),
+                    [$"Feature flag '{flagName}' must be boolean."]);
+            }
+
+            logger.LogInformation(
+                "Feature flag {FeatureFlag} startup state is {FeatureFlagState}.",
+                flagName,
+                string.IsNullOrWhiteSpace(rawValue) ? "unset" : rawValue);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+}
+
+internal sealed class InProcessInternalEventPublisher(
+    IServiceProvider serviceProvider,
+    ILogger<InProcessInternalEventPublisher> logger) : IInternalEventPublisher
+{
+    public async Task PublishAsync<TEvent>(
+        TEvent internalEvent,
+        CancellationToken cancellationToken)
+        where TEvent : class, IInternalEvent
+    {
+        var handlers = serviceProvider.GetServices<IInternalEventHandler<TEvent>>().ToArray();
+
+        logger.LogInformation(
+            "Publishing internal event {EventType} to {HandlersCount} handlers.",
+            typeof(TEvent).Name,
+            handlers.Length);
+
+        foreach (var handler in handlers)
+        {
+            await handler.HandleAsync(internalEvent, cancellationToken);
+        }
+    }
+}

--- a/src/Modules/Auth/AuthModuleServiceCollectionExtensions.cs
+++ b/src/Modules/Auth/AuthModuleServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using BuildingBlocks.Infrastructure.Persistence.Entities.Auth;
+using BuildingBlocks.Infrastructure.PlatformRuntime;
 
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Configuration;
@@ -17,15 +18,9 @@ public static class AuthModuleServiceCollectionExtensions
         IConfiguration configuration,
         IHostEnvironment environment)
     {
-        services.AddOptions<AuthOptions>()
-            .Bind(configuration.GetSection("Modules:Auth"))
-            .Validate(
-                options => options.AccessTokenLifetimeMinutes > 0
-                    && options.RefreshTokenLifetimeHours > 0
-                    && !string.IsNullOrWhiteSpace(options.DevelopmentBootstrapUserLogin)
-                    && !string.IsNullOrWhiteSpace(options.DevelopmentBootstrapUserPassword)
-                    && !string.IsNullOrWhiteSpace(options.DevelopmentBootstrapRoleCode),
-                "Modules:Auth configuration is invalid.");
+        services.AddValidatedModuleOptions<AuthOptions>(
+            configuration,
+            "Modules:Auth");
 
         services.AddSingleton<IPasswordHasher<AuthUser>, PasswordHasher<AuthUser>>();
         services.AddScoped<IAuthService, AuthService>();

--- a/src/Modules/Auth/Configuration/AuthOptions.cs
+++ b/src/Modules/Auth/Configuration/AuthOptions.cs
@@ -1,13 +1,26 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace Modules.Auth.Configuration;
 
 public sealed class AuthOptions
 {
+    [Range(1, 1440)]
     public int AccessTokenLifetimeMinutes { get; init; } = 60;
+
+    [Range(1, 720)]
     public int RefreshTokenLifetimeHours { get; init; } = 24;
+
     public bool OfflineRestrictedModeEnabled { get; init; } = true;
 
+    [Required]
     public string DevelopmentBootstrapUserLogin { get; init; } = "platform-owner";
+
+    [Required]
     public string DevelopmentBootstrapUserDisplayName { get; init; } = "Platform Owner";
+
+    [Required]
     public string DevelopmentBootstrapUserPassword { get; init; } = "ChangeMe123!";
+
+    [Required]
     public string DevelopmentBootstrapRoleCode { get; init; } = "platform_owner";
 }

--- a/src/Modules/Auth/Services/DevelopmentAuthBootstrapService.cs
+++ b/src/Modules/Auth/Services/DevelopmentAuthBootstrapService.cs
@@ -1,5 +1,6 @@
 using BuildingBlocks.Infrastructure.Persistence;
 using BuildingBlocks.Infrastructure.Persistence.Entities.Auth;
+using BuildingBlocks.Infrastructure.PlatformRuntime;
 
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
@@ -16,12 +17,21 @@ public sealed class DevelopmentAuthBootstrapService(
     IServiceScopeFactory scopeFactory,
     IHostEnvironment environment,
     IOptions<AuthOptions> authOptions,
+    IFeatureFlagService featureFlags,
     ILogger<DevelopmentAuthBootstrapService> logger) : IHostedService
 {
     public async Task StartAsync(CancellationToken cancellationToken)
     {
         if (!environment.IsDevelopment())
         {
+            return;
+        }
+
+        if (!featureFlags.IsEnabled(PlatformFeatureFlags.AuthDevelopmentBootstrapEnabled))
+        {
+            logger.LogInformation(
+                "Development auth bootstrap skipped because feature flag {FeatureFlag} is disabled.",
+                PlatformFeatureFlags.AuthDevelopmentBootstrapEnabled);
             return;
         }
 

--- a/src/Modules/Devices/DevicesModule.cs
+++ b/src/Modules/Devices/DevicesModule.cs
@@ -1,10 +1,14 @@
+using System.ComponentModel.DataAnnotations;
+
 using BuildingBlocks.Contracts.Devices;
 using BuildingBlocks.Infrastructure.Persistence;
 using BuildingBlocks.Infrastructure.Persistence.Entities.Devices;
+using BuildingBlocks.Infrastructure.PlatformRuntime;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Modules.Devices;
@@ -12,7 +16,16 @@ namespace Modules.Devices;
 public sealed class DevicesOptions
 {
     public bool AllowTrustedRegistration { get; init; } = true;
+
+    [Range(1, 3650)]
+    public int DeviceSeenRetentionDays { get; init; } = 365;
 }
+
+public sealed record DeviceRegistrationUpsertedInternalEvent(
+    Guid DeviceId,
+    Guid? LastKnownUserId,
+    bool IsTrusted,
+    DateTimeOffset OccurredAtUtc) : IInternalEvent;
 
 public interface IDeviceRegistrationService
 {
@@ -27,10 +40,12 @@ public static class DevicesModuleServiceCollectionExtensions
         this IServiceCollection services,
         IConfiguration configuration)
     {
-        services.AddOptions<DevicesOptions>()
-            .Bind(configuration.GetSection("Modules:Devices"));
+        services.AddValidatedModuleOptions<DevicesOptions>(
+            configuration,
+            "Modules:Devices");
 
         services.AddScoped<IDeviceRegistrationService, DeviceRegistrationService>();
+        services.AddScoped<IInternalEventHandler<DeviceRegistrationUpsertedInternalEvent>, DeviceRegistrationUpsertedLoggingHandler>();
 
         return services;
     }
@@ -38,12 +53,19 @@ public static class DevicesModuleServiceCollectionExtensions
 
 internal sealed class DeviceRegistrationService(
     PlatformDbContext dbContext,
-    IOptions<DevicesOptions> options) : IDeviceRegistrationService
+    IOptions<DevicesOptions> options,
+    IFeatureFlagService featureFlags,
+    IInternalEventPublisher internalEventPublisher) : IDeviceRegistrationService
 {
     public async Task<DeviceRegistrationInfoDto> UpsertAsync(
         DeviceRegistrationUpsertRequestDto request,
         CancellationToken cancellationToken)
     {
+        if (!featureFlags.IsEnabled(PlatformFeatureFlags.DevicesDeviceRegistrationEnabled))
+        {
+            throw new FeatureDisabledException(PlatformFeatureFlags.DevicesDeviceRegistrationEnabled);
+        }
+
         var now = DateTimeOffset.UtcNow;
 
         var entity = await dbContext.DeviceRegistrations
@@ -72,6 +94,14 @@ internal sealed class DeviceRegistrationService(
 
         await dbContext.SaveChangesAsync(cancellationToken);
 
+        await internalEventPublisher.PublishAsync(
+            new DeviceRegistrationUpsertedInternalEvent(
+                entity.DeviceId,
+                entity.LastKnownUserId,
+                entity.IsTrusted,
+                now),
+            cancellationToken);
+
         return new DeviceRegistrationInfoDto(
             entity.DeviceId,
             entity.Platform,
@@ -82,5 +112,23 @@ internal sealed class DeviceRegistrationService(
             entity.LastKnownUserId,
             entity.RegisteredAtUtc,
             entity.LastSeenAtUtc);
+    }
+}
+
+internal sealed class DeviceRegistrationUpsertedLoggingHandler(
+    ILogger<DeviceRegistrationUpsertedLoggingHandler> logger)
+    : IInternalEventHandler<DeviceRegistrationUpsertedInternalEvent>
+{
+    public Task HandleAsync(
+        DeviceRegistrationUpsertedInternalEvent internalEvent,
+        CancellationToken cancellationToken)
+    {
+        logger.LogInformation(
+            "Handled internal event DeviceRegistrationUpsertedInternalEvent. DeviceId={DeviceId} LastKnownUserId={LastKnownUserId} IsTrusted={IsTrusted}",
+            internalEvent.DeviceId,
+            internalEvent.LastKnownUserId,
+            internalEvent.IsTrusted);
+
+        return Task.CompletedTask;
     }
 }

--- a/src/Modules/GroupTree/GroupTreeModule.cs
+++ b/src/Modules/GroupTree/GroupTreeModule.cs
@@ -1,6 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
 using BuildingBlocks.Contracts.Groups;
 using BuildingBlocks.Infrastructure.Persistence;
 using BuildingBlocks.Infrastructure.Persistence.Entities.GroupTree;
+using BuildingBlocks.Infrastructure.PlatformRuntime;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -13,7 +16,17 @@ namespace Modules.GroupTree;
 
 public sealed class GroupTreeOptions
 {
+    [Required]
     public string DevelopmentBootstrapAdminLogin { get; init; } = "platform-owner";
+
+    [Required]
+    public string RootNodeCode { get; init; } = "root";
+
+    [Required]
+    public string BranchNodeCode { get; init; } = "branch-a";
+
+    [Required]
+    public string SubBranchNodeCode { get; init; } = "branch-a-sub";
 }
 
 public interface IGroupTreeQueryService
@@ -33,8 +46,9 @@ public static class GroupTreeModuleServiceCollectionExtensions
         IConfiguration configuration,
         IHostEnvironment environment)
     {
-        services.AddOptions<GroupTreeOptions>()
-            .Bind(configuration.GetSection("Modules:GroupTree"));
+        services.AddValidatedModuleOptions<GroupTreeOptions>(
+            configuration,
+            "Modules:GroupTree");
 
         services.AddScoped<IGroupTreeQueryService, GroupTreeQueryService>();
 
@@ -65,14 +79,20 @@ internal sealed class DevelopmentGroupTreeBootstrapService(
             using var scope = scopeFactory.CreateScope();
             var dbContext = scope.ServiceProvider.GetRequiredService<PlatformDbContext>();
 
+            var normalizedLogin = options.Value.DevelopmentBootstrapAdminLogin.Trim().ToUpperInvariant();
+
             var adminUser = await dbContext.AuthUsers
                 .SingleOrDefaultAsync(
-                    item => item.NormalizedLogin == options.Value.DevelopmentBootstrapAdminLogin.Trim().ToUpperInvariant(),
+                    item => item.NormalizedLogin == normalizedLogin,
                     cancellationToken);
 
             if (adminUser is not null)
             {
-                var targetNodeCodes = new[] { "root", "branch-a" };
+                var targetNodeCodes = new[]
+                {
+                    options.Value.RootNodeCode,
+                    options.Value.BranchNodeCode
+                };
 
                 var nodes = await dbContext.GroupNodes
                     .Where(item => targetNodeCodes.Contains(item.Code))


### PR DESCRIPTION
Closes #17

## Goal
Complete S0-10 feature flags, modular options validation and internal events foundation.

## Included
- feature flag infrastructure
- flag naming convention baseline
- modular options validation with ValidateOnStart
- internal event abstractions and in-process publisher
- one working runtime flag path
- one working internal event publish/handle path
- invalid configuration startup failure path
- engineering note for flags/options/events

## Manual verification
- /api/system/platform-foundation returns active flags/options/events
- device registration succeeds when flag is enabled
- device registration returns 409 when flag is disabled
- invalid auth options fail startup with OptionsValidationException
- internal event publish and handler logs are visible