### PR TITLE
S2-06 Authenticated API Smoke Coverage

### DIFF
--- a/tests/Integration/App.Api/AppApiFactory.cs
+++ b/tests/Integration/App.Api/AppApiFactory.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -38,7 +39,9 @@ public sealed class AppApiFactory : WebApplicationFactory<global::Program>
                 services.Remove(serviceDescriptor);
             }
 
+            services.RemoveAll<IDbContextOptionsConfiguration<PlatformDbContext>>();
             services.RemoveAll<DbContextOptions<PlatformDbContext>>();
+            services.RemoveAll<DbContextOptions>();
             services.RemoveAll<PlatformDbContext>();
 
             services.AddDbContext<PlatformDbContext>(options =>

--- a/tests/Integration/App.Api/AuthenticatedEndpointTests.cs
+++ b/tests/Integration/App.Api/AuthenticatedEndpointTests.cs
@@ -1,7 +1,10 @@
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
 
 using BuildingBlocks.Infrastructure.Persistence;
 using BuildingBlocks.Infrastructure.Persistence.Entities.Auth;
@@ -34,7 +37,7 @@ public sealed class AuthenticatedEndpointTests(AppApiFactory factory) : IClassFi
                 deviceId
             });
 
-        Assert.Equal(HttpStatusCode.OK, signInResponse.StatusCode);
+        await AssertStatusCodeAsync("sign in", HttpStatusCode.OK, signInResponse);
 
         string signInJson = await signInResponse.Content.ReadAsStringAsync();
         using JsonDocument signInDocument = JsonDocument.Parse(signInJson);
@@ -49,7 +52,7 @@ public sealed class AuthenticatedEndpointTests(AppApiFactory factory) : IClassFi
 
         using HttpResponseMessage response = await client.SendAsync(request);
 
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        await AssertStatusCodeAsync("group tree nodes", HttpStatusCode.OK, response);
     }
 
     private async Task SeedUserAsync(string login, string password)
@@ -95,5 +98,100 @@ public sealed class AuthenticatedEndpointTests(AppApiFactory factory) : IClassFi
 
         throw new InvalidOperationException(
             $"None of the required string properties were present: {string.Join(", ", propertyNames)}.");
