### PR TITLE
observability(audit): add S0-11 audit logging health foundation

### DIFF
--- a/docs/observability/audit-logging-health-foundation.md
+++ b/docs/observability/audit-logging-health-foundation.md
@@ -1,0 +1,33 @@
+# Audit / logging / health / observability foundation
+
+## Status
+- Stage: Sprint 0 / S0-11
+- Scope: audit baseline, correlation id propagation, health policy expansion
+
+## Audit baseline
+- AuditRecord table
+- audit categories:
+  - authentication
+  - devices
+  - group_tree
+- database-backed audit service
+- request correlation id is stored in audit records
+
+## Correlation baseline
+- request header: X-Correlation-Id
+- if absent, server generates one
+- response echoes X-Correlation-Id
+- logging scope includes correlation id and request path
+
+## Health policy
+Readiness includes:
+- self
+- platform_runtime
+- audit_foundation
+- postgresql
+
+## First audited actions
+- sign_in_failed
+- sign_in_succeeded
+- device_registration_upserted
+- device_registration_blocked_by_flag

--- a/src/App.Api/Middleware/CorrelationIdMiddleware.cs
+++ b/src/App.Api/Middleware/CorrelationIdMiddleware.cs
@@ -1,0 +1,36 @@
+using BuildingBlocks.Infrastructure.Observability;
+
+namespace App.Api.Middleware;
+
+public sealed class CorrelationIdMiddleware(
+    RequestDelegate next,
+    IRequestContextAccessor requestContext,
+    ILogger<CorrelationIdMiddleware> logger)
+{
+    public const string HeaderName = "X-Correlation-Id";
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        var incomingCorrelationId = context.Request.Headers[HeaderName].ToString();
+        var correlationId = string.IsNullOrWhiteSpace(incomingCorrelationId)
+            ? Guid.NewGuid().ToString("N")
+            : incomingCorrelationId.Trim();
+
+        requestContext.CorrelationId = correlationId;
+        requestContext.RequestPath = context.Request.Path.Value;
+
+        context.Response.Headers[HeaderName] = correlationId;
+
+        using (logger.BeginScope(new Dictionary<string, object?>
+        {
+            ["CorrelationId"] = correlationId,
+            ["RequestPath"] = context.Request.Path.Value
+        }))
+        {
+            await next(context);
+        }
+
+        requestContext.CorrelationId = null;
+        requestContext.RequestPath = null;
+    }
+}

--- a/src/App.Api/Program.cs
+++ b/src/App.Api/Program.cs
@@ -1,11 +1,11 @@
 using System.Linq;
-using System.Runtime.InteropServices;
 
 using App.Api.Middleware;
 
 using BuildingBlocks.Contracts.Auth;
 using BuildingBlocks.Contracts.Devices;
 using BuildingBlocks.Infrastructure.AssemblyMetadata;
+using BuildingBlocks.Infrastructure.Observability;
 using BuildingBlocks.Infrastructure.Persistence;
 using BuildingBlocks.Infrastructure.PlatformRuntime;
 
@@ -42,6 +42,7 @@ var databaseOptions = new DatabaseOptions
 builder.Services.AddProblemDetails();
 builder.Services.AddPlatformRuntimeFoundation(builder.Configuration);
 builder.Services.AddPlatformPersistence(databaseOptions);
+builder.Services.AddAuditObservabilityFoundation();
 builder.Services.AddAuthModule(builder.Configuration, builder.Environment);
 builder.Services.AddGroupTreeModule(builder.Configuration, builder.Environment);
 builder.Services.AddDevicesModule(builder.Configuration);
@@ -51,12 +52,21 @@ builder.Services.AddHealthChecks()
         "self",
         () => HealthCheckResult.Healthy("App.Api self-check passed."),
         tags: new[] { "ready" })
+    .AddCheck(
+        "platform_runtime",
+        () => HealthCheckResult.Healthy("Feature flags and modular options foundation ready."),
+        tags: new[] { "ready" })
+    .AddCheck(
+        "audit_foundation",
+        () => HealthCheckResult.Healthy("Audit service baseline ready."),
+        tags: new[] { "ready" })
     .AddDbContextCheck<PlatformDbContext>(
         name: "postgresql",
         tags: new[] { "ready" });
 
 var app = builder.Build();
 
