### PR TITLE
S2-22 Post-Receipt Pipeline Bridge

### DIFF
--- a/src/App.Worker/App.Worker.csproj
+++ b/src/App.Worker/App.Worker.csproj
@@ -16,6 +16,9 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\BuildingBlocks\Infrastructure\BuildingBlocks.Infrastructure.csproj" />
+    <ProjectReference Include="..\Modules\GroupTree\Modules.GroupTree.csproj" />
+    <ProjectReference Include="..\Modules\Incidents\Modules.Incidents.csproj" />
+    <ProjectReference Include="..\Modules\VideoDuplicates\Modules.VideoDuplicates.csproj" />
     <ProjectReference Include="..\Modules\WorkerPipeline\Modules.WorkerPipeline.csproj" />
   </ItemGroup>
 </Project>

--- a/src/App.Worker/Program.cs
+++ b/src/App.Worker/Program.cs
@@ -1,3 +1,6 @@
+using Modules.GroupTree;
+using Modules.Incidents;
+using Modules.VideoDuplicates;
 using Modules.WorkerPipeline;
 
 using App.Worker.Queues;
@@ -26,7 +29,11 @@ var databaseOptions = new DatabaseOptions
 
 builder.Services.AddPlatformPersistence(databaseOptions);
 
+builder.Services.AddGroupTreeModule(builder.Configuration, builder.Environment);
+builder.Services.AddVideoDuplicatesModule(builder.Configuration);
+builder.Services.AddIncidentsModule(builder.Configuration);
 builder.Services.AddWorkerPipelineModule(builder.Configuration);
