### PR TITLE
S2-04 Manual Korobochka Deploy Workflow

### DIFF
--- a/.github/workflows/deploy-korobochka.yml
+++ b/.github/workflows/deploy-korobochka.yml
@@ -1,0 +1,40 @@
+name: Deploy Korobochka
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: korobochka-deploy
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy to Korobochka
+    runs-on:
+      - self-hosted
+      - linux
+      - korobochka
+
+    steps:
+      - name: Show runner
+        shell: bash
+        run: |
+          hostname
+          whoami
+          date
+          pwd
+
+      - name: Deploy
+        shell: bash
+        run: sudo /usr/local/bin/v1-deploy
+
+      - name: Smoke check
+        shell: bash
+        run: |
+          curl -fsS http://127.0.0.1/health/ready
+          echo
+          curl -fsS http://127.0.0.1/api/system/version
+          echo

--- a/docs/ops/s2-04-korobochka-deploy-workflow-activation.md
+++ b/docs/ops/s2-04-korobochka-deploy-workflow-activation.md
@@ -1,4 +1,4 @@
-﻿# S2-04 Korobochka Deploy Workflow Activation
+# S2-04 Korobochka Deploy Workflow Activation
 
 Status: Draft
 Owner: Coder 1 / Platform Owner
@@ -118,3 +118,22 @@ The follow-up implementation PR must explicitly state whether `push` to `main` d
 - workflow behavior is documented in PR;
 - PR passes CI;
 - production/stage deployment behavior is explicitly approved before merge if `push: main` trigger is enabled.
+## Implementation update
+
+The first clean implementation PR adds `.github/workflows/deploy-korobochka.yml` as `workflow_dispatch` only.
+
+Decision:
+
+- no automatic deploy on `push` to `main` in the first implementation;
+- no deploy from pull_request;
+- deploy runs only when manually dispatched by an authorized maintainer;
+- workflow targets only the Korobochka self-hosted runner labels:
+  - self-hosted;
+  - linux;
+  - korobochka;
+- workflow calls existing `sudo /usr/local/bin/v1-deploy`;
+- workflow performs smoke checks:
+  - `http://127.0.0.1/health/ready`;
+  - `http://127.0.0.1/api/system/version`.
+
+A separate follow-up PR is required before enabling automatic deploy on `push` to `main`.


### PR DESCRIPTION
## Goal

Add the clean Korobochka deploy workflow implementation from current main.

## Module

GitHub Actions / Deploy / Korobochka / Platform.

## Changes

- Adds `.github/workflows/deploy-korobochka.yml`.
- First implementation is manual-only via `workflow_dispatch`.
- Does not deploy on pull_request.
- Does not enable automatic deploy on push to main yet.
- Uses Korobochka self-hosted runner labels:
  - self-hosted;
  - linux;
  - korobochka.
- Calls existing `sudo /usr/local/bin/v1-deploy`.
- Adds smoke checks after deploy:
  - `http://127.0.0.1/health/ready`;
  - `http://127.0.0.1/api/system/version`.
- Updates S2-04 task card with the implementation decision.

## Contracts

No shared DTO changes.
No API route changes.
No response payload shape changes.
No enum/status changes.

## Migration

No database migration in this PR.

## Feature flag

No application feature flag.

Deploy is controlled by GitHub Actions manual dispatch.

## Security

No secrets added.
No runner tokens added.
No SSH keys added.
No `/opt/v1-pyton/secrets` content added.

## Tests

Expected PR CI:
- restore;
- format;
- build;
- unit-tests;
- integration-tests.

## Rollback

Revert this PR.

## Production deploy

Not triggered by this PR.
The workflow is manual-only.