+app.UseMiddleware<CorrelationIdMiddleware>();
 app.UseMiddleware<GlobalExceptionHandlingMiddleware>();
 
 app.MapGet(
@@ -106,12 +116,9 @@ app.MapGet(
         service = environment.ApplicationName,
         environmentName = environment.EnvironmentName,
         version = ApplicationVersionReader.GetVersion<Program>(),
-        framework = RuntimeInformation.FrameworkDescription,
+        framework = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription,
         assemblyVersion = typeof(Program).Assembly.GetName().Version?.ToString(),
         databaseProvider = "PostgreSQL / EF Core / Npgsql",
-        authMode = "Opaque access token + server side refresh session",
-        groupTreeMode = "Tree nodes + branch admin escalation",
-        devicesMode = "Device registration + last known user link",
         startedAtUtc
     }));
 
@@ -131,15 +138,66 @@ app.MapGet(
         }
     }));
 
+app.MapGet(
+    "/api/system/observability",
+    (IRequestContextAccessor requestContext) => Results.Ok(new
+    {
+        correlationId = requestContext.CorrelationId,
+        healthChecks = new[]
+        {
+            "self",
+            "platform_runtime",
+            "audit_foundation",
+            "postgresql"
+        },
+        auditCategories = AuditCategories.All
+    }));
+
 app.MapPost(
     "/api/auth/sign-in",
     async Task<IResult> (
         SignInRequestDto request,
         IAuthService authService,
+        IAuditService auditService,
         CancellationToken cancellationToken) =>
     {
         var response = await authService.SignInAsync(request, cancellationToken);
-        return response is null ? Results.Unauthorized() : Results.Ok(response);
+
+        if (response is null)
+        {
+            await auditService.WriteAsync(
+                new AuditWriteEntry(
+                    AuditCategories.Authentication,
+                    "sign_in_failed",
+                    null,
+                    request.DeviceId,
+                    "auth_session",
+                    null,
+                    new
+                    {
+                        request.Login
+                    }),
+                cancellationToken);
+
+            return Results.Unauthorized();
+        }
+
+        await auditService.WriteAsync(
+            new AuditWriteEntry(
+                AuditCategories.Authentication,
+                "sign_in_succeeded",
+                response.User.UserId,
+                response.Session.DeviceId,
+                "auth_session",
+                response.Session.SessionId.ToString(),
+                new
+                {
+                    response.User.UserName,
+                    response.User.Roles
+                }),
+            cancellationToken);
+
+        return Results.Ok(response);
     });
 
 app.MapPost(
@@ -180,15 +238,48 @@ app.MapPost(
     async Task<IResult> (
         DeviceRegistrationUpsertRequestDto request,
         IDeviceRegistrationService service,
+        IAuditService auditService,
         CancellationToken cancellationToken) =>
     {
         try
         {
             var result = await service.UpsertAsync(request, cancellationToken);
+
+            await auditService.WriteAsync(
+                new AuditWriteEntry(
+                    AuditCategories.Devices,
+                    "device_registration_upserted",
+                    request.LastKnownUserId,
+                    request.DeviceId,
+                    "device_registration",
+                    result.DeviceId.ToString(),
+                    new
+                    {
+                        result.Platform,
+                        result.DeviceName,
+                        result.IsTrusted
+                    }),
+                cancellationToken);
+
             return Results.Ok(result);
         }
         catch (FeatureDisabledException ex)
         {
+            await auditService.WriteAsync(
+                new AuditWriteEntry(
+                    AuditCategories.Devices,
+                    "device_registration_blocked_by_flag",
+                    request.LastKnownUserId,
+                    request.DeviceId,
+                    "device_registration",
+                    request.DeviceId.ToString(),
+                    new
+                    {
+                        ex.FlagName,
+                        request.Platform
+                    }),
+                cancellationToken);
+
             return Results.Conflict(new
             {
                 error = "feature_disabled",

--- a/src/BuildingBlocks/Infrastructure/Observability/AuditObservabilityFoundation.cs
+++ b/src/BuildingBlocks/Infrastructure/Observability/AuditObservabilityFoundation.cs
@@ -1,0 +1,120 @@
+using System.Text.Json;
+
+using BuildingBlocks.Infrastructure.Persistence;
+using BuildingBlocks.Infrastructure.Persistence.Entities.Audit;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace BuildingBlocks.Infrastructure.Observability;
+
+public static class AuditCategories
+{
+    public const string Authentication = "authentication";
+    public const string Devices = "devices";
+    public const string GroupTree = "group_tree";
+
+    public static readonly IReadOnlyCollection<string> All =
+    [
+        Authentication,
+        Devices,
+        GroupTree
+    ];
+}
+
+public sealed record AuditWriteEntry(
+    string Category,
+    string Action,
+    Guid? SubjectUserId,
+    Guid? DeviceId,
+    string? EntityType,
+    string? EntityId,
+    object? Payload);
+
+public interface IRequestContextAccessor
+{
+    string? CorrelationId { get; set; }
+    string? RequestPath { get; set; }
+}
+
+internal sealed class RequestContextState
+{
+    public string? CorrelationId { get; set; }
+    public string? RequestPath { get; set; }
+}
+
+internal sealed class AsyncLocalRequestContextAccessor : IRequestContextAccessor
+{
+    private static readonly AsyncLocal<RequestContextState?> Current = new();
+
+    public string? CorrelationId
+    {
+        get => Current.Value?.CorrelationId;
+        set
+        {
+            var state = Current.Value ??= new RequestContextState();
+            state.CorrelationId = value;
+        }
+    }
+
+    public string? RequestPath
+    {
+        get => Current.Value?.RequestPath;
+        set
+        {
+            var state = Current.Value ??= new RequestContextState();
+            state.RequestPath = value;
+        }
+    }
+}
+
+public interface IAuditService
+{
+    Task WriteAsync(AuditWriteEntry entry, CancellationToken cancellationToken);
+}
+
+internal sealed class DatabaseAuditService(
+    PlatformDbContext dbContext,
+    IRequestContextAccessor requestContext,
+    ILogger<DatabaseAuditService> logger) : IAuditService
+{
+    public async Task WriteAsync(AuditWriteEntry entry, CancellationToken cancellationToken)
+    {
+        var record = new AuditRecord
+        {
+            Id = Guid.NewGuid(),
+            Category = entry.Category,
+            Action = entry.Action,
+            SubjectUserId = entry.SubjectUserId,
+            DeviceId = entry.DeviceId,
+            EntityType = entry.EntityType,
+            EntityId = entry.EntityId,
+            CorrelationId = requestContext.CorrelationId,
+            RequestPath = requestContext.RequestPath,
+            PayloadJson = entry.Payload is null ? null : JsonSerializer.Serialize(entry.Payload),
+            OccurredAtUtc = DateTimeOffset.UtcNow
+        };
+
+        dbContext.AuditRecords.Add(record);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        logger.LogInformation(
+            "Audit record stored. Category={Category} Action={Action} CorrelationId={CorrelationId} EntityType={EntityType} EntityId={EntityId}",
+            record.Category,
+            record.Action,
+            record.CorrelationId,
+            record.EntityType,
+            record.EntityId);
+    }
+}
+
+public static class AuditObservabilityServiceCollectionExtensions
+{
+    public static IServiceCollection AddAuditObservabilityFoundation(this IServiceCollection services)
+    {
+        services.AddSingleton<IRequestContextAccessor, AsyncLocalRequestContextAccessor>();
+        services.AddScoped<IAuditService, DatabaseAuditService>();
+
+        return services;
+    }
+}

--- a/src/BuildingBlocks/Infrastructure/Persistence/Configurations/Audit/AuditRecordConfiguration.cs
+++ b/src/BuildingBlocks/Infrastructure/Persistence/Configurations/Audit/AuditRecordConfiguration.cs
@@ -1,0 +1,38 @@
+using BuildingBlocks.Infrastructure.Persistence.Entities.Audit;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace BuildingBlocks.Infrastructure.Persistence.Configurations.Audit;
+
+public sealed class AuditRecordConfiguration : IEntityTypeConfiguration<AuditRecord>
+{
+    public void Configure(EntityTypeBuilder<AuditRecord> builder)
+    {
+        builder.ToTable("audit_records");
+
+        builder.HasKey(item => item.Id)
+            .HasName("pk_audit_records");
+
+        builder.Property(item => item.Id).HasColumnName("id");
+        builder.Property(item => item.Category).HasColumnName("category").HasMaxLength(128).IsRequired();
+        builder.Property(item => item.Action).HasColumnName("action").HasMaxLength(128).IsRequired();
+        builder.Property(item => item.SubjectUserId).HasColumnName("subject_user_id");
+        builder.Property(item => item.DeviceId).HasColumnName("device_id");
+        builder.Property(item => item.EntityType).HasColumnName("entity_type").HasMaxLength(128);
+        builder.Property(item => item.EntityId).HasColumnName("entity_id").HasMaxLength(128);
+        builder.Property(item => item.CorrelationId).HasColumnName("correlation_id").HasMaxLength(128);
+        builder.Property(item => item.RequestPath).HasColumnName("request_path").HasMaxLength(256);
+        builder.Property(item => item.PayloadJson).HasColumnName("payload_json");
+        builder.Property(item => item.OccurredAtUtc).HasColumnName("occurred_at_utc").IsRequired();
+
+        builder.HasIndex(item => item.OccurredAtUtc)
+            .HasDatabaseName("ix_audit_records_occurred_at_utc");
+
+        builder.HasIndex(item => new { item.Category, item.Action })
+            .HasDatabaseName("ix_audit_records_category_action");
+
+        builder.HasIndex(item => item.SubjectUserId)
+            .HasDatabaseName("ix_audit_records_subject_user_id");
+    }
+}

--- a/src/BuildingBlocks/Infrastructure/Persistence/Entities/Audit/AuditRecord.cs
+++ b/src/BuildingBlocks/Infrastructure/Persistence/Entities/Audit/AuditRecord.cs
@@ -1,0 +1,16 @@
+namespace BuildingBlocks.Infrastructure.Persistence.Entities.Audit;
+
+public sealed class AuditRecord
+{
+    public Guid Id { get; set; }
+    public string Category { get; set; } = string.Empty;
+    public string Action { get; set; } = string.Empty;
+    public Guid? SubjectUserId { get; set; }
+    public Guid? DeviceId { get; set; }
+    public string? EntityType { get; set; }
+    public string? EntityId { get; set; }
+    public string? CorrelationId { get; set; }
+    public string? RequestPath { get; set; }
+    public string? PayloadJson { get; set; }
+    public DateTimeOffset OccurredAtUtc { get; set; }
+}

--- a/src/BuildingBlocks/Infrastructure/Persistence/Migrations/20260417152232_AddAuditAndObservabilityFoundation.Designer.cs
+++ b/src/BuildingBlocks/Infrastructure/Persistence/Migrations/20260417152232_AddAuditAndObservabilityFoundation.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using BuildingBlocks.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BuildingBlocks.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(PlatformDbContext))]
-    partial class PlatformDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260417152232_AddAuditAndObservabilityFoundation")]
+    partial class AddAuditAndObservabilityFoundation
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/BuildingBlocks/Infrastructure/Persistence/Migrations/20260417152232_AddAuditAndObservabilityFoundation.cs
+++ b/src/BuildingBlocks/Infrastructure/Persistence/Migrations/20260417152232_AddAuditAndObservabilityFoundation.cs
@@ -1,0 +1,64 @@
+﻿using System;
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BuildingBlocks.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAuditAndObservabilityFoundation : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "audit_records",
+                schema: "app",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    category = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    action = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    subject_user_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    device_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    entity_type = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true),
+                    entity_id = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true),
+                    correlation_id = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true),
+                    request_path = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    payload_json = table.Column<string>(type: "text", nullable: true),
+                    occurred_at_utc = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_audit_records", x => x.id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_audit_records_category_action",
+                schema: "app",
+                table: "audit_records",
+                columns: new[] { "category", "action" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_audit_records_occurred_at_utc",
+                schema: "app",
+                table: "audit_records",
+                column: "occurred_at_utc");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_audit_records_subject_user_id",
+                schema: "app",
+                table: "audit_records",
+                column: "subject_user_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "audit_records",
+                schema: "app");
+        }
+    }
+}

