### PR TITLE
docs(handoff): add S1-11 backend integration handoff

### DIFF
--- a/docs/handoffs/s1-11-backend-integration-note.md
+++ b/docs/handoffs/s1-11-backend-integration-note.md
@@ -1,0 +1,119 @@
+# S1-11 Backend integration note
+Status: Sprint 1 backend integration handoff.
+Scope: web and Android integration against backend control-plane contracts.
+Runtime code changes: none.
+DB migration: none.
+Auth note: current auth foundation is baseline. Full authz policy middleware hardening is deferred.
+Stage note: use stage API only after stage URL/env is provided by owner.
+Core rule: video bytes go direct client <-> site. API is control plane.
+Health endpoints:
+GET /health/live
+GET /health/ready
+WebsiteIntegration endpoints:
+GET /api/website-integration/contracts
+POST /api/website-integration/upload-receipts/preview
+POST /api/website-integration/download-intents/preview
+POST /api/website-integration/reconcile/preview
+Upload pre-check endpoint:
+POST /api/video-upload/pre-upload-check
+PreUploadCheck decisions:
+ALLOW
+BLOCK_HARD_DUPLICATE
+ALLOW_WITH_REVIEW
+BLOCK_POSSIBLE_FALSIFICATION
+PreUploadCheck minimal request fields:
+userId, deviceId, groupNodeId, businessObjectKey, fileName, contentType, sizeBytes, byteSha256
+Upload receipt endpoint:
+POST /api/video-upload/receipts
+UploadReceipt statuses:
+accepted
+duplicate_ignored
+rejected
+UploadReceipt minimal request fields:
+clientReceiptKey, userId, deviceId, groupNodeId, businessObjectKey, externalVideoId, fileName, contentType, sizeBytes, byteSha256, uploadedAtUtc
+Duplicate registry endpoints:
+POST /api/video-duplicates/assets/register
+POST /api/video-duplicates/candidates/evaluate
+GET /api/video-duplicates/candidates/{candidateId}
+Duplicate match classes:
+HARD_DUPLICATE
+SUSPECT_DUPLICATE
+POSSIBLE_FALSIFICATION
+Duplicate incident endpoints:
+POST /api/incidents/duplicates
+GET /api/incidents/duplicates/assigned/{assignedAdminUserId}
+POST /api/incidents/duplicates/{incidentId}/decision
+Duplicate incident statuses:
+ASSIGNED
+RESOLVED
+IGNORED_BELOW_THRESHOLD
+Duplicate decisions:
+CONFIRM_DUPLICATE
+DISMISS_DUPLICATE
+ESCALATE
+Fraud signal endpoints:
+POST /api/fraud-signals/evaluate-upload
+GET /api/fraud-signals/incidents/assigned/{assignedAdminUserId}
+POST /api/fraud-signals/incidents/{incidentId}/decision
+Fraud severities:
+LOW
+MEDIUM
+HIGH
+Fraud decisions:
+CONFIRM_SUSPICION
+DISMISS_SUSPICION
+ESCALATE
+Worker pipeline endpoints:
+POST /api/worker-pipeline/jobs/analyze-uploaded-video
+POST /api/worker-pipeline/jobs/process-one
+GET /api/worker-pipeline/jobs/{jobId}
+GET /api/worker-pipeline/jobs?take=25
+Worker job type:
+AnalyzeUploadedVideo
+Worker statuses:
+queued
+running
+completed
+failed
+Download endpoints:
+POST /api/video-download/intents
+POST /api/video-download/receipts
+GET /api/video-download/intents/{downloadIntentId}
+GET /api/video-download/receipts/{downloadReceiptId}
+GET /api/video-download/status-vocabulary
+Download intent statuses:
+created
+consumed
+expired
+rejected
+Download receipt statuses:
+accepted
+duplicate_ignored
+Online upload flow:
+1. Client calculates local file metadata.
+2. Client calls PreUploadCheck.
+3. If allowed, client uploads bytes direct to site.
+4. Client sends UploadReceipt to API.
+5. Backend writes audit and can queue AnalyzeUploadedVideo.
+6. Duplicate or fraud incidents can be assigned to admins.
+Offline upload flow:
+1. Client uses last active account only.
+2. Client performs local outbox/dedupe-cache check.
+3. Client uploads to site if allowed by offline UX.
+4. Client stores PendingSyncItem/outbox item.
+5. On reconnect, client sends UploadReceipt/sync payload.
+6. Server performs late duplicate/fraud detection.
+Online download flow:
+1. Client calls CreateDownloadIntent.
+2. API returns DownloadUrl.
+3. Client downloads bytes direct from site.
+4. Client sends DownloadReceipt.
+Known limitations:
+Real site provider beyond stub-compatible URL is deferred.
+Deep media ffprobe/ffmpeg/Chromaprint payload is deferred.
+Full authz policy middleware hardening is deferred.
+Worker-to-incident fan-out from deep result is deferred.
+Offline absolute duplicate/fraud block is not guaranteed.
+Generic error shape:
+Use HTTP 400 for invalid request, 409 for rejected business operation, 404 for missing read model, 5xx for unexpected server error.
+Do not invent new statuses in clients. Unknown statuses must be displayed as unknown/unsupported and logged.

