### PR TITLE
upload(video): add S1-03 upload receipt fixation

### DIFF
--- a/docs/video-upload/upload-receipt-v1.md
+++ b/docs/video-upload/upload-receipt-v1.md
@@ -1,0 +1,29 @@
+# VideoUpload UploadReceipt v1
+
+## Status
+- Stage: Sprint 1 / S1-03
+- Endpoint: `POST /api/video/upload-receipt`
+- Module kill switch: `Modules:VideoUpload:UploadReceiptEnabled`
+
+## Purpose
+UploadReceipt fixes the server-side fact that a client uploaded video bytes directly to the site.
+
+## Receipt rules
+- receipt must reference an existing PreUploadCheck
+- PreUploadCheck must allow site upload
+- user/device/group context must match
+- fingerprint and storage keys must match
+- receipt is idempotent by `IdempotencyKey`
+
+## Baseline side effects
+- server-side receipt record is stored
+- baseline deep-analysis job is queued in `video_upload_receipt_analysis_jobs`
+- module-owned receipt audit record is stored in `video_upload_receipt_audit_records`
+
+## Offline behavior
+When server is offline, the client stores UploadReceipt in local outbox/PendingSyncItem.
+On reconnect, the client sends the receipt to this endpoint.
+
+## Rollback
+Disable `Modules:VideoUpload:UploadReceiptEnabled` or revert the PR.
+The migration is additive.

