### PR TITLE
infra(stage): add S1-10 smoke checks and rollback rehearsal

### DIFF
--- a/docs/runbooks/stage-deploy-and-rollback.md
+++ b/docs/runbooks/stage-deploy-and-rollback.md
@@ -7,9 +7,15 @@ bash infra/deploy/stage-publish.sh
 bash infra/deploy/stage-apply-migrations.sh
 sudo systemctl restart analytics-api
 sudo systemctl restart analytics-worker
-bash infra/deploy/stage-smoke.sh
+BASE_URL=http://127.0.0.1:5000 bash infra/deploy/stage-smoke.sh
 Rollback:
 bash infra/deploy/stage-rollback.sh /opt/analytics-automation/releases/<previous-release-id>
-bash infra/deploy/stage-smoke.sh
+BASE_URL=http://127.0.0.1:5000 bash infra/deploy/stage-smoke.sh
+Rollback rehearsal:
+See docs/runbooks/stage-rollback-rehearsal.md.
+Smoke checklist:
+See docs/runbooks/stage-smoke-checks.md.
 DB rollback policy:
 Migrations are additive-first. DB rollback is manual decision only. Default rollback is application artifact rollback.
+Secrets:
+Secrets are stored outside repo in /etc/analytics-automation/*.env.

--- a/docs/runbooks/stage-operations.md
+++ b/docs/runbooks/stage-operations.md
@@ -2,6 +2,8 @@
 Health:
 curl -fsS http://127.0.0.1:5000/health/live
 curl -fsS http://127.0.0.1:5000/health/ready
+Smoke:
+BASE_URL=http://127.0.0.1:5000 bash infra/deploy/stage-smoke.sh
 Services:
 sudo systemctl status analytics-api
 sudo systemctl status analytics-worker
@@ -13,3 +15,7 @@ journalctl -u analytics-worker -f
 Nginx:
 sudo nginx -t
 sudo systemctl reload nginx
+Database:
+bash infra/deploy/stage-apply-migrations.sh
+Rollback:
+bash infra/deploy/stage-rollback.sh /opt/analytics-automation/releases/<previous-release-id>

--- a/docs/runbooks/stage-rollback-rehearsal.md
+++ b/docs/runbooks/stage-rollback-rehearsal.md
@@ -1,0 +1,20 @@
+# Stage rollback rehearsal v1
+Purpose: verify that stage can move from current release to previous release.
+Preconditions:
+- At least two release folders exist under /opt/analytics-automation/releases.
+- /opt/analytics-automation/current points to the active release.
+- stage-smoke.sh passes before rehearsal.
+Rehearsal:
+1. Capture current target: readlink -f /opt/analytics-automation/current.
+2. Select previous release folder.
+3. Run: bash infra/deploy/stage-rollback.sh /opt/analytics-automation/releases/<previous-release-id>.
+4. Run: BASE_URL=http://127.0.0.1:5000 bash infra/deploy/stage-smoke.sh.
+5. Record rollback target and smoke result in release notes.
+DB policy:
+- Default rollback is application artifact rollback.
+- DB rollback is manual decision only.
+- Additive migrations are preferred and should not require immediate DB rollback.
+Failure triage:
+- If service restart fails, restore symlink to prior known-good release.
+- If ready fails after rollback, inspect DB migration compatibility.
+- If nginx fails, revert nginx config separately.

--- a/docs/runbooks/stage-smoke-checks.md
+++ b/docs/runbooks/stage-smoke-checks.md
@@ -1,0 +1,18 @@
+# Stage smoke checks v1
+Purpose: verify that a deployed stage release is alive before handoff.
+Scope: App.Api, App.Worker, Nginx, health endpoints and basic logs.
+Command:
+BASE_URL=http://127.0.0.1:5000 bash infra/deploy/stage-smoke.sh
+Checks:
+1. analytics-api systemd service is active.
+2. analytics-worker systemd service is active.
+3. GET /health/live returns success.
+4. GET /health/ready returns success.
+5. nginx -t returns success.
+6. journalctl tail for API and Worker is readable.
+Failure triage:
+- API inactive: check journalctl -u analytics-api -n 120 --no-pager.
+- Worker inactive: check journalctl -u analytics-worker -n 120 --no-pager.
+- ready failed: check PostgreSQL connection string and migrations.
+- nginx failed: run sudo nginx -t and inspect site config.
+Done marker: STAGE_SMOKE_OK.

--- a/infra/deploy/stage-rollback.sh
+++ b/infra/deploy/stage-rollback.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 APP_ROOT="${APP_ROOT:-/opt/analytics-automation}"
+API_SERVICE="${API_SERVICE:-analytics-api}"
+WORKER_SERVICE="${WORKER_SERVICE:-analytics-worker}"
 TARGET_RELEASE="${1:-}"
 if [ -z "$TARGET_RELEASE" ]; then
   echo "Usage: stage-rollback.sh /opt/analytics-automation/releases/<release-id>"
@@ -9,7 +11,10 @@ if [ -z "$TARGET_RELEASE" ]; then
   exit 2
 fi
 test -d "$TARGET_RELEASE"
+CURRENT_BEFORE="$(readlink -f "$APP_ROOT/current" || true)"
 ln -sfn "$TARGET_RELEASE" "$APP_ROOT/current"
-sudo systemctl restart analytics-api
-sudo systemctl restart analytics-worker
-printf "%s\n" "STAGE_ROLLBACK_DONE=$TARGET_RELEASE"
+sudo systemctl restart "$API_SERVICE"
+sudo systemctl restart "$WORKER_SERVICE"
+echo "STAGE_ROLLBACK_FROM=$CURRENT_BEFORE"
+echo "STAGE_ROLLBACK_TO=$TARGET_RELEASE"
+echo "STAGE_ROLLBACK_DONE"

--- a/infra/deploy/stage-smoke.sh
+++ b/infra/deploy/stage-smoke.sh
@@ -1,10 +1,20 @@
 #!/usr/bin/env bash
 set -euo pipefail
 BASE_URL="${BASE_URL:-http://127.0.0.1:5000}"
-systemctl is-active --quiet analytics-api
-systemctl is-active --quiet analytics-worker
+API_SERVICE="${API_SERVICE:-analytics-api}"
+WORKER_SERVICE="${WORKER_SERVICE:-analytics-worker}"
+echo "SMOKE_CHECK=systemd_api"
+systemctl is-active --quiet "$API_SERVICE"
+echo "SMOKE_CHECK=systemd_worker"
+systemctl is-active --quiet "$WORKER_SERVICE"
+echo "SMOKE_CHECK=health_live"
 curl -fsS "$BASE_URL/health/live" >/dev/null
+echo "SMOKE_CHECK=health_ready"
 curl -fsS "$BASE_URL/health/ready" >/dev/null
-journalctl -u analytics-api -n 40 --no-pager
-journalctl -u analytics-worker -n 40 --no-pager
-printf "%s\n" "STAGE_SMOKE_OK"
+echo "SMOKE_CHECK=nginx_config"
+sudo nginx -t >/dev/null
+echo "SMOKE_LOGS=api_tail"
+journalctl -u "$API_SERVICE" -n 40 --no-pager
+echo "SMOKE_LOGS=worker_tail"
+journalctl -u "$WORKER_SERVICE" -n 40 --no-pager
+echo "STAGE_SMOKE_OK"


### PR DESCRIPTION
Closes #45
Goal: implement S1-10 smoke checks and rollback rehearsal path v1.
Module: Infra / Deploy / Observability / App.Api / App.Worker.
Contracts: no runtime shared DTO changes.
Migration: no new DB migration.
Feature flags: no new flags.
Manual verification: dotnet restore, dotnet build, dotnet publish App.Api Release, dotnet publish App.Worker Release.
Tests: CI restore/build/unit-tests/integration-tests.
Deploy artifacts updated: stage-smoke.sh and stage-rollback.sh.
Docs added: stage-smoke-checks.md and stage-rollback-rehearsal.md.
Docs updated: stage-deploy-and-rollback.md and stage-operations.md.
Security: no secrets in repo; production deploy is not performed by this PR.
Rollback: switch /opt/analytics-automation/current to previous release and restart analytics-api/analytics-worker.
