### PR TITLE
infra(stage): add S0-12 ubuntu stage foundation and runbooks skeleton

### DIFF
--- a/docs/deploy/ubuntu-stage-foundation.md
+++ b/docs/deploy/ubuntu-stage-foundation.md
@@ -1,0 +1,34 @@
+# Ubuntu stage foundation
+
+## Runtime layout
+- `/opt/analytics-automation/releases/<release>/api`
+- `/opt/analytics-automation/releases/<release>/worker`
+- `/opt/analytics-automation/api/current`
+- `/opt/analytics-automation/worker/current`
+- `/etc/analytics-automation/api.env`
+- `/etc/analytics-automation/worker.env`
+- `/etc/analytics-automation/secrets/`
+- `/var/log/analytics-automation/`
+- `/var/backups/analytics-automation/postgresql/`
+
+## Services and ports
+- `analytics-api.service`
+- `analytics-worker.service`
+- Kestrel: `127.0.0.1:18080`
+- public entrypoint: Nginx with TLS
+
+## Secrets policy
+- secrets are never stored in repo
+- repo keeps only `*.example` env files
+- runtime secrets live under `/etc/analytics-automation/secrets`
+- DB password is referenced through `Database__PasswordFilePath`
+
+## Smoke endpoints
+- `GET /health/live`
+- `GET /health/ready`
+- `GET /api/system/version`
+
+## Stage baseline
+- provider for website integration remains `Stub`
+- stage deploy is manual and reproducible
+- rollback is symlink-based

--- a/docs/runbooks/postgresql-backup-restore-stage.md
+++ b/docs/runbooks/postgresql-backup-restore-stage.md
@@ -1,0 +1,21 @@
+# PostgreSQL backup and restore on stage
+
+## Backup
+Recommended path:
+- `/var/backups/analytics-automation/postgresql/`
+
+Example:
+- `sudo -u postgres pg_dump -Fc analytics_automation_stage > /var/backups/analytics-automation/postgresql/analytics_automation_stage_YYYYMMDD_HHMMSS.dump`
+
+## Restore drill
+1. Create restore target DB:
+   - `sudo -u postgres createdb analytics_automation_stage_restore`
+2. Restore:
+   - `sudo -u postgres pg_restore -d analytics_automation_stage_restore /var/backups/analytics-automation/postgresql/<file>.dump`
+3. Run API against restore DB only for validation if needed.
+4. Do not overwrite stage DB without explicit rollback decision.
+
+## Policy
+- backups are scheduled outside repo
+- restore must be rehearsed on stage before production use
+- migration flow remains additive-first

--- a/docs/runbooks/stage-deploy-and-rollback.md
+++ b/docs/runbooks/stage-deploy-and-rollback.md
@@ -1,0 +1,29 @@
+# Stage deploy and rollback
+
+## Deploy
+1. Publish `App.Api` and `App.Worker`.
+2. Copy artifacts to `/opt/analytics-automation/releases/<release>/`.
+3. Update symlinks:
+   - `/opt/analytics-automation/api/current`
+   - `/opt/analytics-automation/worker/current`
+4. Put real env files in:
+   - `/etc/analytics-automation/api.env`
+   - `/etc/analytics-automation/worker.env`
+5. Install/update:
+   - `infra/systemd/analytics-api.service`
+   - `infra/systemd/analytics-worker.service`
+   - `infra/nginx/analytics-automation-stage.conf`
+6. Run:
+   - `sudo systemctl daemon-reload`
+   - `sudo systemctl restart analytics-api analytics-worker`
+   - `sudo nginx -t && sudo systemctl reload nginx`
+7. Smoke-check:
+   - `curl -f https://stage.example.com/health/live`
+   - `curl -f https://stage.example.com/health/ready`
+   - `curl -f https://stage.example.com/api/system/version`
+
+## Rollback
+1. Point `api/current` and `worker/current` back to previous release.
+2. Restart API and Worker.
+3. Repeat smoke-check.
+4. Keep failed release for investigation until root cause is clear.