--- a/src/App.Api/appsettings.json
+++ b/src/App.Api/appsettings.json
@@ -32,6 +32,7 @@
                                 },
                     "VideoUpload":  {
                                         "PreUploadCheckEnabled":  true,
+                                        "UploadReceiptEnabled":  true,
                                         "MaxFastAllowSizeBytes":  5368709120,
                                         "SiteProvider":  "Stub",
                                         "ExternalVideoIdPrefix":  "site-video",

--- a/src/BuildingBlocks/Contracts/VideoUpload/UploadReceiptDtosV1.cs
+++ b/src/BuildingBlocks/Contracts/VideoUpload/UploadReceiptDtosV1.cs
@@ -1,0 +1,31 @@
+namespace BuildingBlocks.Contracts.VideoUpload;
+
+public static class VideoUploadReceiptStatuses
+{
+    public const string Accepted = "ACCEPTED";
+    public const string AlreadyAccepted = "ALREADY_ACCEPTED";
+    public const string Rejected = "REJECTED";
+}
+
+public sealed record VideoUploadReceiptRequestDto(
+    Guid PreUploadCheckId,
+    Guid UserId,
+    Guid? DeviceId,
+    Guid? GroupNodeId,
+    string ExternalVideoId,
+    string StorageKey,
+    string SiteStatus,
+    long SizeBytes,
+    string ByteSha256,
+    string IdempotencyKey,
+    DateTimeOffset UploadedAtUtc);
+
+public sealed record VideoUploadReceiptResponseDto(
+    Guid UploadReceiptId,
+    Guid PreUploadCheckId,
+    string Status,
+    bool Accepted,
+    bool WasAlreadyAccepted,
+    string Message,
+    string AnalysisJobStatus,
+    DateTimeOffset ReceivedAtUtc);

--- a/src/BuildingBlocks/Infrastructure/Persistence/Configurations/VideoUpload/VideoUploadReceiptAnalysisJobConfiguration.cs
+++ b/src/BuildingBlocks/Infrastructure/Persistence/Configurations/VideoUpload/VideoUploadReceiptAnalysisJobConfiguration.cs
@@ -1,0 +1,38 @@
+using BuildingBlocks.Infrastructure.Persistence.Entities.VideoUpload;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace BuildingBlocks.Infrastructure.Persistence.Configurations.VideoUpload;
+
+public sealed class VideoUploadReceiptAnalysisJobConfiguration : IEntityTypeConfiguration<VideoUploadReceiptAnalysisJob>
+{
+    public void Configure(EntityTypeBuilder<VideoUploadReceiptAnalysisJob> builder)
+    {
+        builder.ToTable("video_upload_receipt_analysis_jobs");
+
+        builder.HasKey(item => item.Id);
+
+        builder.Property(item => item.Id).HasColumnName("id");
+        builder.Property(item => item.UploadReceiptId).HasColumnName("upload_receipt_id");
+        builder.Property(item => item.PreUploadCheckId).HasColumnName("pre_upload_check_id");
+
+        builder.Property(item => item.CommandName)
+            .HasColumnName("command_name")
+            .HasMaxLength(128)
+            .IsRequired();
+
+        builder.Property(item => item.Status)
+            .HasColumnName("status")
+            .HasMaxLength(64)
+            .IsRequired();
+
+        builder.Property(item => item.EnqueuedAtUtc).HasColumnName("enqueued_at_utc");
+
+        builder.HasIndex(item => item.UploadReceiptId)
+            .HasDatabaseName("ix_video_upload_receipt_analysis_jobs_upload_receipt_id");
+
+        builder.HasIndex(item => item.Status)
+            .HasDatabaseName("ix_video_upload_receipt_analysis_jobs_status");
+    }
+}

--- a/src/BuildingBlocks/Infrastructure/Persistence/Configurations/VideoUpload/VideoUploadReceiptAuditRecordConfiguration.cs
+++ b/src/BuildingBlocks/Infrastructure/Persistence/Configurations/VideoUpload/VideoUploadReceiptAuditRecordConfiguration.cs
@@ -1,0 +1,47 @@
+using BuildingBlocks.Infrastructure.Persistence.Entities.VideoUpload;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace BuildingBlocks.Infrastructure.Persistence.Configurations.VideoUpload;
+
+public sealed class VideoUploadReceiptAuditRecordConfiguration : IEntityTypeConfiguration<VideoUploadReceiptAuditRecord>
+{
+    public void Configure(EntityTypeBuilder<VideoUploadReceiptAuditRecord> builder)
+    {
+        builder.ToTable("video_upload_receipt_audit_records");
+
+        builder.HasKey(item => item.Id);
+
+        builder.Property(item => item.Id).HasColumnName("id");
+        builder.Property(item => item.UploadReceiptId).HasColumnName("upload_receipt_id");
+
+        builder.Property(item => item.Category)
+            .HasColumnName("category")
+            .HasMaxLength(128)
+            .IsRequired();
+
+        builder.Property(item => item.Action)
+            .HasColumnName("action")
+            .HasMaxLength(128)
+            .IsRequired();
+
+        builder.Property(item => item.CorrelationId)
+            .HasColumnName("correlation_id")
+            .HasMaxLength(128)
+            .IsRequired();
+
+        builder.Property(item => item.PayloadJson)
+            .HasColumnName("payload_json")
+            .HasMaxLength(4096)
+            .IsRequired();
+
+        builder.Property(item => item.CreatedAtUtc).HasColumnName("created_at_utc");
+
+        builder.HasIndex(item => item.UploadReceiptId)
+            .HasDatabaseName("ix_video_upload_receipt_audit_records_upload_receipt_id");
+
+        builder.HasIndex(item => item.CorrelationId)
+            .HasDatabaseName("ix_video_upload_receipt_audit_records_correlation_id");
+    }
+}

--- a/src/BuildingBlocks/Infrastructure/Persistence/Configurations/VideoUpload/VideoUploadReceiptConfiguration.cs
+++ b/src/BuildingBlocks/Infrastructure/Persistence/Configurations/VideoUpload/VideoUploadReceiptConfiguration.cs
@@ -1,0 +1,72 @@
+using BuildingBlocks.Infrastructure.Persistence.Entities.VideoUpload;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace BuildingBlocks.Infrastructure.Persistence.Configurations.VideoUpload;
+
+public sealed class VideoUploadReceiptConfiguration : IEntityTypeConfiguration<VideoUploadReceipt>
+{
+    public void Configure(EntityTypeBuilder<VideoUploadReceipt> builder)
+    {
+        builder.ToTable("video_upload_receipts");
+
+        builder.HasKey(item => item.Id);
+
+        builder.Property(item => item.Id).HasColumnName("id");
+        builder.Property(item => item.PreUploadCheckId).HasColumnName("pre_upload_check_id");
+        builder.Property(item => item.UserId).HasColumnName("user_id");
+        builder.Property(item => item.DeviceId).HasColumnName("device_id");
+        builder.Property(item => item.GroupNodeId).HasColumnName("group_node_id");
+
+        builder.Property(item => item.ExternalVideoId)
+            .HasColumnName("external_video_id")
+            .HasMaxLength(256)
+            .IsRequired();
+
+        builder.Property(item => item.StorageKey)
+            .HasColumnName("storage_key")
+            .HasMaxLength(512)
+            .IsRequired();
+
+        builder.Property(item => item.SiteStatus)
+            .HasColumnName("site_status")
+            .HasMaxLength(64)
+            .IsRequired();
+
+        builder.Property(item => item.SizeBytes).HasColumnName("size_bytes");
+
+        builder.Property(item => item.ByteSha256)
+            .HasColumnName("byte_sha256")
+            .HasMaxLength(64)
+            .IsRequired();
+
+        builder.Property(item => item.IdempotencyKey)
+            .HasColumnName("idempotency_key")
+            .HasMaxLength(128)
+            .IsRequired();
+
+        builder.Property(item => item.ReceiptStatus)
+            .HasColumnName("receipt_status")
+            .HasMaxLength(64)
+            .IsRequired();
+
+        builder.Property(item => item.AnalysisJobStatus)
+            .HasColumnName("analysis_job_status")
+            .HasMaxLength(64)
+            .IsRequired();
+
+        builder.Property(item => item.UploadedAtUtc).HasColumnName("uploaded_at_utc");
+        builder.Property(item => item.ReceivedAtUtc).HasColumnName("received_at_utc");
+
+        builder.HasIndex(item => item.IdempotencyKey)
+            .IsUnique()
+            .HasDatabaseName("ux_video_upload_receipts_idempotency_key");
+
+        builder.HasIndex(item => item.PreUploadCheckId)
+            .HasDatabaseName("ix_video_upload_receipts_pre_upload_check_id");
+
+        builder.HasIndex(item => new { item.ByteSha256, item.SizeBytes })
+            .HasDatabaseName("ix_video_upload_receipts_fingerprint");
+    }
+}

--- a/src/BuildingBlocks/Infrastructure/Persistence/Entities/VideoUpload/VideoUploadReceipt.cs
+++ b/src/BuildingBlocks/Infrastructure/Persistence/Entities/VideoUpload/VideoUploadReceipt.cs
@@ -1,0 +1,20 @@
+namespace BuildingBlocks.Infrastructure.Persistence.Entities.VideoUpload;
+
+public sealed class VideoUploadReceipt
+{
+    public Guid Id { get; set; }
+    public Guid PreUploadCheckId { get; set; }
+    public Guid UserId { get; set; }
+    public Guid? DeviceId { get; set; }
+    public Guid? GroupNodeId { get; set; }
+    public string ExternalVideoId { get; set; } = string.Empty;
+    public string StorageKey { get; set; } = string.Empty;
+    public string SiteStatus { get; set; } = string.Empty;
+    public long SizeBytes { get; set; }
+    public string ByteSha256 { get; set; } = string.Empty;
+    public string IdempotencyKey { get; set; } = string.Empty;
+    public string ReceiptStatus { get; set; } = string.Empty;
+    public string AnalysisJobStatus { get; set; } = string.Empty;
+    public DateTimeOffset UploadedAtUtc { get; set; }
+    public DateTimeOffset ReceivedAtUtc { get; set; }
+}

--- a/src/BuildingBlocks/Infrastructure/Persistence/Entities/VideoUpload/VideoUploadReceiptAnalysisJob.cs
+++ b/src/BuildingBlocks/Infrastructure/Persistence/Entities/VideoUpload/VideoUploadReceiptAnalysisJob.cs
@@ -1,0 +1,11 @@
+namespace BuildingBlocks.Infrastructure.Persistence.Entities.VideoUpload;
+
+public sealed class VideoUploadReceiptAnalysisJob
+{
+    public Guid Id { get; set; }
+    public Guid UploadReceiptId { get; set; }
+    public Guid PreUploadCheckId { get; set; }
+    public string CommandName { get; set; } = string.Empty;
+    public string Status { get; set; } = string.Empty;
+    public DateTimeOffset EnqueuedAtUtc { get; set; }
+}

--- a/src/BuildingBlocks/Infrastructure/Persistence/Entities/VideoUpload/VideoUploadReceiptAuditRecord.cs
+++ b/src/BuildingBlocks/Infrastructure/Persistence/Entities/VideoUpload/VideoUploadReceiptAuditRecord.cs
@@ -1,0 +1,12 @@
+namespace BuildingBlocks.Infrastructure.Persistence.Entities.VideoUpload;
+
+public sealed class VideoUploadReceiptAuditRecord
+{
+    public Guid Id { get; set; }
+    public Guid UploadReceiptId { get; set; }
+    public string Category { get; set; } = string.Empty;
+    public string Action { get; set; } = string.Empty;
+    public string CorrelationId { get; set; } = string.Empty;
+    public string PayloadJson { get; set; } = string.Empty;
+    public DateTimeOffset CreatedAtUtc { get; set; }
+}

--- a/src/BuildingBlocks/Infrastructure/Persistence/Migrations/20260418103647_AddVideoUploadReceiptFoundation.Designer.cs
+++ b/src/BuildingBlocks/Infrastructure/Persistence/Migrations/20260418103647_AddVideoUploadReceiptFoundation.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using BuildingBlocks.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BuildingBlocks.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(PlatformDbContext))]
-    partial class PlatformDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260418103647_AddVideoUploadReceiptFoundation")]
+    partial class AddVideoUploadReceiptFoundation
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/BuildingBlocks/Infrastructure/Persistence/Migrations/20260418103647_AddVideoUploadReceiptFoundation.cs
+++ b/src/BuildingBlocks/Infrastructure/Persistence/Migrations/20260418103647_AddVideoUploadReceiptFoundation.cs
@@ -1,0 +1,136 @@
+﻿using System;
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BuildingBlocks.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddVideoUploadReceiptFoundation : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "video_upload_receipt_analysis_jobs",
+                schema: "app",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    upload_receipt_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    pre_upload_check_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    command_name = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    status = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    enqueued_at_utc = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_video_upload_receipt_analysis_jobs", x => x.id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "video_upload_receipt_audit_records",
+                schema: "app",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    upload_receipt_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    category = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    action = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    correlation_id = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    payload_json = table.Column<string>(type: "character varying(4096)", maxLength: 4096, nullable: false),
+                    created_at_utc = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_video_upload_receipt_audit_records", x => x.id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "video_upload_receipts",
+                schema: "app",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    pre_upload_check_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    user_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    device_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    group_node_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    external_video_id = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    storage_key = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: false),
+                    site_status = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    size_bytes = table.Column<long>(type: "bigint", nullable: false),
+                    byte_sha256 = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    idempotency_key = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    receipt_status = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    analysis_job_status = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    uploaded_at_utc = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    received_at_utc = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_video_upload_receipts", x => x.id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_video_upload_receipt_analysis_jobs_status",
+                schema: "app",
+                table: "video_upload_receipt_analysis_jobs",
+                column: "status");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_video_upload_receipt_analysis_jobs_upload_receipt_id",
+                schema: "app",
+                table: "video_upload_receipt_analysis_jobs",
+                column: "upload_receipt_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_video_upload_receipt_audit_records_correlation_id",
+                schema: "app",
+                table: "video_upload_receipt_audit_records",
+                column: "correlation_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_video_upload_receipt_audit_records_upload_receipt_id",
+                schema: "app",
+                table: "video_upload_receipt_audit_records",
+                column: "upload_receipt_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_video_upload_receipts_fingerprint",
+                schema: "app",
+                table: "video_upload_receipts",
+                columns: new[] { "byte_sha256", "size_bytes" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_video_upload_receipts_pre_upload_check_id",
+                schema: "app",
+                table: "video_upload_receipts",
+                column: "pre_upload_check_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ux_video_upload_receipts_idempotency_key",
+                schema: "app",
+                table: "video_upload_receipts",
+                column: "idempotency_key",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "video_upload_receipt_analysis_jobs",
+                schema: "app");
+
+            migrationBuilder.DropTable(
+                name: "video_upload_receipt_audit_records",
+                schema: "app");
+
+            migrationBuilder.DropTable(
+                name: "video_upload_receipts",
+                schema: "app");
+        }
+    }
+}

