### PR TITLE
S2-03 CI Actions Node 24 Readiness

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,4 +1,4 @@
-name: ci
+﻿name: ci
 
 on:
   pull_request:
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -94,7 +94,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -143,7 +143,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -192,7 +192,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5

--- a/docs/ci/s2-03-ci-actions-node24-readiness.md
+++ b/docs/ci/s2-03-ci-actions-node24-readiness.md
@@ -82,3 +82,15 @@ No production deploy included.
   - feature flag: none;
   - rollback: revert PR;
   - production deploy: not included.
+## Inventory update
+
+Current workflow inventory:
+- `.github/workflows/ci-pr.yml` used `actions/checkout@v4`.
+- CI annotations reported Node.js 20 deprecation for `actions/checkout@v4`.
+- Official `actions/checkout@v5` release notes state that v5 uses Node 24.
+- Official `actions/checkout@v5` requires Actions Runner `v2.327.1+`.
+- Existing GitHub-hosted runner log showed runner `2.333.1`, which satisfies the minimum runner requirement.
+
+S2-03 change:
+- update `actions/checkout@v4` to `actions/checkout@v5`;
+- keep restore, format, build, unit-tests and integration-tests behavior unchanged.

--- a/docs/ci/s2-03-ci-actions-node24-readiness.md
+++ b/docs/ci/s2-03-ci-actions-node24-readiness.md
@@ -1,0 +1,84 @@
+﻿# S2-03 CI Actions Node 24 Readiness
+
+Status: Draft
+Owner: Coder 1 / Platform Owner
+Module: GitHub Actions / CI / Platform
+Type: CI maintenance / platform readiness
+
+## Goal
+
+Remove GitHub Actions Node.js 20 deprecation risk from the CI pipeline while keeping the current CI behavior unchanged.
+
+## Context
+
+After S2-02 was merged, manual workflow_dispatch CI on main completed successfully.
+
+CI annotations reported that Node.js 20 actions are deprecated and that actions such as actions/checkout@v4 may require updates before GitHub-hosted runner defaults change.
+
+## What changes
+
+- backend: no runtime code change.
+- web: no change.
+- mobile: no change.
+- worker: no runtime code change.
+- db: no migration.
+- ci: verify and update GitHub Actions versions only where needed.
+- docs: document the maintenance scope and validation evidence.
+
+## Contracts
+
+No shared DTO changes.
+No API route changes.
+No response payload shape changes.
+No enum/status changes.
+
+## Migration
+
+Not needed.
+
+## Feature flag
+
+Not needed.
+
+## Events
+
+No new events.
+
+## Offline behavior
+
+No offline behavior change.
+
+## Security
+
+No auth/authz behavior change.
+No secrets change.
+
+## Observability
+
+CI logs must clearly show restore, format, build, unit-tests and integration-tests.
+No new runtime observability hooks.
+
+## Rollback
+
+Rollback by reverting the PR.
+No database rollback.
+No shared contract rollback.
+No production deploy included.
+
+## Definition of Done
+
+- current action versions in .github/workflows are inventoried;
+- Node 24-compatible replacement versions are verified before update;
+- CI behavior remains the same:
+  - restore;
+  - format;
+  - build;
+  - unit-tests;
+  - integration-tests;
+- PR explains:
+  - module: GitHub Actions / CI;
+  - contracts: none;
+  - migration: none;
+  - feature flag: none;
+  - rollback: revert PR;
+  - production deploy: not included.


### PR DESCRIPTION
﻿## Goal

S2-03 CI Actions Node 24 Readiness.

Remove GitHub Actions Node.js 20 deprecation warning from CI by updating checkout action runtime compatibility.

## Module

GitHub Actions / CI / Platform.

## Changes

- Updates `.github/workflows/ci-pr.yml` from `actions/checkout@v4` to `actions/checkout@v5`.
- Documents S2-03 inventory and validation evidence in task card.
- Keeps CI behavior unchanged:
  - restore;
  - format;
  - build;
  - unit-tests;
  - integration-tests.

## Contracts

No shared DTO changes.
No API route changes.
No response payload shape changes.
No enum/status changes.

## Migration

No database migration.

## Feature flag

No feature flag.

## Offline behavior

No offline behavior change.

## Tests

Expected PR CI:
- restore;
- format;
- build;
- unit-tests;
- integration-tests.

## Rollback

Revert this PR.

## Production deploy

Not included.