--- a/docs/runbooks/stage-operations.md
+++ b/docs/runbooks/stage-operations.md
@@ -1,0 +1,25 @@
+# Stage operations
+
+## Health
+- `curl -f https://stage.example.com/health/live`
+- `curl -f https://stage.example.com/health/ready`
+- `curl -f https://stage.example.com/api/system/version`
+
+## Service status
+- `sudo systemctl status analytics-api`
+- `sudo systemctl status analytics-worker`
+
+## Restart
+- `sudo systemctl restart analytics-api`
+- `sudo systemctl restart analytics-worker`
+
+## Logs
+- `sudo journalctl -u analytics-api -n 200 --no-pager`
+- `sudo journalctl -u analytics-worker -n 200 --no-pager`
+- `sudo tail -n 200 /var/log/nginx/access.log`
+- `sudo tail -n 200 /var/log/nginx/error.log`
+
+## Incident hints
+- if API readiness is red, check PostgreSQL connectivity and env files
+- if Worker lags, inspect worker journal and retry pipeline state
+- if Nginx fails, run `sudo nginx -t`

--- a/infra/deploy/examples/stage.api.env.example
+++ b/infra/deploy/examples/stage.api.env.example
@@ -1,0 +1,13 @@
+ASPNETCORE_ENVIRONMENT=Stage
+ConnectionStrings__MainDatabase=
+Database__Host=127.0.0.1
+Database__Port=5432
+Database__Database=analytics_automation_stage
+Database__Username=analytics_automation_app_stage
+Database__PasswordFilePath=/etc/analytics-automation/secrets/postgres-app-password
+Modules__Auth__DevelopmentBootstrapEnabled=false
+Modules__Devices__DeviceRegistrationEnabled=true
+Modules__WebsiteIntegration__Provider=Stub
+Modules__WebsiteIntegration__StubMode=Stage
+Modules__WebsiteIntegration__ExternalVideoIdPrefix=site-video
+Modules__WebsiteIntegration__StorageKeyPrefix=videos

--- a/infra/deploy/examples/stage.worker.env.example
+++ b/infra/deploy/examples/stage.worker.env.example
@@ -1,0 +1,7 @@
+DOTNET_ENVIRONMENT=Stage
+ConnectionStrings__MainDatabase=
+Database__Host=127.0.0.1
+Database__Port=5432
+Database__Database=analytics_automation_stage
+Database__Username=analytics_automation_app_stage
+Database__PasswordFilePath=/etc/analytics-automation/secrets/postgres-app-password

--- a/infra/nginx/analytics-automation-stage.conf
+++ b/infra/nginx/analytics-automation-stage.conf
@@ -1,0 +1,25 @@
+server {
+    listen 80;
+    server_name stage.example.com;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    server_name stage.example.com;
+
+    ssl_certificate /etc/letsencrypt/live/stage.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/stage.example.com/privkey.pem;
+
+    client_max_body_size 2m;
+
+    location / {
+        proxy_pass http://127.0.0.1:18080;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}

--- a/infra/systemd/analytics-api.service
+++ b/infra/systemd/analytics-api.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=AnalyticsAutomation App.Api
+After=network.target postgresql.service
+Wants=network.target
+
+[Service]
+Type=simple
+User=analytics
+Group=analytics
+WorkingDirectory=/opt/analytics-automation/api/current
+EnvironmentFile=/etc/analytics-automation/api.env
+ExecStart=/usr/bin/dotnet /opt/analytics-automation/api/current/App.Api.dll --urls http://127.0.0.1:18080
+Restart=always
+RestartSec=5
+KillSignal=SIGINT
+SyslogIdentifier=analytics-api
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/systemd/analytics-worker.service
+++ b/infra/systemd/analytics-worker.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=AnalyticsAutomation App.Worker
+After=network.target postgresql.service
+Wants=network.target
+
+[Service]
+Type=simple
+User=analytics
+Group=analytics
+WorkingDirectory=/opt/analytics-automation/worker/current
+EnvironmentFile=/etc/analytics-automation/worker.env
+ExecStart=/usr/bin/dotnet /opt/analytics-automation/worker/current/App.Worker.dll
+Restart=always
+RestartSec=5
+KillSignal=SIGINT
+SyslogIdentifier=analytics-worker
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Closes #25

## Goal
Complete S0-12 Ubuntu/stage foundation and runbooks skeleton.

## Module
infra / docs / deploy foundation

## Contracts
- no shared DTO changes

## Migration
- none

## Feature flag
- none

## Manual verification
- infra/systemd skeleton files added
- infra/nginx skeleton added
- stage env example files added
- deploy/rollback/logs/health/backup runbooks added
- solution restore/build stays green

## Rollback
- revert PR
- keep docs/config skeleton out of deployment until explicitly applied