--- a/src/BuildingBlocks/Infrastructure/Persistence/PlatformDbContext.cs
+++ b/src/BuildingBlocks/Infrastructure/Persistence/PlatformDbContext.cs
@@ -31,10 +31,17 @@ public sealed class PlatformDbContext(DbContextOptions<PlatformDbContext> option
 
     public DbSet<VideoUploadPreUploadCheck> VideoUploadPreUploadChecks => Set<VideoUploadPreUploadCheck>();
 
+    public DbSet<VideoUploadReceipt> VideoUploadReceipts => Set<VideoUploadReceipt>();
+    public DbSet<VideoUploadReceiptAnalysisJob> VideoUploadReceiptAnalysisJobs => Set<VideoUploadReceiptAnalysisJob>();
+    public DbSet<VideoUploadReceiptAuditRecord> VideoUploadReceiptAuditRecords => Set<VideoUploadReceiptAuditRecord>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.HasDefaultSchema("app");
         modelBuilder.ApplyConfiguration(new VideoUploadPreUploadCheckConfiguration());
+        modelBuilder.ApplyConfiguration(new VideoUploadReceiptConfiguration());
+        modelBuilder.ApplyConfiguration(new VideoUploadReceiptAnalysisJobConfiguration());
+        modelBuilder.ApplyConfiguration(new VideoUploadReceiptAuditRecordConfiguration());
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(PlatformDbContext).Assembly);
     }
 }