+builder.Services.AddHostedService<UploadReceiptPipelineBridgeHostedService>();
 builder.Services.AddHostedService<WorkerPipelineHostedService>();
 builder.Services.Configure<HostOptions>(options =>
 {

--- a/src/Modules/WorkerPipeline/Modules.WorkerPipeline.csproj
+++ b/src/Modules/WorkerPipeline/Modules.WorkerPipeline.csproj
@@ -12,5 +12,8 @@
   <ItemGroup>
     <ProjectReference Include="..\..\BuildingBlocks\Contracts\BuildingBlocks.Contracts.csproj" />
     <ProjectReference Include="..\..\BuildingBlocks\Infrastructure\BuildingBlocks.Infrastructure.csproj" />
+    <ProjectReference Include="..\GroupTree\Modules.GroupTree.csproj" />
+    <ProjectReference Include="..\Incidents\Modules.Incidents.csproj" />
+    <ProjectReference Include="..\VideoDuplicates\Modules.VideoDuplicates.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Modules/WorkerPipeline/UploadReceiptPipelineBridge.cs
+++ b/src/Modules/WorkerPipeline/UploadReceiptPipelineBridge.cs
@@ -1,0 +1,492 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+using BuildingBlocks.Contracts.Incidents;
+using BuildingBlocks.Contracts.VideoDuplicates;
+using BuildingBlocks.Contracts.WorkerPipeline;
+using BuildingBlocks.Infrastructure.Persistence;
+using BuildingBlocks.Infrastructure.Persistence.Entities.VideoUpload;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+using Modules.GroupTree;
+using Modules.Incidents;
+using Modules.VideoDuplicates;
+
+namespace Modules.WorkerPipeline;
+
+public interface IUploadReceiptPipelineBridgeService
+{
+    Task<UploadReceiptPipelineProcessResult> ProcessNextQueuedAsync(CancellationToken cancellationToken);
+
+    Task<UploadReceiptPipelineProcessResult> ProcessAsync(
+        Guid analysisJobId,
+        CancellationToken cancellationToken);
+}
+
+public sealed record UploadReceiptPipelineProcessResult(
+    bool Processed,
+    Guid? AnalysisJobId,
+    Guid? UploadReceiptId,
+    string? JobStatus,
+    Guid? VideoAssetId,
+    IReadOnlyCollection<Guid> DuplicateCandidateIds,
+    IReadOnlyCollection<Guid> IncidentIds,
+    string Message);
+
+public sealed class UploadReceiptPipelineBridgeService(
+    PlatformDbContext dbContext,
+    IVideoDuplicateRegistryService duplicateRegistryService,
+    IGroupTreeQueryService groupTreeQueryService,
+    IDuplicateIncidentRoutingService duplicateIncidentRoutingService,
+    IOptions<WorkerPipelineOptions> options,
+    ILogger<UploadReceiptPipelineBridgeService> logger) : IUploadReceiptPipelineBridgeService
+{
+    private const string DeepAnalysisCommandName = "video-upload.deep-analysis";
+    private const string AuditCategory = "video_upload_analysis_job";
+
+    private static readonly Regex SecretAssignmentPattern = new(
+        "(?i)(password|accessToken|refreshToken)\\s*[:=]\\s*([^,;\\s]+)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    public async Task<UploadReceiptPipelineProcessResult> ProcessNextQueuedAsync(CancellationToken cancellationToken)
+    {
+        if (!options.Value.DeepAnalysisEnabled)
+        {
+            return CreateNoOpResult("Upload receipt analysis bridge is disabled.");
+        }
+
+        var job = await dbContext.VideoUploadReceiptAnalysisJobs
+            .Where(item =>
+                item.Status == WorkerPipelineJobStatusesV1.Queued &&
+                item.CommandName == DeepAnalysisCommandName)
+            .OrderBy(item => item.EnqueuedAtUtc)
+            .ThenBy(item => item.Id)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (job is null)
+        {
+            return CreateNoOpResult("No queued upload receipt analysis job is available.");
+        }
+
+        return await ProcessTrackedAsync(job, cancellationToken);
+    }
+
+    public async Task<UploadReceiptPipelineProcessResult> ProcessAsync(
+        Guid analysisJobId,
+        CancellationToken cancellationToken)
+    {
+        if (analysisJobId == Guid.Empty)
+        {
+            throw new ArgumentException("AnalysisJobId is required.", nameof(analysisJobId));
+        }
+
+        if (!options.Value.DeepAnalysisEnabled)
+        {
+            return new UploadReceiptPipelineProcessResult(
+                Processed: false,
+                AnalysisJobId: analysisJobId,
+                UploadReceiptId: null,
+                JobStatus: null,
+                VideoAssetId: null,
+                DuplicateCandidateIds: Array.Empty<Guid>(),
+                IncidentIds: Array.Empty<Guid>(),
+                Message: "Upload receipt analysis bridge is disabled.");
+        }
+
+        var job = await dbContext.VideoUploadReceiptAnalysisJobs
+            .SingleOrDefaultAsync(item => item.Id == analysisJobId, cancellationToken);
+
+        if (job is null)
+        {
+            throw new InvalidOperationException("Upload receipt analysis job was not found.");
+        }
+
+        if (!string.Equals(job.CommandName, DeepAnalysisCommandName, StringComparison.Ordinal))
+        {
+            return new UploadReceiptPipelineProcessResult(
+                Processed: false,
+                AnalysisJobId: job.Id,
+                UploadReceiptId: job.UploadReceiptId,
+                JobStatus: job.Status,
+                VideoAssetId: null,
+                DuplicateCandidateIds: Array.Empty<Guid>(),
+                IncidentIds: Array.Empty<Guid>(),
+                Message: "Upload receipt analysis job command is not supported by the bridge.");
+        }
+
+        if (job.Status == WorkerPipelineJobStatusesV1.Completed)
+        {
+            logger.LogInformation(
+                "Upload receipt analysis job skipped because it is already completed. AnalysisJobId={AnalysisJobId} UploadReceiptId={UploadReceiptId}",
+                job.Id,
+                job.UploadReceiptId);
+
+            return new UploadReceiptPipelineProcessResult(
+                Processed: false,
+                AnalysisJobId: job.Id,
+                UploadReceiptId: job.UploadReceiptId,
+                JobStatus: job.Status,
+                VideoAssetId: null,
+                DuplicateCandidateIds: Array.Empty<Guid>(),
+                IncidentIds: Array.Empty<Guid>(),
+                Message: "Upload receipt analysis job is already completed.");
+        }
+
+        if (job.Status != WorkerPipelineJobStatusesV1.Queued)
+        {
+            return new UploadReceiptPipelineProcessResult(
+                Processed: false,
+                AnalysisJobId: job.Id,
+                UploadReceiptId: job.UploadReceiptId,
+                JobStatus: job.Status,
+                VideoAssetId: null,
+                DuplicateCandidateIds: Array.Empty<Guid>(),
+                IncidentIds: Array.Empty<Guid>(),
+                Message: "Upload receipt analysis job is not queued.");
+        }
+
+        return await ProcessTrackedAsync(job, cancellationToken);
+    }
+
+    private async Task<UploadReceiptPipelineProcessResult> ProcessTrackedAsync(
+        VideoUploadReceiptAnalysisJob job,
+        CancellationToken cancellationToken)
+    {
+        var receipt = await dbContext.VideoUploadReceipts
+            .SingleOrDefaultAsync(item => item.Id == job.UploadReceiptId, cancellationToken);
+
+        if (receipt is null)
+        {
+            return await FailJobAsync(
+                job,
+                receipt,
+                "Upload receipt was not found for analysis job processing.",
+                cancellationToken);
+        }
+
+        if (receipt.AnalysisJobStatus == WorkerPipelineJobStatusesV1.Completed)
+        {
+            if (job.Status != WorkerPipelineJobStatusesV1.Completed)
+            {
+                job.Status = WorkerPipelineJobStatusesV1.Completed;
+                AddAudit(
+                    receipt.Id,
+                    "upload_receipt_analysis_job_reconciled_completed",
+                    new
+                    {
+                        AnalysisJobId = job.Id,
+                        receipt.Id,
+                        job.Status
+                    });
+
+                await dbContext.SaveChangesAsync(cancellationToken);
+            }
+
+            logger.LogInformation(
+                "Upload receipt analysis job skipped because receipt is already completed. AnalysisJobId={AnalysisJobId} UploadReceiptId={UploadReceiptId}",
+                job.Id,
+                receipt.Id);
+
+            return new UploadReceiptPipelineProcessResult(
+                Processed: false,
+                AnalysisJobId: job.Id,
+                UploadReceiptId: receipt.Id,
+                JobStatus: job.Status,
+                VideoAssetId: null,
+                DuplicateCandidateIds: Array.Empty<Guid>(),
+                IncidentIds: Array.Empty<Guid>(),
+                Message: "Upload receipt analysis job is already completed.");
+        }
+
+        try
+        {
+            job.Status = WorkerPipelineJobStatusesV1.Running;
+
+            AddAudit(
+                receipt.Id,
+                "upload_receipt_analysis_job_started",
+                new
+                {
+                    AnalysisJobId = job.Id,
+                    receipt.Id,
+                    job.CommandName,
+                    receipt.ExternalVideoId,
+                    receipt.StorageKey
+                });
+
+            await dbContext.SaveChangesAsync(cancellationToken);
+
+            logger.LogInformation(
+                "Upload receipt analysis job started. AnalysisJobId={AnalysisJobId} UploadReceiptId={UploadReceiptId} CommandName={CommandName}",
+                job.Id,
+                receipt.Id,
+                job.CommandName);
+
+            var preUploadCheck = await dbContext.VideoUploadPreUploadChecks
+                .AsNoTracking()
+                .SingleOrDefaultAsync(item => item.Id == job.PreUploadCheckId, cancellationToken);
+
+            if (preUploadCheck is null)
+            {
+                throw new InvalidOperationException("PreUploadCheck was not found for upload receipt analysis job.");
+            }
+
+            var duplicateRegistration = await duplicateRegistryService.RegisterAssetAsync(
+                new DuplicateAssetRegistrationRequestDto(
+                    UploadReceiptId: receipt.Id,
+                    PreUploadCheckId: receipt.PreUploadCheckId,
+                    UserId: receipt.UserId,
+                    DeviceId: receipt.DeviceId,
+                    GroupNodeId: receipt.GroupNodeId,
+                    BusinessObjectKey: preUploadCheck.BusinessObjectKey,
+                    ExternalVideoId: receipt.ExternalVideoId,
+                    StorageKey: receipt.StorageKey,
+                    SizeBytes: receipt.SizeBytes,
+                    ByteSha256: receipt.ByteSha256,
+                    UploadedAtUtc: receipt.UploadedAtUtc),
+                cancellationToken);
+
+            var candidateIds = duplicateRegistration.Candidates
+                .Select(item => item.CandidateId)
+                .ToArray();
+
+            var incidentIds = await CreateDuplicateIncidentsAsync(
+                receipt,
+                duplicateRegistration.Candidates,
+                cancellationToken);
+
+            job.Status = WorkerPipelineJobStatusesV1.Completed;
+            receipt.AnalysisJobStatus = WorkerPipelineJobStatusesV1.Completed;
+
+            AddAudit(
+                receipt.Id,
+                "upload_receipt_analysis_job_completed",
+                new
+                {
+                    AnalysisJobId = job.Id,
+                    receipt.Id,
+                    duplicateRegistration.VideoAssetId,
+                    DuplicateCandidateIds = candidateIds,
+                    IncidentIds = incidentIds
+                });
+
+            await dbContext.SaveChangesAsync(cancellationToken);
+
+            logger.LogInformation(
+                "Upload receipt analysis job completed. AnalysisJobId={AnalysisJobId} UploadReceiptId={UploadReceiptId} VideoAssetId={VideoAssetId} DuplicateCandidateCount={DuplicateCandidateCount} IncidentCount={IncidentCount}",
+                job.Id,
+                receipt.Id,
+                duplicateRegistration.VideoAssetId,
+                candidateIds.Length,
+                incidentIds.Count);
+
+            return new UploadReceiptPipelineProcessResult(
+                Processed: true,
+                AnalysisJobId: job.Id,
+                UploadReceiptId: receipt.Id,
+                JobStatus: job.Status,
+                VideoAssetId: duplicateRegistration.VideoAssetId,
+                DuplicateCandidateIds: candidateIds,
+                IncidentIds: incidentIds,
+                Message: "Upload receipt analysis job completed.");
+        }
+        catch (Exception exception)
+        {
+            return await FailJobAsync(job, receipt, exception.Message, cancellationToken);
+        }
+    }
+
+    private async Task<IReadOnlyCollection<Guid>> CreateDuplicateIncidentsAsync(
+        VideoUploadReceipt receipt,
+        IReadOnlyCollection<DuplicateCandidateDto> candidates,
+        CancellationToken cancellationToken)
+    {
+        if (candidates.Count == 0 || receipt.GroupNodeId is null)
+        {
+            return Array.Empty<Guid>();
+        }
+
+        var routing = await groupTreeQueryService.PreviewRoutingAsync(
+            receipt.GroupNodeId.Value,
+            receipt.UserId,
+            cancellationToken);
+
+        if (routing is null || routing.ResolvedAdminUserIds.Count == 0)
+        {
+            logger.LogInformation(
+                "Upload receipt analysis job skipped incident routing because no admin routing was resolved. UploadReceiptId={UploadReceiptId} GroupNodeId={GroupNodeId}",
+                receipt.Id,
+                receipt.GroupNodeId);
+
+            return Array.Empty<Guid>();
+        }
+
+        var branchAdminUserIds = routing.EscalatedHigher
+            ? Array.Empty<Guid>()
+            : routing.ResolvedAdminUserIds.ToArray();
+
+        var higherAdminUserIds = routing.EscalatedHigher
+            ? routing.ResolvedAdminUserIds.ToArray()
+            : Array.Empty<Guid>();
+
+        var incidentIds = new List<Guid>(candidates.Count);
+        foreach (var candidate in candidates)
+        {
+            try
+            {
+                var incident = await duplicateIncidentRoutingService.CreateFromCandidateAsync(
+                    new DuplicateIncidentCreateRequestV1Dto(
+                        DuplicateCandidateId: candidate.CandidateId,
+                        SourceVideoAssetId: candidate.SourceVideoAssetId,
+                        MatchedVideoAssetId: candidate.MatchedVideoAssetId,
+                        UploaderUserId: receipt.UserId,
+                        UploaderGroupNodeId: receipt.GroupNodeId.Value,
+                        IsUploaderBranchAdmin: routing.EscalatedHigher,
+                        BranchAdminUserIds: branchAdminUserIds,
+                        HigherAdminUserIds: higherAdminUserIds,
+                        MatchKind: candidate.MatchKind,
+                        ReasonCode: candidate.ReasonCode,
+                        DetectedAtUtc: candidate.DetectedAtUtc),
+                    cancellationToken);
+
+                incidentIds.Add(incident.IncidentId);
+            }
+            catch (InvalidOperationException exception)
+                when (exception.Message.Contains("disabled", StringComparison.OrdinalIgnoreCase))
+            {
+                logger.LogInformation(
+                    "Upload receipt analysis job skipped duplicate incident routing because the incidents module is disabled. UploadReceiptId={UploadReceiptId}",
+                    receipt.Id);
+
+                return Array.Empty<Guid>();
+            }
+        }
+
+        return incidentIds;
+    }
+
+    private async Task<UploadReceiptPipelineProcessResult> FailJobAsync(
+        VideoUploadReceiptAnalysisJob job,
+        VideoUploadReceipt? receipt,
+        string error,
+        CancellationToken cancellationToken)
+    {
+        var sanitizedError = SanitizeMessage(error);
+
+        job.Status = WorkerPipelineJobStatusesV1.Failed;
+
+        if (receipt is not null)
+        {
+            receipt.AnalysisJobStatus = WorkerPipelineJobStatusesV1.Failed;
+
+            AddAudit(
+                receipt.Id,
+                "upload_receipt_analysis_job_failed",
+                new
+                {
+                    AnalysisJobId = job.Id,
+                    receipt.Id,
+                    Error = sanitizedError
+                });
+        }
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        logger.LogError(
+            "Upload receipt analysis job failed. AnalysisJobId={AnalysisJobId} UploadReceiptId={UploadReceiptId} Error={Error}",
+            job.Id,
+            job.UploadReceiptId,
+            sanitizedError);
+
+        return new UploadReceiptPipelineProcessResult(
+            Processed: true,
+            AnalysisJobId: job.Id,
+            UploadReceiptId: job.UploadReceiptId,
+            JobStatus: job.Status,
+            VideoAssetId: null,
+            DuplicateCandidateIds: Array.Empty<Guid>(),
+            IncidentIds: Array.Empty<Guid>(),
+            Message: sanitizedError);
+    }
+
+    private void AddAudit(Guid uploadReceiptId, string action, object payload)
+    {
+        dbContext.VideoUploadReceiptAuditRecords.Add(new VideoUploadReceiptAuditRecord
+        {
+            Id = Guid.NewGuid(),
+            UploadReceiptId = uploadReceiptId,
+            Category = AuditCategory,
+            Action = action,
+            CorrelationId = CreateCorrelationId(uploadReceiptId),
+            PayloadJson = JsonSerializer.Serialize(payload),
+            CreatedAtUtc = DateTimeOffset.UtcNow
+        });
+    }
+
+    private static UploadReceiptPipelineProcessResult CreateNoOpResult(string message)
+    {
+        return new UploadReceiptPipelineProcessResult(
+            Processed: false,
+            AnalysisJobId: null,
+            UploadReceiptId: null,
+            JobStatus: null,
+            VideoAssetId: null,
+            DuplicateCandidateIds: Array.Empty<Guid>(),
+            IncidentIds: Array.Empty<Guid>(),
+            Message: message);
+    }
+
+    private static string CreateCorrelationId(Guid uploadReceiptId)
+    {
+        return $"upload-receipt-{uploadReceiptId:N}";
+    }
+
+    private static string SanitizeMessage(string? message)
+    {
+        var value = string.IsNullOrWhiteSpace(message)
+            ? "Upload receipt analysis job failed."
+            : message.Trim();
+
+        return SecretAssignmentPattern.Replace(
+            value,
+            match => $"{match.Groups[1].Value}=[REDACTED]");
+    }
+}
+
+public sealed class UploadReceiptPipelineBridgeHostedService(
+    IServiceScopeFactory scopeFactory,
+    IOptions<WorkerPipelineOptions> options,
+    ILogger<UploadReceiptPipelineBridgeHostedService> logger) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        logger.LogInformation("Upload receipt pipeline bridge hosted service started.");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                using var scope = scopeFactory.CreateScope();
+                var service = scope.ServiceProvider.GetRequiredService<IUploadReceiptPipelineBridgeService>();
+                await service.ProcessNextQueuedAsync(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception exception)
+            {
+                logger.LogError(exception, "Upload receipt pipeline bridge hosted service iteration failed.");
+            }
+
+            await Task.Delay(
+                TimeSpan.FromMilliseconds(Math.Max(250, options.Value.PollingIntervalMilliseconds)),
+                stoppingToken);
+        }
+    }
+}