--- a/docs/handoffs/s1-11-coder2-web-integration.md
+++ b/docs/handoffs/s1-11-coder2-web-integration.md
@@ -1,0 +1,33 @@
+# S1-11 handoff for coder 2
+Target: Web/Desktop PWA integration.
+Do not change shared contracts in web branch.
+Use backend contracts as source of truth.
+Primary upload UI flow:
+1. collect file metadata
+2. call POST /api/video-upload/pre-upload-check
+3. handle ALLOW, BLOCK_HARD_DUPLICATE, ALLOW_WITH_REVIEW, BLOCK_POSSIBLE_FALSIFICATION
+4. upload bytes direct to site when allowed
+5. call POST /api/video-upload/receipts
+6. show receipt status accepted, duplicate_ignored, or rejected
+Admin review UI can use:
+GET /api/incidents/duplicates/assigned/{assignedAdminUserId}
+POST /api/incidents/duplicates/{incidentId}/decision
+GET /api/fraud-signals/incidents/assigned/{assignedAdminUserId}
+POST /api/fraud-signals/incidents/{incidentId}/decision
+Worker status UI can use:
+GET /api/worker-pipeline/jobs/{jobId}
+GET /api/worker-pipeline/jobs?take=25
+Download UI flow:
+1. call POST /api/video-download/intents
+2. open DownloadUrl or stream direct from site in browser context
+3. call POST /api/video-download/receipts
+Health check for stage:
+GET /health/live
+GET /health/ready
+Do not invent:
+real site provider payload
+new duplicate/fraud statuses
+deep media analysis payload
+final authz policy behavior
+stale download intent reconcile behavior
+If an endpoint returns unknown status, display unsupported status and log it.

--- a/docs/handoffs/s1-11-coder3-android-integration.md
+++ b/docs/handoffs/s1-11-coder3-android-integration.md
@@ -1,0 +1,37 @@
+# S1-11 handoff for coder 3
+Target: Android MAUI Blazor Hybrid integration.
+Do not change shared contracts in Android branch.
+Use backend contracts as source of truth.
+Primary mobile upload flow:
+1. collect file metadata locally
+2. if online, call POST /api/video-upload/pre-upload-check
+3. handle ALLOW, BLOCK_HARD_DUPLICATE, ALLOW_WITH_REVIEW, BLOCK_POSSIBLE_FALSIFICATION
+4. upload bytes direct to site when allowed
+5. call POST /api/video-upload/receipts
+6. store local outbox state until receipt is accepted
+Offline upload behavior:
+last active account only
+limited upload-related functionality only
+local outbox and local dedupe cache only
+absolute duplicate/fraud block is not guaranteed offline
+on reconnect send UploadReceipt/sync payload
+Download behavior:
+download intent creation is online-only
+call POST /api/video-download/intents
+download bytes direct from site DownloadUrl
+call POST /api/video-download/receipts
+do not create DownloadReceipt without server-issued intent
+Worker and incidents:
+mobile does not start worker jobs directly
+server may create AnalyzeUploadedVideo after receipt/sync
+mobile should not invent deep media result payload
+Health check for stage:
+GET /health/live
+GET /health/ready
+Do not invent:
+real site provider payload
+new duplicate/fraud statuses
+final offline cache policy beyond current baseline
+final authz policy behavior
+stale download intent reconcile behavior
+If an endpoint returns unknown status, display unsupported status and log it.


### PR DESCRIPTION
Closes #47
Goal: publish S1-11 backend integration handoff for coder 2 and coder 3.
Module: Docs / Backend integration handoff.
Contracts: no runtime shared DTO changes.
Migration: no DB migration.
Feature flags: no new flags.
Runtime code: no runtime code changes.
Manual verification: dotnet restore and dotnet build passed in STEP97.
Tests: CI restore/build/unit-tests/integration-tests.
Docs added: backend integration note, coder 2 web handoff, coder 3 Android handoff.
Scope: upload flow, download flow, duplicate/fraud/incidents, worker statuses, health/stage notes, known limitations.
Rollback: docs-only revert PR.
After merge: send handoff summary to 40_*, coder 2 and coder 3.