--- a/src/Modules/VideoUpload/VideoUploadModule.cs
+++ b/src/Modules/VideoUpload/VideoUploadModule.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Text.Json;
 
 using BuildingBlocks.Contracts.VideoUpload;
 using BuildingBlocks.Infrastructure.Persistence;
@@ -20,6 +21,7 @@ public sealed class VideoUploadOptions
     public const string SectionName = "Modules:VideoUpload";
 
     public bool PreUploadCheckEnabled { get; set; } = true;
+    public bool UploadReceiptEnabled { get; set; } = true;
     public long MaxFastAllowSizeBytes { get; set; } = 5L * 1024L * 1024L * 1024L;
     public string SiteProvider { get; set; } = "Stub";
     public string ExternalVideoIdPrefix { get; set; } = "site-video";
@@ -30,6 +32,13 @@ public interface IPreUploadCheckService
 {
     Task<VideoPreUploadCheckResponseDto> CheckAsync(
         VideoPreUploadCheckRequestDto request,
+        CancellationToken cancellationToken);
+}
+
+public interface IUploadReceiptService
+{
+    Task<VideoUploadReceiptResponseDto> AcceptAsync(
+        VideoUploadReceiptRequestDto request,
         CancellationToken cancellationToken);
 }
 
@@ -219,6 +228,226 @@ public sealed class PreUploadCheckService(
     }
 }
 