--- a/src/BuildingBlocks/Infrastructure/Persistence/PlatformDbContext.cs
+++ b/src/BuildingBlocks/Infrastructure/Persistence/PlatformDbContext.cs
@@ -1,4 +1,5 @@
 using BuildingBlocks.Infrastructure.Persistence.Entities;
+using BuildingBlocks.Infrastructure.Persistence.Entities.Audit;
 using BuildingBlocks.Infrastructure.Persistence.Entities.Auth;
 using BuildingBlocks.Infrastructure.Persistence.Entities.Devices;
 using BuildingBlocks.Infrastructure.Persistence.Entities.GroupTree;
@@ -23,6 +24,8 @@ public sealed class PlatformDbContext(DbContextOptions<PlatformDbContext> option
     public DbSet<GroupAdminAssignment> GroupAdminAssignments => Set<GroupAdminAssignment>();
 
     public DbSet<DeviceRegistration> DeviceRegistrations => Set<DeviceRegistration>();
+
+    public DbSet<AuditRecord> AuditRecords => Set<AuditRecord>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {


### PR DESCRIPTION
Closes #19

## Goal
Complete S0-11 audit / logging / health / observability foundation.

## Module
App.Api / BuildingBlocks.Infrastructure / audit baseline

## Contracts
- shared DTO unchanged
- new audit and observability abstractions only
- additive only

## Migration
- AddAuditAndObservabilityFoundation
- additive-first

## Flags
- no new user-facing feature flag

## Manual verification
- /health/ready includes self, platform_runtime, audit_foundation, postgresql
- X-Correlation-Id is echoed by API
- sign-in writes authentication audit record
- device registration writes devices audit record
- observability endpoint returns audit categories

## Tests
- local build green
- local migration applied
- local API smoke passed
- audit query verified against PostgreSQL

## Rollback
- revert PR
- disable deployment of this increment
- migration rollback only by explicit follow-up plan