--- a/src/Modules/WorkerPipeline/WorkerPipelineModule.cs
+++ b/src/Modules/WorkerPipeline/WorkerPipelineModule.cs
@@ -453,6 +453,14 @@ public static class WorkerPipelineModule
             .ValidateOnStart();
 
         services.AddScoped<IWorkerPipelineService, WorkerPipelineService>();
+        services.AddScoped<IUploadReceiptPipelineBridgeService>(
+            serviceProvider => new UploadReceiptPipelineBridgeService(
+                serviceProvider.GetRequiredService<PlatformDbContext>(),
+                serviceProvider.GetRequiredService<Modules.VideoDuplicates.IVideoDuplicateRegistryService>(),
+                serviceProvider.GetRequiredService<Modules.GroupTree.IGroupTreeQueryService>(),
+                serviceProvider.GetRequiredService<Modules.Incidents.IDuplicateIncidentRoutingService>(),
+                serviceProvider.GetRequiredService<IOptions<WorkerPipelineOptions>>(),
+                serviceProvider.GetRequiredService<ILogger<UploadReceiptPipelineBridgeService>>()));
 
         return services;
     }

--- a/tests/Integration/VideoUpload/UploadReceiptServiceTests.cs
+++ b/tests/Integration/VideoUpload/UploadReceiptServiceTests.cs
@@ -53,10 +53,13 @@ public sealed class UploadReceiptServiceTests
 
         var precheckResult = await precheck.CheckAsync(CreatePrecheckRequest("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), CancellationToken.None);
         var receipt = await receipts.AcceptAsync(CreateReceiptRequest(precheckResult, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "idem-1"), CancellationToken.None);
+        var job = await db.VideoUploadReceiptAnalysisJobs.SingleAsync();
 
         Assert.Equal(VideoUploadReceiptStatuses.Accepted, receipt.Status);
         Assert.True(receipt.Accepted);
         Assert.False(receipt.WasAlreadyAccepted);
+        Assert.Equal("video-upload.deep-analysis", job.CommandName);
+        Assert.Equal("queued", job.Status);
         Assert.Equal(1, await db.VideoUploadReceipts.CountAsync());
         Assert.Equal(1, await db.VideoUploadReceiptAnalysisJobs.CountAsync());
         Assert.Equal(1, await db.VideoUploadReceiptAuditRecords.CountAsync());

--- a/tests/Integration/WorkerPipeline/UploadReceiptPipelineBridgeTests.cs
+++ b/tests/Integration/WorkerPipeline/UploadReceiptPipelineBridgeTests.cs
@@ -1,0 +1,321 @@
+using System.Globalization;
+
+using BuildingBlocks.Contracts.WorkerPipeline;
+using BuildingBlocks.Contracts.VideoUpload;
+using BuildingBlocks.Infrastructure.Persistence;
+using BuildingBlocks.Infrastructure.Persistence.Entities.GroupTree;
+using BuildingBlocks.Infrastructure.Persistence.Entities.VideoUpload;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+
+using Modules.GroupTree;
+using Modules.Incidents;
+using Modules.VideoDuplicates;
+using Modules.VideoUpload;
+using Modules.WorkerPipeline;
+
+namespace WorkerPipeline.IntegrationTests;
+
+public sealed class UploadReceiptPipelineBridgeTests
+{
+    private static readonly Guid UserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid DeviceId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private static readonly Guid BranchGroupNodeId = Guid.Parse("D4D74008-0ED5-4E46-B0A1-91E0628079C0");
+    private static readonly Guid RootGroupNodeId = Guid.Parse("C15EE7FE-7C9A-4B31-8B7E-C278B59F318C");
+    private static readonly Guid BranchAdminUserId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly DateTimeOffset FixedTime = DateTimeOffset.Parse(
+        "2026-04-18T00:00:00+00:00",
+        CultureInfo.InvariantCulture);
+
+    [Fact]
+    public async Task ProcessNextQueuedAsyncMarksQueuedJobAndReceiptCompletedAndRegistersAsset()
+    {
+        using var provider = CreateProvider();
+
+        var accepted = await AcceptReceiptAsync(
+            provider,
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "bridge-idem-1");
+
+        using var scope = provider.CreateScope();
+        var bridge = scope.ServiceProvider.GetRequiredService<IUploadReceiptPipelineBridgeService>();
+        var db = scope.ServiceProvider.GetRequiredService<PlatformDbContext>();
+
+        var processed = await bridge.ProcessNextQueuedAsync(CancellationToken.None);
+        var receipt = await db.VideoUploadReceipts.SingleAsync(item => item.Id == accepted.UploadReceiptId);
+        var job = await db.VideoUploadReceiptAnalysisJobs.SingleAsync(item => item.Id == accepted.AnalysisJobId);
+
+        Assert.True(processed.Processed);
+        Assert.Equal(accepted.AnalysisJobId, processed.AnalysisJobId);
+        Assert.Equal(accepted.UploadReceiptId, processed.UploadReceiptId);
+        Assert.Equal(WorkerPipelineJobStatusesV1.Completed, processed.JobStatus);
+        Assert.Equal(WorkerPipelineJobStatusesV1.Completed, receipt.AnalysisJobStatus);
+        Assert.Equal(WorkerPipelineJobStatusesV1.Completed, job.Status);
+        Assert.Equal(1, await db.VideoDuplicateAssets.CountAsync());
+        Assert.Equal(0, await db.VideoDuplicateCandidates.CountAsync());
+        Assert.Equal(0, await db.DuplicateIncidentRecords.CountAsync());
+        Assert.Equal(3, await db.VideoUploadReceiptAuditRecords.CountAsync());
+    }
+
+    [Fact]
+    public async Task ProcessNextQueuedAsyncCreatesDuplicateCandidateAndIncidentWhenRoutingSupported()
+    {
+        using var provider = CreateProvider();
+
+        await EnsureBranchAdminRoutingAsync(provider);
+
+        await ProcessAcceptedReceiptAsync(
+            provider,
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "bridge-idem-2");
+
+        var duplicate = await AcceptReceiptAsync(
+            provider,
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "bridge-idem-3");
+
+        using var scope = provider.CreateScope();
+        var bridge = scope.ServiceProvider.GetRequiredService<IUploadReceiptPipelineBridgeService>();
+        var db = scope.ServiceProvider.GetRequiredService<PlatformDbContext>();
+
+        var processed = await bridge.ProcessNextQueuedAsync(CancellationToken.None);
+        var candidate = await db.VideoDuplicateCandidates.SingleAsync();
+        var incident = await db.DuplicateIncidentRecords.SingleAsync();
+        var receipt = await db.VideoUploadReceipts.SingleAsync(item => item.Id == duplicate.UploadReceiptId);
+        var job = await db.VideoUploadReceiptAnalysisJobs.SingleAsync(item => item.Id == duplicate.AnalysisJobId);
+
+        Assert.True(processed.Processed);
+        Assert.Single(processed.DuplicateCandidateIds);
+        Assert.Single(processed.IncidentIds);
+        Assert.Equal(candidate.Id, processed.DuplicateCandidateIds.Single());
+        Assert.Equal(incident.Id, processed.IncidentIds.Single());
+        Assert.Equal(candidate.Id, incident.DuplicateCandidateId);
+        Assert.Equal(BranchAdminUserId, (await db.DuplicateIncidentAssignmentRecords.SingleAsync()).AssignedAdminUserId);
+        Assert.Equal(WorkerPipelineJobStatusesV1.Completed, receipt.AnalysisJobStatus);
+        Assert.Equal(WorkerPipelineJobStatusesV1.Completed, job.Status);
+    }
+
+    [Fact]
+    public async Task ProcessAsyncIsIdempotentForCompletedJob()
+    {
+        using var provider = CreateProvider();
+
+        await EnsureBranchAdminRoutingAsync(provider);
+
+        await ProcessAcceptedReceiptAsync(
+            provider,
+            "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+            "bridge-idem-4");
+
+        var duplicate = await AcceptReceiptAsync(
+            provider,
+            "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+            "bridge-idem-5");
+
+        using var scope = provider.CreateScope();
+        var bridge = scope.ServiceProvider.GetRequiredService<IUploadReceiptPipelineBridgeService>();
+        var db = scope.ServiceProvider.GetRequiredService<PlatformDbContext>();
+
+        var first = await bridge.ProcessNextQueuedAsync(CancellationToken.None);
+        var second = await bridge.ProcessAsync(duplicate.AnalysisJobId, CancellationToken.None);
+
+        Assert.True(first.Processed);
+        Assert.False(second.Processed);
+        Assert.Equal("completed", second.JobStatus);
+        Assert.Equal(2, await db.VideoDuplicateAssets.CountAsync());
+        Assert.Equal(1, await db.VideoDuplicateCandidates.CountAsync());
+        Assert.Equal(1, await db.DuplicateIncidentRecords.CountAsync());
+        Assert.Equal(1, await db.DuplicateIncidentAssignmentRecords.CountAsync());
+    }
+
+    private static async Task<AcceptedReceipt> ProcessAcceptedReceiptAsync(
+        ServiceProvider provider,
+        string hash,
+        string idempotencyKey)
+    {
+        var accepted = await AcceptReceiptAsync(provider, hash, idempotencyKey);
+
+        using var scope = provider.CreateScope();
+        var bridge = scope.ServiceProvider.GetRequiredService<IUploadReceiptPipelineBridgeService>();
+
+        var processed = await bridge.ProcessNextQueuedAsync(CancellationToken.None);
+
+        Assert.True(processed.Processed);
+
+        return accepted;
+    }
+
+    private static async Task<AcceptedReceipt> AcceptReceiptAsync(
+        ServiceProvider provider,
+        string hash,
+        string idempotencyKey)
+    {
+        using var scope = provider.CreateScope();
+        var receipts = scope.ServiceProvider.GetRequiredService<IUploadReceiptService>();
+        var db = scope.ServiceProvider.GetRequiredService<PlatformDbContext>();
+
+        var precheck = CreatePreUploadCheck(hash);
+        db.VideoUploadPreUploadChecks.Add(precheck);
+        await db.SaveChangesAsync(CancellationToken.None);
+
+        var receipt = await receipts.AcceptAsync(
+            CreateReceiptRequest(precheck, hash, idempotencyKey),
+            CancellationToken.None);
+
+        var job = await db.VideoUploadReceiptAnalysisJobs
+            .SingleAsync(item => item.UploadReceiptId == receipt.UploadReceiptId);
+
+        return new AcceptedReceipt(receipt.UploadReceiptId, job.Id);
+    }
+
+    private static async Task EnsureBranchAdminRoutingAsync(ServiceProvider provider)
+    {
+        using var scope = provider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<PlatformDbContext>();
+
+        await db.Database.EnsureCreatedAsync();
+
+        if (!await db.GroupNodes.AnyAsync(item => item.Id == RootGroupNodeId))
+        {
+            db.GroupNodes.Add(new GroupNode
+            {
+                Id = RootGroupNodeId,
+                ParentNodeId = null,
+                Code = "root",
+                Name = "Root",
+                Depth = 0,
+                IsActive = true
+            });
+        }
+
+        if (!await db.GroupNodes.AnyAsync(item => item.Id == BranchGroupNodeId))
+        {
+            db.GroupNodes.Add(new GroupNode
+            {
+                Id = BranchGroupNodeId,
+                ParentNodeId = RootGroupNodeId,
+                Code = "branch-a",
+                Name = "Branch A",
+                Depth = 1,
+                IsActive = true
+            });
+        }
+
+        if (!await db.GroupAdminAssignments.AnyAsync(
+                item => item.GroupNodeId == BranchGroupNodeId && item.UserId == BranchAdminUserId))
+        {
+            db.GroupAdminAssignments.Add(new GroupAdminAssignment
+            {
+                GroupNodeId = BranchGroupNodeId,
+                UserId = BranchAdminUserId,
+                AssignedAtUtc = FixedTime
+            });
+        }
+
+        await db.SaveChangesAsync();
+    }
+
+    private static ServiceProvider CreateProvider()
+    {
+        var settings = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Modules:VideoUpload:PreUploadCheckEnabled"] = "true",
+            ["Modules:VideoUpload:UploadReceiptEnabled"] = "true",
+            ["Modules:VideoUpload:MaxFastAllowSizeBytes"] = "5368709120",
+            ["Modules:VideoUpload:SiteProvider"] = "Stub",
+            ["Modules:VideoUpload:ExternalVideoIdPrefix"] = "site-video",
+            ["Modules:VideoUpload:StorageKeyPrefix"] = "videos",
+            ["Modules:VideoDuplicates:RegistryEnabled"] = "true",
+            ["Modules:VideoDuplicates:ExactFingerprintEnabled"] = "true",
+            ["Modules:Incidents:DuplicateIncidentRoutingEnabled"] = "true",
+            ["Modules:WorkerPipeline:DeepAnalysisEnabled"] = "true",
+            ["Modules:WorkerPipeline:MaxAttempts"] = "3",
+            ["Modules:WorkerPipeline:PollingIntervalMilliseconds"] = "1000",
+            ["Modules:WorkerPipeline:RetryDelaySeconds"] = "10"
+        };
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(settings)
+            .Build();
+
+        var databaseName = Guid.NewGuid().ToString("N");
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddDbContext<PlatformDbContext>(
+            options => options.UseInMemoryDatabase(databaseName));
+        services.AddGroupTreeModule(configuration, new TestHostEnvironment());
+        services.AddVideoUploadModule(configuration);
+        services.AddVideoDuplicatesModule(configuration);
+        services.AddIncidentsModule(configuration);
+        services.AddWorkerPipelineModule(configuration);
+
+        return services.BuildServiceProvider(
+            new ServiceProviderOptions
+            {
+                ValidateOnBuild = true,
+                ValidateScopes = true
+            });
+    }
+
+    private static VideoUploadPreUploadCheck CreatePreUploadCheck(string hash)
+    {
+        var preUploadCheckId = Guid.NewGuid();
+        var externalVideoId = $"site-video-{preUploadCheckId:N}";
+
+        return new VideoUploadPreUploadCheck
+        {
+            Id = preUploadCheckId,
+            UserId = UserId,
+            DeviceId = DeviceId,
+            GroupNodeId = BranchGroupNodeId,
+            BusinessObjectKey = "demo-business-object",
+            FileName = "demo.mp4",
+            SizeBytes = 12345,
+            ByteSha256 = hash,
+            ContentType = "video/mp4",
+            CapturedAtUtc = FixedTime,
+            Decision = PreUploadCheckDecisions.Allow,
+            CanUploadToSite = true,
+            ReasonCode = "fast_path_clear",
+            ExistingPreUploadCheckId = null,
+            RequiredNextSteps = "UPLOAD_TO_SITE_DIRECT,SEND_UPLOAD_RECEIPT",
+            SiteProvider = "Stub",
+            ExternalVideoId = externalVideoId,
+            StorageKey = $"videos/{externalVideoId}.mp4",
+            CheckedAtUtc = FixedTime
+        };
+    }
+
+    private static VideoUploadReceiptRequestDto CreateReceiptRequest(
+        VideoUploadPreUploadCheck precheck,
+        string hash,
+        string idempotencyKey)
+    {
+        return new VideoUploadReceiptRequestDto(
+            PreUploadCheckId: precheck.Id,
+            UserId: UserId,
+            DeviceId: DeviceId,
+            GroupNodeId: BranchGroupNodeId,
+            ExternalVideoId: precheck.ExternalVideoId!,
+            StorageKey: precheck.StorageKey!,
+            SiteStatus: "uploaded",
+            SizeBytes: 12345,
+            ByteSha256: hash,
+            IdempotencyKey: idempotencyKey,
+            UploadedAtUtc: FixedTime);
+    }
+
+    private sealed record AcceptedReceipt(Guid UploadReceiptId, Guid AnalysisJobId);
+
+    private sealed class TestHostEnvironment : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = Environments.Production;
+        public string ApplicationName { get; set; } = "WorkerPipeline.IntegrationTests";
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+    }
+}

--- a/tests/Integration/WorkerPipeline/WorkerPipeline.IntegrationTests.csproj
+++ b/tests/Integration/WorkerPipeline/WorkerPipeline.IntegrationTests.csproj
@@ -11,6 +11,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Modules\GroupTree\Modules.GroupTree.csproj" />
+    <ProjectReference Include="..\..\..\src\Modules\Incidents\Modules.Incidents.csproj" />
+    <ProjectReference Include="..\..\..\src\Modules\VideoDuplicates\Modules.VideoDuplicates.csproj" />
+    <ProjectReference Include="..\..\..\src\Modules\VideoUpload\Modules.VideoUpload.csproj" />
     <ProjectReference Include="..\..\..\src\Modules\WorkerPipeline\Modules.WorkerPipeline.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
﻿## Goal

Implement S2-22 Post-Receipt Pipeline Bridge.

## Module / Scope

App.Worker / WorkerPipeline / VideoUpload / VideoDuplicates / Incidents.

## Changes

- Adds `UploadReceiptPipelineBridgeService`.
- Adds `UploadReceiptPipelineBridgeHostedService`.
- Processes queued `VideoUploadReceiptAnalysisJob` records for `video-upload.deep-analysis`.
- Marks receipt/job analysis state through the exact-hash bridge.
- Registers exact duplicate assets using `ByteSha256 + SizeBytes`.
- Uses existing VideoDuplicates idempotency by `UploadReceiptId`.
- Creates duplicate incident through existing GroupTree routing + Incidents service when duplicate candidates exist and routing supports it.
- Wires App.Worker to the needed modules:
  - GroupTree;
  - VideoDuplicates;
  - Incidents;
  - WorkerPipeline bridge hosted service.
- Adds integration coverage for:
  - queued job foundation;
  - job completion;
  - duplicate registry exact-hash update;
  - duplicate candidate / incident path;
  - idempotent processing.

## Contracts

No shared DTO changes.
No public API route changes.
No response payload shape changes.
No enum/status changes.

## Migration

No database migration.

Existing tables are sufficient for this S2-22 bridge.

## Feature flag

No new feature flag.

Reason: existing `Modules:WorkerPipeline:DeepAnalysisEnabled` gates runtime behavior for this exact-hash bridge, so a second flag would duplicate the same kill switch.

## Security

- No password logging.
- No accessToken/refreshToken logging.
- No hidden auth bypass.
- No video bytes through App.Api as a required proxy.
- No secrets added.
- FraudSignals intentionally not connected in this increment because current UploadReceipt flow does not produce safe behavioral/window observations.

## Tests

Local validation:
- `dotnet restore AnalyticsAutomation-Core.sln -nologo`
- `dotnet build AnalyticsAutomation-Core.sln --no-restore -nologo -v minimal`
- `dotnet test tests\Integration\App.Api\App.Api.IntegrationTests.csproj -nologo -v minimal`
- `dotnet test tests\Integration\WorkerPipeline\WorkerPipeline.IntegrationTests.csproj -nologo -v minimal`
- `dotnet test tests\Integration\VideoUpload\VideoUpload.IntegrationTests.csproj -nologo -v minimal`
- `dotnet test tests\Integration\VideoDuplicates\VideoDuplicates.IntegrationTests.csproj -nologo -v minimal`
- `dotnet test tests\Integration\Incidents\Incidents.IntegrationTests.csproj -nologo -v minimal`
- `dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore`
- `git diff --check`

Expected PR CI:
- restore;
- format;
- build;
- unit-tests;
- integration-tests.

## Rollback

Revert this PR.

If deployed and runtime behavior must be disabled before revert, use the existing `Modules:WorkerPipeline:DeepAnalysisEnabled` kill switch.

## Production deploy

Not triggered by this PR.
Deploy workflow is not run from this PR.
