### PR TITLE
docs(gate): add S1-12 sprint1 quality gate

### DIFF
--- a/docs/handoffs/s1-12-sprint1-quality-gate.md
+++ b/docs/handoffs/s1-12-sprint1-quality-gate.md
@@ -1,0 +1,90 @@
+# S1-12 Sprint 1 quality gate
+GeneratedAtUtc: 2026-04-19T08:24:49Z
+Branch: docs/s1-12-sprint1-quality-gate
+BaseHeadAtGate: 09a970a
+Gate status: PASS_FOR_BACKEND_HANDOFF
+Production status: NOT_A_PRODUCTION_RELEASE
+Stage execution status: RUNBOOK_READY_STAGE_EXECUTION_DEFERRED
+Scope: Sprint 1 backend/platform foundation quality gate.
+Runtime code changes in this step: none.
+DB migration in this step: none.
+Shared contract changes in this step: none.
+Sprint 1 goal:
+First backend vertical slice for upload control plane is ready for web/mobile integration.
+Quality gate decision:
+Backend/platform foundation is ready for coder 2 and coder 3 integration work.
+This is not a final production launch approval.
+Validated areas:
+- WebsiteIntegration gateway v1 and stub contracts.
+- VideoUpload PreUploadCheck v1.
+- VideoUpload UploadReceipt v1.
+- VideoDuplicates registry v1.
+- DuplicateIncident routing v1.
+- FraudSignals v1.
+- WorkerPipeline AnalyzeUploadedVideo v1.
+- VideoDownload control plane v1.
+- Ubuntu/stage deploy path v1.
+- Stage smoke checks and rollback rehearsal docs.
+- S1-11 backend integration handoff for web and Android.
+Primary upload flow:
+Client file metadata -> PreUploadCheck -> direct client/site upload -> UploadReceipt -> audit -> worker/deep analysis baseline -> duplicate/fraud incidents.
+Primary download flow:
+CreateDownloadIntent -> direct site download -> DownloadReceipt -> audit.
+Offline upload constraints:
+Last active account only.
+Limited upload-related functionality only.
+Local outbox and local dedupe cache only.
+Absolute duplicate/fraud block is not guaranteed offline.
+Server performs late duplicate/fraud detection after sync.
+Key status vocabularies:
+PreUploadCheck: ALLOW, BLOCK_HARD_DUPLICATE, ALLOW_WITH_REVIEW, BLOCK_POSSIBLE_FALSIFICATION.
+UploadReceipt: accepted, duplicate_ignored, rejected.
+Duplicate match: HARD_DUPLICATE, SUSPECT_DUPLICATE, POSSIBLE_FALSIFICATION.
+DuplicateIncident: ASSIGNED, RESOLVED, IGNORED_BELOW_THRESHOLD.
+Fraud severity: LOW, MEDIUM, HIGH.
+Worker job: queued, running, completed, failed.
+DownloadIntent: created, consumed, expired, rejected.
+DownloadReceipt: accepted, duplicate_ignored.
+Stage readiness:
+App.Api and App.Worker have publish path.
+systemd unit skeletons exist for API and Worker.
+Nginx stage config exists.
+Secrets are outside repo in /etc/analytics-automation/*.env.
+Smoke checks cover systemd active, health live, health ready, nginx -t and journalctl tails.
+Rollback path switches /opt/analytics-automation/current to previous release and restarts services.
+CI/local verification expected:
+dotnet restore.
+dotnet build.
+dotnet test.
+dotnet publish App.Api Release.
+dotnet publish App.Worker Release.
+Known analyzer warnings:
+Existing CA warnings are accepted for this gate and are not new blocking failures.
+Known deferred items:
+Full authz middleware hardening.
+Real site provider payload beyond stub-compatible baseline.
+ffprobe/ffmpeg/Chromaprint deep media payload.
+Worker-to-incident fan-out from deep result.
+Final mobile offline cache policy.
+Real stage host execution and rollback rehearsal with actual release folders.
+Future 1C foundation implementation.
+Risk register:
+Auth foundation exists, but policy enforcement must be hardened before production.
+Stage runbooks exist, but real server rehearsal must be executed before production.
+Deep media analysis is represented as baseline worker flow, not final fingerprint analysis.
+Offline duplicate prevention remains best-effort until site-side or later sync mechanisms mature.
+Go / No-Go:
+GO for coder 2 web integration against documented contracts.
+GO for coder 3 Android integration against documented contracts.
+GO for opening repository in IDE for deeper UI/C# integration work after this gate is merged.
+NO-GO for production deploy.
+NO-GO for changing shared contracts without new task card and coordination.
+NO-GO for inventing new statuses in clients.
+Required handoff after merge:
+Send S1-12 quality gate summary to 40_*.
+Tell coder 2 to proceed from S1-11 web handoff and quality gate constraints.
+Tell coder 3 to proceed from S1-11 Android handoff and quality gate constraints.
+Rollback:
+Docs-only revert PR.
+No database changes to roll back.
+No runtime feature flag changes in this step.


### PR DESCRIPTION
Closes #49
Goal: publish S1-12 Sprint 1 quality gate.
Module: Docs / Quality Gate / Release readiness.
Contracts: no runtime shared DTO changes.
Migration: no DB migration.
Feature flags: no new flags.
Runtime code: no runtime code changes.
Manual verification: STEP100 passed dotnet restore/build/test and publish for App.Api/App.Worker.
Tests: CI restore/build/unit-tests/integration-tests.
Docs added: docs/handoffs/s1-12-sprint1-quality-gate.md.
Gate result: backend/platform foundation is ready for coder 2 and coder 3 integration work.
Production status: not a production release approval.
Known deferred: authz hardening, real site provider, deep media ffprobe/ffmpeg/Chromaprint payload, worker-to-incident fan-out, final mobile offline cache policy.
Rollback: docs-only revert PR.
After merge: send S1-12 quality gate handoff to 40_*, coder 2 and coder 3.
