### PR TITLE
docs(handoff): add S0-14 freeze summary for coder 2 and coder 3

### DIFF
--- a/docs/handoffs/s0-14-backend-freeze-summary.md
+++ b/docs/handoffs/s0-14-backend-freeze-summary.md
@@ -1,0 +1,68 @@
+# S0-14 backend freeze summary
+
+## Status
+- Sprint 0 backend freeze point is reached.
+- This summary is valid after S0-05, S0-08, S0-09, S0-10, S0-11 and S0-13.
+
+## Frozen shared contracts baseline
+- Common API envelopes and error contract baseline
+- Auth/session DTO baseline
+- Group tree DTO baseline
+- Device registration DTO baseline
+- Video upload / download / sync / incidents DTO baseline v0
+- WebsiteIntegration DTO baseline
+
+## Frozen backend endpoints
+- GET /health/live
+- GET /health/ready
+- GET /api/system/version
+- GET /api/system/platform-foundation
+- GET /api/system/observability
+- GET /api/system/site-gateway
+- POST /api/system/site-gateway/reconcile-preview
+- POST /api/auth/sign-in
+- POST /api/auth/refresh
+- GET /api/group-tree/nodes
+- GET /api/group-tree/routing-preview
+- POST /api/devices/register
+
+## Frozen feature flags
+- Modules.Auth.DevelopmentBootstrapEnabled
+- Modules.Devices.DeviceRegistrationEnabled
+
+## Known internal/runtime baseline
+- ValidateOnStart modular options
+- correlation id middleware and audit foundation
+- known internal event baseline currently surfaced in system diagnostics:
+  - DeviceRegistrationUpsertedInternalEvent
+
+## Frozen site stub expectations
+- provider = Stub
+- mode = Development
+- externalVideoId format = site-video-<guid>
+- storageKey format = videos/<externalVideoId>.mp4
+- known statuses:
+  - uploaded
+  - available
+  - deleted
+
+## Known stubs / not production-like yet
+- no PreUploadCheck runtime endpoint yet
+- no UploadReceipt runtime endpoint yet
+- no CreateDownloadIntent runtime endpoint yet
+- no DownloadReceipt runtime endpoint yet
+- no real sync runtime path yet
+- no duplicate/fraud runtime incidents API for UI binding yet
+- website integration is stub-only, not a live site provider
+
+## What may still change
+- Sprint 1 runtime endpoints
+- duplicate/fraud payload details
+- site gateway real provider implementation
+- download control plane payload expansion
+All such changes must stay additive-first and be coordinated through coder 1.
+
+## Coordination rule
+- coder 2 and coder 3 may rely on this baseline for shell/deep integration preparation
+- they must not invent new shared DTO or statuses without coordination
+- production-like upload binding starts only after Sprint 1 backend handoff

--- a/docs/handoffs/s0-14-coder2-web-handoff.md
+++ b/docs/handoffs/s0-14-coder2-web-handoff.md
@@ -1,0 +1,37 @@
+# S0-14 handoff for coder 2 (web / desktop / shared UI)
+
+## You can now treat as stable
+- auth/session baseline
+- current user roles/permissions payload
+- group tree nodes
+- routing preview
+- platform foundation endpoint
+- observability endpoint
+- website integration stub contracts
+
+## Real backend endpoints available
+- POST /api/auth/sign-in
+- POST /api/auth/refresh
+- GET /api/group-tree/nodes
+- GET /api/group-tree/routing-preview
+- GET /api/system/platform-foundation
+- GET /api/system/observability
+- GET /api/system/site-gateway
+- POST /api/system/site-gateway/reconcile-preview
+
+## What you should do now
+- bind web shell to real auth/group/platform endpoints
+- make backend-driven UI gating use platform-foundation
+- keep upload/download UX behind adapter interfaces
+- align upload/download adapter request/response shapes to SiteGatewayDtos
+- use routing preview for admin/debug shell
+
+## What you must not do yet
+- do not build a fake production upload runtime
+- do not invent PreUploadCheck/UploadReceipt payloads
+- do not assume download control plane exists
+- do not invent duplicate/fraud statuses outside frozen baseline
+
+## Current known stub
+- site gateway is stub-only
+- use it for contract alignment, not for business-complete upload flow

--- a/docs/handoffs/s0-14-coder3-android-handoff.md
+++ b/docs/handoffs/s0-14-coder3-android-handoff.md
@@ -1,0 +1,37 @@
+# S0-14 handoff for coder 3 (android / mobile)
+
+## You can now treat as stable
+- auth/session baseline
+- current user roles/permissions payload
+- device registration endpoint
+- group tree nodes baseline
+- platform foundation endpoint
+- observability endpoint
+- website integration stub contracts
+
+## Real backend endpoints available
+- POST /api/auth/sign-in
+- POST /api/auth/refresh
+- POST /api/devices/register
+- GET /api/group-tree/nodes
+- GET /api/system/platform-foundation
+- GET /api/system/observability
+- GET /api/system/site-gateway
+- POST /api/system/site-gateway/reconcile-preview
+
+## What you should do now
+- bind mobile shell to real auth/device/platform endpoints
+- persist last active account/session locally
+- use backend-driven flags from platform-foundation
+- keep camera/file upload behind adapter interfaces
+- align future site-facing adapter shapes to SiteGatewayDtos
+
+## What you must not do yet
+- do not build fake production upload runtime
+- do not invent UploadReceipt/PreUploadCheck payloads
+- do not invent sync statuses or incident payloads
+- do not move duplicate/fraud business logic into mobile
+
+## Current known stub
+- site gateway is stub-only
+- use it for contract alignment, not for business-complete upload flow


### PR DESCRIPTION
Closes #23

## Goal
Complete S0-14 freeze point and handoff summary.

## Module
docs / handoff / coordination

## Contracts
- no shared DTO changes
- publish frozen baseline for coder 2 and coder 3

## Migration
- none

## Feature flag
- none

## Manual verification
- handoff summary lists frozen endpoints, flags and known stubs
- coder 2 note exists
- coder 3 note exists
- local txt files for 40_* and direct coder messages are generated

## Rollback
- revert PR