+public sealed class UploadReceiptService(
+    PlatformDbContext dbContext,
+    IOptions<VideoUploadOptions> options,
+    ILogger<UploadReceiptService> logger) : IUploadReceiptService
+{
+    public async Task<VideoUploadReceiptResponseDto> AcceptAsync(
+        VideoUploadReceiptRequestDto request,
+        CancellationToken cancellationToken)
+    {
+        var value = options.Value;
+        if (!value.UploadReceiptEnabled)
+        {
+            throw new InvalidOperationException("UploadReceipt is disabled.");
+        }
+
+        ValidateRequest(request);
+
+        var normalizedHash = request.ByteSha256.Trim().ToLowerInvariant();
+        var normalizedIdempotencyKey = request.IdempotencyKey.Trim();
+        var normalizedExternalVideoId = request.ExternalVideoId.Trim();
+        var normalizedStorageKey = request.StorageKey.Trim();
+        var normalizedSiteStatus = request.SiteStatus.Trim().ToLowerInvariant();
+
+        var existing = await dbContext.VideoUploadReceipts
+            .AsNoTracking()
+            .SingleOrDefaultAsync(
+                item => item.IdempotencyKey == normalizedIdempotencyKey,
+                cancellationToken);
+
+        if (existing is not null)
+        {
+            logger.LogInformation(
+                "UploadReceipt idempotency hit. UploadReceiptId={UploadReceiptId} PreUploadCheckId={PreUploadCheckId}",
+                existing.Id,
+                existing.PreUploadCheckId);
+
+            return new VideoUploadReceiptResponseDto(
+                UploadReceiptId: existing.Id,
+                PreUploadCheckId: existing.PreUploadCheckId,
+                Status: VideoUploadReceiptStatuses.AlreadyAccepted,
+                Accepted: true,
+                WasAlreadyAccepted: true,
+                Message: "Upload receipt already accepted.",
+                AnalysisJobStatus: existing.AnalysisJobStatus,
+                ReceivedAtUtc: existing.ReceivedAtUtc);
+        }
+
+        var preUploadCheck = await dbContext.VideoUploadPreUploadChecks
+            .SingleOrDefaultAsync(
+                item => item.Id == request.PreUploadCheckId,
+                cancellationToken);
+
+        if (preUploadCheck is null)
+        {
+            throw new InvalidOperationException("PreUploadCheck was not found.");
+        }
+
+        if (!preUploadCheck.CanUploadToSite)
+        {
+            throw new InvalidOperationException("PreUploadCheck decision does not allow site upload.");
+        }
+
+        if (preUploadCheck.UserId != request.UserId)
+        {
+            throw new InvalidOperationException("UploadReceipt user context does not match PreUploadCheck.");
+        }
+
+        if (preUploadCheck.DeviceId != request.DeviceId || preUploadCheck.GroupNodeId != request.GroupNodeId)
+        {
+            throw new InvalidOperationException("UploadReceipt device or group context does not match PreUploadCheck.");
+        }
+
+        if (!string.Equals(preUploadCheck.ByteSha256, normalizedHash, StringComparison.OrdinalIgnoreCase) ||
+            preUploadCheck.SizeBytes != request.SizeBytes)
+        {
+            throw new InvalidOperationException("UploadReceipt fingerprint does not match PreUploadCheck.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(preUploadCheck.ExternalVideoId) &&
+            !string.Equals(preUploadCheck.ExternalVideoId, normalizedExternalVideoId, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("UploadReceipt external video id does not match PreUploadCheck.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(preUploadCheck.StorageKey) &&
+            !string.Equals(preUploadCheck.StorageKey, normalizedStorageKey, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("UploadReceipt storage key does not match PreUploadCheck.");
+        }
+
+        var receivedAtUtc = DateTimeOffset.UtcNow;
+        var receiptId = Guid.NewGuid();
+        var correlationId = $"upload-receipt-{receiptId:N}";
+
+        var receipt = new VideoUploadReceipt
+        {
+            Id = receiptId,
+            PreUploadCheckId = request.PreUploadCheckId,
+            UserId = request.UserId,
+            DeviceId = request.DeviceId,
+            GroupNodeId = request.GroupNodeId,
+            ExternalVideoId = normalizedExternalVideoId,
+            StorageKey = normalizedStorageKey,
+            SiteStatus = normalizedSiteStatus,
+            SizeBytes = request.SizeBytes,
+            ByteSha256 = normalizedHash,
+            IdempotencyKey = normalizedIdempotencyKey,
+            ReceiptStatus = VideoUploadReceiptStatuses.Accepted,
+            AnalysisJobStatus = "queued",
+            UploadedAtUtc = request.UploadedAtUtc,
+            ReceivedAtUtc = receivedAtUtc
+        };
+
+        var job = new VideoUploadReceiptAnalysisJob
+        {
+            Id = Guid.NewGuid(),
+            UploadReceiptId = receiptId,
+            PreUploadCheckId = request.PreUploadCheckId,
+            CommandName = "video-upload.deep-analysis",
+            Status = "queued",
+            EnqueuedAtUtc = receivedAtUtc
+        };
+
+        var auditPayload = JsonSerializer.Serialize(new
+        {
+            receipt.Id,
+            receipt.PreUploadCheckId,
+            receipt.UserId,
+            receipt.DeviceId,
+            receipt.GroupNodeId,
+            receipt.ExternalVideoId,
+            receipt.StorageKey,
+            receipt.ByteSha256,
+            receipt.SizeBytes
+        });
+
+        var audit = new VideoUploadReceiptAuditRecord
+        {
+            Id = Guid.NewGuid(),
+            UploadReceiptId = receiptId,
+            Category = "video_upload",
+            Action = "upload_receipt_accepted",
+            CorrelationId = correlationId,
+            PayloadJson = auditPayload,
+            CreatedAtUtc = receivedAtUtc
+        };
+
+        dbContext.VideoUploadReceipts.Add(receipt);
+        dbContext.VideoUploadReceiptAnalysisJobs.Add(job);
+        dbContext.VideoUploadReceiptAuditRecords.Add(audit);
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        logger.LogInformation(
+            "UploadReceipt accepted. UploadReceiptId={UploadReceiptId} PreUploadCheckId={PreUploadCheckId} ExternalVideoId={ExternalVideoId}",
+            receipt.Id,
+            receipt.PreUploadCheckId,
+            receipt.ExternalVideoId);
+
+        return new VideoUploadReceiptResponseDto(
+            UploadReceiptId: receipt.Id,
+            PreUploadCheckId: receipt.PreUploadCheckId,
+            Status: VideoUploadReceiptStatuses.Accepted,
+            Accepted: true,
+            WasAlreadyAccepted: false,
+            Message: "Upload receipt accepted and analysis job queued.",
+            AnalysisJobStatus: receipt.AnalysisJobStatus,
+            ReceivedAtUtc: receipt.ReceivedAtUtc);
+    }
+
+    private static void ValidateRequest(VideoUploadReceiptRequestDto request)
+    {
+        if (request.PreUploadCheckId == Guid.Empty)
+        {
+            throw new ArgumentException("PreUploadCheckId is required.", nameof(request));
+        }
+
+        if (request.UserId == Guid.Empty)
+        {
+            throw new ArgumentException("UserId is required.", nameof(request));
+        }
+
+        if (string.IsNullOrWhiteSpace(request.ExternalVideoId))
+        {
+            throw new ArgumentException("ExternalVideoId is required.", nameof(request));
+        }
+
+        if (string.IsNullOrWhiteSpace(request.StorageKey))
+        {
+            throw new ArgumentException("StorageKey is required.", nameof(request));
+        }
+
+        if (string.IsNullOrWhiteSpace(request.SiteStatus))
+        {
+            throw new ArgumentException("SiteStatus is required.", nameof(request));
+        }
+
+        if (request.SizeBytes <= 0)
+        {
+            throw new ArgumentException("SizeBytes must be positive.", nameof(request));
+        }
+
+        if (string.IsNullOrWhiteSpace(request.ByteSha256))
+        {
+            throw new ArgumentException("ByteSha256 is required.", nameof(request));
+        }
+
+        var normalizedHash = request.ByteSha256.Trim();
+        if (normalizedHash.Length != 64 || !normalizedHash.All(Uri.IsHexDigit))
+        {
+            throw new ArgumentException("ByteSha256 must be a 64-character hexadecimal SHA-256 value.", nameof(request));
+        }
+
+        if (string.IsNullOrWhiteSpace(request.IdempotencyKey))
+        {
+            throw new ArgumentException("IdempotencyKey is required.", nameof(request));
+        }
+    }
+}
+
 public static class VideoUploadModule
 {
     public static IServiceCollection AddVideoUploadModule(
@@ -230,9 +459,14 @@ public static class VideoUploadModule
             {
                 var section = configuration.GetSection(VideoUploadOptions.SectionName);
 
-                if (bool.TryParse(section["PreUploadCheckEnabled"], out var enabled))
+                if (bool.TryParse(section["PreUploadCheckEnabled"], out var preUploadCheckEnabled))
                 {
-                    options.PreUploadCheckEnabled = enabled;
+                    options.PreUploadCheckEnabled = preUploadCheckEnabled;
+                }
+
+                if (bool.TryParse(section["UploadReceiptEnabled"], out var uploadReceiptEnabled))
+                {
+                    options.UploadReceiptEnabled = uploadReceiptEnabled;
                 }
 
                 if (long.TryParse(
@@ -271,6 +505,7 @@ public static class VideoUploadModule
             .ValidateOnStart();
 
         services.AddScoped<IPreUploadCheckService, PreUploadCheckService>();
+        services.AddScoped<IUploadReceiptService, UploadReceiptService>();
 
         return services;
     }
@@ -295,13 +530,42 @@ public static class VideoUploadModule
                     return Results.Problem(
                         detail: exception.Message,
                         statusCode: StatusCodes.Status503ServiceUnavailable,
-                        title: "PreUploadCheck disabled");
+                        title: "PreUploadCheck unavailable");
                 }
                 catch (ArgumentException exception)
                 {
                     return Results.BadRequest(new
                     {
                         error = "invalid_pre_upload_check_request",
+                        message = exception.Message
+                    });
+                }
+            });
+
+        endpoints.MapPost(
+            "/api/video/upload-receipt",
+            async Task<IResult> (
+                VideoUploadReceiptRequestDto request,
+                IUploadReceiptService service,
+                CancellationToken cancellationToken) =>
+            {
+                try
+                {
+                    var result = await service.AcceptAsync(request, cancellationToken);
+                    return Results.Ok(result);
+                }
+                catch (InvalidOperationException exception)
+                {
+                    return Results.Problem(
+                        detail: exception.Message,
+                        statusCode: StatusCodes.Status409Conflict,
+                        title: "UploadReceipt rejected");
+                }
+                catch (ArgumentException exception)
+                {
+                    return Results.BadRequest(new
+                    {
+                        error = "invalid_upload_receipt_request",
                         message = exception.Message
                     });
                 }

--- a/tests/Integration/VideoUpload/UploadReceiptServiceTests.cs
+++ b/tests/Integration/VideoUpload/UploadReceiptServiceTests.cs
@@ -1,0 +1,152 @@
+using BuildingBlocks.Contracts.VideoUpload;
+using BuildingBlocks.Infrastructure.Persistence;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+using Modules.VideoUpload;
+
+namespace VideoUpload.IntegrationTests;
+
+public sealed class UploadReceiptServiceTests
+{
+    private static ServiceProvider CreateProvider()
+    {
+        var settings = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Modules:VideoUpload:PreUploadCheckEnabled"] = "true",
+            ["Modules:VideoUpload:UploadReceiptEnabled"] = "true",
+            ["Modules:VideoUpload:MaxFastAllowSizeBytes"] = "5368709120",
+            ["Modules:VideoUpload:SiteProvider"] = "Stub",
+            ["Modules:VideoUpload:ExternalVideoIdPrefix"] = "site-video",
+            ["Modules:VideoUpload:StorageKeyPrefix"] = "videos"
+        };
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(settings)
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddDbContext<PlatformDbContext>(
+            options => options.UseInMemoryDatabase(Guid.NewGuid().ToString("N")));
+        services.AddVideoUploadModule(configuration);
+
+        return services.BuildServiceProvider(
+            new ServiceProviderOptions
+            {
+                ValidateOnBuild = true,
+                ValidateScopes = true
+            });
+    }
+
+    [Fact]
+    public async Task AcceptAsyncStoresReceiptQueuesJobAndAudit()
+    {
+        using var provider = CreateProvider();
+        using var scope = provider.CreateScope();
+
+        var precheck = scope.ServiceProvider.GetRequiredService<IPreUploadCheckService>();
+        var receipts = scope.ServiceProvider.GetRequiredService<IUploadReceiptService>();
+        var db = scope.ServiceProvider.GetRequiredService<PlatformDbContext>();
+
+        var precheckResult = await precheck.CheckAsync(CreatePrecheckRequest("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), CancellationToken.None);
+        var receipt = await receipts.AcceptAsync(CreateReceiptRequest(precheckResult, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "idem-1"), CancellationToken.None);
+
+        Assert.Equal(VideoUploadReceiptStatuses.Accepted, receipt.Status);
+        Assert.True(receipt.Accepted);
+        Assert.False(receipt.WasAlreadyAccepted);
+        Assert.Equal(1, await db.VideoUploadReceipts.CountAsync());
+        Assert.Equal(1, await db.VideoUploadReceiptAnalysisJobs.CountAsync());
+        Assert.Equal(1, await db.VideoUploadReceiptAuditRecords.CountAsync());
+    }
+
+    [Fact]
+    public async Task AcceptAsyncIsIdempotentByKey()
+    {
+        using var provider = CreateProvider();
+        using var scope = provider.CreateScope();
+
+        var precheck = scope.ServiceProvider.GetRequiredService<IPreUploadCheckService>();
+        var receipts = scope.ServiceProvider.GetRequiredService<IUploadReceiptService>();
+        var db = scope.ServiceProvider.GetRequiredService<PlatformDbContext>();
+
+        var hash = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+        var precheckResult = await precheck.CheckAsync(CreatePrecheckRequest(hash), CancellationToken.None);
+
+        var first = await receipts.AcceptAsync(CreateReceiptRequest(precheckResult, hash, "idem-2"), CancellationToken.None);
+        var second = await receipts.AcceptAsync(CreateReceiptRequest(precheckResult, hash, "idem-2"), CancellationToken.None);
+
+        Assert.Equal(first.UploadReceiptId, second.UploadReceiptId);
+        Assert.True(second.WasAlreadyAccepted);
+        Assert.Equal(VideoUploadReceiptStatuses.AlreadyAccepted, second.Status);
+        Assert.Equal(1, await db.VideoUploadReceipts.CountAsync());
+        Assert.Equal(1, await db.VideoUploadReceiptAnalysisJobs.CountAsync());
+    }
+
+    [Fact]
+    public async Task AcceptAsyncRejectsUnknownPreUploadCheck()
+    {
+        using var provider = CreateProvider();
+        using var scope = provider.CreateScope();
+
+        var receipts = scope.ServiceProvider.GetRequiredService<IUploadReceiptService>();
+
+        var request = new VideoUploadReceiptRequestDto(
+            PreUploadCheckId: Guid.NewGuid(),
+            UserId: UserId,
+            DeviceId: DeviceId,
+            GroupNodeId: GroupNodeId,
+            ExternalVideoId: "site-video-missing",
+            StorageKey: "videos/site-video-missing.mp4",
+            SiteStatus: "uploaded",
+            SizeBytes: 12345,
+            ByteSha256: "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+            IdempotencyKey: "idem-3",
+            UploadedAtUtc: FixedTime);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => receipts.AcceptAsync(request, CancellationToken.None));
+    }
+
+    private static readonly Guid UserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid DeviceId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private static readonly Guid GroupNodeId = Guid.Parse("33333333-3333-3333-3333-333333333333");
+    private static readonly DateTimeOffset FixedTime = DateTimeOffset.Parse(
+        "2026-04-18T00:00:00+00:00",
+        System.Globalization.CultureInfo.InvariantCulture);
+
+    private static VideoPreUploadCheckRequestDto CreatePrecheckRequest(string hash)
+    {
+        return new VideoPreUploadCheckRequestDto(
+            UserId: UserId,
+            DeviceId: DeviceId,
+            GroupNodeId: GroupNodeId,
+            BusinessObjectKey: "demo-business-object",
+            FileName: "demo.mp4",
+            SizeBytes: 12345,
+            ByteSha256: hash,
+            ContentType: "video/mp4",
+            CapturedAtUtc: FixedTime);
+    }
+
+    private static VideoUploadReceiptRequestDto CreateReceiptRequest(
+        VideoPreUploadCheckResponseDto precheck,
+        string hash,
+        string idempotencyKey)
+    {
+        return new VideoUploadReceiptRequestDto(
+            PreUploadCheckId: precheck.PreUploadCheckId,
+            UserId: UserId,
+            DeviceId: DeviceId,
+            GroupNodeId: GroupNodeId,
+            ExternalVideoId: precheck.SitePlan!.ExternalVideoId,
+            StorageKey: precheck.SitePlan.StorageKey,
+            SiteStatus: "uploaded",
+            SizeBytes: 12345,
+            ByteSha256: hash,
+            IdempotencyKey: idempotencyKey,
+            UploadedAtUtc: FixedTime);
+    }
+}


### PR DESCRIPTION
Closes #31

## Goal
Implement S1-03 UploadReceipt and server-side fixation after direct client-to-site upload.

## Module
VideoUpload

## Contracts
- Adds UploadReceipt DTOs
- Adds runtime endpoint: POST /api/video/upload-receipt
- Receipt statuses:
  - ACCEPTED
  - ALREADY_ACCEPTED
  - REJECTED

## Migration
Additive migration:
- video_upload_receipts
- video_upload_receipt_analysis_jobs
- video_upload_receipt_audit_records
- idempotency index on IdempotencyKey

## Feature flag / kill switch
- Modules:VideoUpload:UploadReceiptEnabled

## Tests
- UploadReceipt service integration tests
- happy path stores receipt, queues analysis job and writes audit record
- idempotency by key
- unknown PreUploadCheck rejection

## Manual verification
- dotnet build
- dotnet test tests/Integration/VideoUpload/VideoUpload.IntegrationTests.csproj
- dotnet ef database update
- API smoke:
  - POST /api/video/pre-upload-check
  - POST /api/video/upload-receipt
  - repeated receipt returns ALREADY_ACCEPTED

## Offline behavior
When server is offline, client stores UploadReceipt in local outbox/PendingSyncItem and sends it after reconnect.

## Rollback
- disable Modules:VideoUpload:UploadReceiptEnabled
- revert PR if needed
- migration is additive and preserves already created data