+    }
+
+    private static async Task AssertStatusCodeAsync(
+        string stepName,
+        HttpStatusCode expectedStatus,
+        HttpResponseMessage response)
+    {
+        if (response.StatusCode == expectedStatus)
+        {
+            return;
+        }
+
+        string responseBody = await response.Content.ReadAsStringAsync();
+        string redactedResponseBody = RedactSensitiveTokenValues(responseBody);
+
+        Assert.Fail(
+            $"""
+            Step: {stepName}
+            Expected status: {expectedStatus} ({(int)expectedStatus})
+            Actual status: {response.StatusCode} ({(int)response.StatusCode})
+            Response body:
+            {redactedResponseBody}
+            """);
+    }
+
+    private static string RedactSensitiveTokenValues(string responseBody)
+    {
+        if (string.IsNullOrEmpty(responseBody))
+        {
+            return responseBody;
+        }
+
+        try
+        {
+            JsonNode? responseJson = JsonNode.Parse(responseBody);
+
+            if (responseJson is not null)
+            {
+                RedactSensitiveTokenProperties(responseJson);
+
+                return responseJson.ToJsonString(new JsonSerializerOptions
+                {
+                    Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+                });
+            }
+        }
+        catch (JsonException)
+        {
+        }
+
+        return Regex.Replace(
+            responseBody,
+            @"(?i)(\b(?:accessToken|refreshToken)\b\s*[:=]\s*[""']?)[^""'\s,}\]]+([""']?)",
+            "$1<redacted>$2");
+    }
+
+    private static void RedactSensitiveTokenProperties(JsonNode node)
+    {
+        if (node is JsonObject jsonObject)
+        {
+            foreach (string propertyName in jsonObject.Select(property => property.Key).ToArray())
+            {
+                if (IsSensitiveTokenProperty(propertyName))
+                {
+                    jsonObject[propertyName] = "<redacted>";
+                    continue;
+                }
+
+                JsonNode? propertyValue = jsonObject[propertyName];
+
+                if (propertyValue is not null)
+                {
+                    RedactSensitiveTokenProperties(propertyValue);
+                }
+            }
+
+            return;
+        }
+
+        if (node is JsonArray jsonArray)
+        {
+            foreach (JsonNode? item in jsonArray)
+            {
+                if (item is not null)
+                {
+                    RedactSensitiveTokenProperties(item);
+                }
+            }
+        }
+    }
+
+    private static bool IsSensitiveTokenProperty(string propertyName)
+    {
+        return string.Equals(propertyName, "accessToken", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(propertyName, "refreshToken", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/tests/Integration/App.Api/AuthenticatedEndpointTests.cs
+++ b/tests/Integration/App.Api/AuthenticatedEndpointTests.cs
@@ -1,0 +1,99 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+using BuildingBlocks.Infrastructure.Persistence;
+using BuildingBlocks.Infrastructure.Persistence.Entities.Auth;
+
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace App.Api.IntegrationTests;
+
+public sealed class AuthenticatedEndpointTests(AppApiFactory factory) : IClassFixture<AppApiFactory>
+{
+    [Fact]
+    public async Task GroupTreeNodesAllowsAuthenticated()
+    {
+        using HttpClient client = factory.CreateClient();
+
+        string login = $"s2-06-user-{Guid.NewGuid():N}";
+        const string password = "S2-06-test-password!";
+        Guid deviceId = Guid.NewGuid();
+
+        await SeedUserAsync(login, password);
+
+        using HttpResponseMessage signInResponse = await client.PostAsJsonAsync(
+            "/api/auth/sign-in",
+            new
+            {
+                login,
+                password,
+                deviceId
+            });
+
+        Assert.Equal(HttpStatusCode.OK, signInResponse.StatusCode);
+
+        string signInJson = await signInResponse.Content.ReadAsStringAsync();
+        using JsonDocument signInDocument = JsonDocument.Parse(signInJson);
+
+        string accessToken = ReadRequiredStringProperty(
+            signInDocument.RootElement,
+            "accessToken",
+            "AccessToken");
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/api/group-tree/nodes");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+
+        using HttpResponseMessage response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    private async Task SeedUserAsync(string login, string password)
+    {
+        using IServiceScope scope = factory.Services.CreateScope();
+
+        var dbContext = scope.ServiceProvider.GetRequiredService<PlatformDbContext>();
+        var passwordHasher = scope.ServiceProvider.GetRequiredService<IPasswordHasher<AuthUser>>();
+
+        string normalizedLogin = login.Trim().ToUpperInvariant();
+
+        var user = new AuthUser
+        {
+            Id = Guid.NewGuid(),
+            Login = login,
+            NormalizedLogin = normalizedLogin,
+            DisplayName = "S2-06 Test User",
+            IsActive = true,
+            CreatedAtUtc = DateTimeOffset.UtcNow
+        };
+
+        user.PasswordHash = passwordHasher.HashPassword(user, password);
+
+        dbContext.AuthUsers.Add(user);
+        await dbContext.SaveChangesAsync();
+    }
+
+    private static string ReadRequiredStringProperty(JsonElement element, params string[] propertyNames)
+    {
+        foreach (string propertyName in propertyNames)
+        {
+            if (element.TryGetProperty(propertyName, out JsonElement property)
+                && property.ValueKind == JsonValueKind.String)
+            {
+                string? value = property.GetString();
+
+                if (!string.IsNullOrWhiteSpace(value))
+                {
+                    return value;
+                }
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"None of the required string properties were present: {string.Join(", ", propertyNames)}.");
+    }
+}


### PR DESCRIPTION
## Goal

Implement S2-06 authenticated API smoke coverage.

## Module

App.Api / Auth / GroupTree / Integration Tests.

## Changes

- Adds App.Api integration test for:
  - sign-in;
  - access token extraction;
  - authenticated `GET /api/group-tree/nodes`;
  - expected `200 OK` for authenticated request.
- Keeps existing anonymous rejection test for `GET /api/group-tree/nodes`.

## Contracts

No shared DTO changes.
No API route changes.
No response payload shape changes.
No enum/status changes.

## Migration

No database migration.

## Feature flag

No feature flag.

## Security

No secrets added.
No test token logged.
Bearer token is used only inside test scope.

## Tests

Local validation:
- `dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore`
- `git diff --check`
- `dotnet test tests\Integration\App.Api\App.Api.IntegrationTests.csproj`

Expected PR CI:
- restore;
- format;
- build;
- unit-tests;
- integration-tests.

## Rollback

Revert this PR.

## Production deploy

Not included.
Deploy workflow is not triggered by this PR.