### PR TITLE
S2-26 Late Sync Upload Receipt Intake

### DIFF
--- a/src/BuildingBlocks/Contracts/VideoUpload/UploadReceiptSyncDtosV1.cs
+++ b/src/BuildingBlocks/Contracts/VideoUpload/UploadReceiptSyncDtosV1.cs
@@ -1,0 +1,17 @@
+namespace BuildingBlocks.Contracts.VideoUpload;
+
+public sealed record VideoUploadReceiptSyncRequestDto(
+    Guid UserId,
+    Guid? DeviceId,
+    Guid? GroupNodeId,
+    string BusinessObjectKey,
+    string FileName,
+    string? ContentType,
+    string ExternalVideoId,
+    string StorageKey,
+    string SiteStatus,
+    long SizeBytes,
+    string ByteSha256,
+    string IdempotencyKey,
+    DateTimeOffset CapturedAtUtc,
+    DateTimeOffset UploadedAtUtc);

--- a/src/BuildingBlocks/Infrastructure/Observability/AuditObservabilityFoundation.cs
+++ b/src/BuildingBlocks/Infrastructure/Observability/AuditObservabilityFoundation.cs
@@ -13,12 +13,14 @@ public static class AuditCategories
     public const string Authentication = "authentication";
     public const string Devices = "devices";
     public const string GroupTree = "group_tree";
+    public const string VideoUpload = "video_upload";
 
     public static readonly IReadOnlyCollection<string> All =
     [
         Authentication,
         Devices,
-        GroupTree
+        GroupTree,
+        VideoUpload
     ];
 }
 

--- a/src/Modules/VideoUpload/UploadReceiptSyncService.cs
+++ b/src/Modules/VideoUpload/UploadReceiptSyncService.cs
@@ -1,0 +1,709 @@
+using System.Security.Claims;
+using System.Text.Json;
+
+using BuildingBlocks.Contracts.VideoUpload;
+using BuildingBlocks.Infrastructure.Observability;
+using BuildingBlocks.Infrastructure.Persistence;
+using BuildingBlocks.Infrastructure.Persistence.Entities.VideoUpload;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Modules.VideoUpload;
+
+public interface IUploadReceiptSyncService
+{
+    Task<VideoUploadReceiptResponseDto> AcceptAsync(
+        VideoUploadReceiptSyncRequestDto request,
+        AuthenticatedVideoUploadScope authenticatedScope,
+        CancellationToken cancellationToken);
+}
+
+public sealed record AuthenticatedVideoUploadScope(
+    Guid UserId,
+    Guid? DeviceId,
+    Guid? GroupNodeId)
+{
+    private const string DeviceIdClaimType = "device_id";
+    private const string GroupNodeIdClaimType = "current_group_node_id";
+
+    public static AuthenticatedVideoUploadScope FromClaimsPrincipal(ClaimsPrincipal principal)
+    {
+        ArgumentNullException.ThrowIfNull(principal);
+
+        var userId = ParseRequiredGuidClaim(principal, ClaimTypes.NameIdentifier, "Authenticated user id claim is required.");
+        var deviceId = ParseOptionalGuidClaim(principal, DeviceIdClaimType);
+        var groupNodeId = ParseOptionalGuidClaim(principal, GroupNodeIdClaimType);
+
+        return new AuthenticatedVideoUploadScope(userId, deviceId, groupNodeId);
+    }
+
+    private static Guid ParseRequiredGuidClaim(
+        ClaimsPrincipal principal,
+        string claimType,
+        string errorMessage)
+    {
+        var value = principal.FindFirstValue(claimType);
+        if (!Guid.TryParse(value, out var parsed) || parsed == Guid.Empty)
+        {
+            throw new InvalidOperationException(errorMessage);
+        }
+
+        return parsed;
+    }
+
+    private static Guid? ParseOptionalGuidClaim(ClaimsPrincipal principal, string claimType)
+    {
+        var value = principal.FindFirstValue(claimType);
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        if (!Guid.TryParse(value, out var parsed) || parsed == Guid.Empty)
+        {
+            throw new InvalidOperationException($"Authenticated {claimType} claim is invalid.");
+        }
+
+        return parsed;
+    }
+}
+
+internal sealed record UploadReceiptPersistRequest(
+    Guid PreUploadCheckId,
+    Guid UserId,
+    Guid? DeviceId,
+    Guid? GroupNodeId,
+    string ExternalVideoId,
+    string StorageKey,
+    string SiteStatus,
+    long SizeBytes,
+    string ByteSha256,
+    string IdempotencyKey,
+    DateTimeOffset UploadedAtUtc,
+    string AuditAction,
+    string AcceptedMessage);
+
+internal sealed record UploadReceiptPersistResult(
+    VideoUploadReceiptResponseDto Response,
+    Guid UploadReceiptId,
+    Guid PreUploadCheckId,
+    Guid AnalysisJobId);
+
+internal static class VideoUploadRequestSupport
+{
+    private const string DeepAnalysisCommandName = "video-upload.deep-analysis";
+    private const string ReceiptAuditCategory = "video_upload";
+    private const string RequestParamName = "request";
+
+    public static void ValidatePreUploadRequest(
+        Guid userId,
+        string businessObjectKey,
+        string fileName,
+        long sizeBytes,
+        string byteSha256,
+        VideoUploadOptions options)
+    {
+        if (userId == Guid.Empty)
+        {
+            throw new ArgumentException("UserId is required.", RequestParamName);
+        }
+
+        if (string.IsNullOrWhiteSpace(businessObjectKey))
+        {
+            throw new ArgumentException("BusinessObjectKey is required.", RequestParamName);
+        }
+
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            throw new ArgumentException("FileName is required.", RequestParamName);
+        }
+
+        ValidateSizeBytes(sizeBytes, options.MaxFastAllowSizeBytes, RequestParamName);
+        ValidateByteSha256(byteSha256, RequestParamName);
+    }
+
+    public static void ValidateUploadReceiptRequest(VideoUploadReceiptRequestDto request)
+    {
+        if (request.PreUploadCheckId == Guid.Empty)
+        {
+            throw new ArgumentException("PreUploadCheckId is required.", nameof(request));
+        }
+
+        ValidateUploadReceiptFields(
+            request.UserId,
+            request.ExternalVideoId,
+            request.StorageKey,
+            request.SiteStatus,
+            request.SizeBytes,
+            request.ByteSha256,
+            request.IdempotencyKey);
+    }
+
+    public static void ValidateUploadReceiptSyncRequest(
+        VideoUploadReceiptSyncRequestDto request,
+        VideoUploadOptions options)
+    {
+        ValidatePreUploadRequest(
+            request.UserId,
+            request.BusinessObjectKey,
+            request.FileName,
+            request.SizeBytes,
+            request.ByteSha256,
+            options);
+
+        ValidateUploadReceiptFields(
+            request.UserId,
+            request.ExternalVideoId,
+            request.StorageKey,
+            request.SiteStatus,
+            request.SizeBytes,
+            request.ByteSha256,
+            request.IdempotencyKey);
+    }
+
+    public static string NormalizeHash(string value)
+    {
+        return value.Trim().ToLowerInvariant();
+    }
+
+    public static string NormalizeRequired(string value)
+    {
+        return value.Trim();
+    }
+
+    public static string? NormalizeOptional(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value)
+            ? null
+            : value.Trim();
+    }
+
+    public static VideoUploadReceiptResponseDto CreateAlreadyAcceptedResponse(
+        VideoUploadReceipt existing,
+        string message)
+    {
+        return new VideoUploadReceiptResponseDto(
+            UploadReceiptId: existing.Id,
+            PreUploadCheckId: existing.PreUploadCheckId,
+            Status: VideoUploadReceiptStatuses.AlreadyAccepted,
+            Accepted: true,
+            WasAlreadyAccepted: true,
+            Message: message,
+            AnalysisJobStatus: existing.AnalysisJobStatus,
+            ReceivedAtUtc: existing.ReceivedAtUtc);
+    }
+
+    public static async Task<UploadReceiptPersistResult> PersistAcceptedReceiptAsync(
+        PlatformDbContext dbContext,
+        UploadReceiptPersistRequest request,
+        VideoUploadPreUploadCheck? preUploadCheckToCreate,
+        CancellationToken cancellationToken)
+    {
+        if (preUploadCheckToCreate is not null && preUploadCheckToCreate.Id != request.PreUploadCheckId)
+        {
+            throw new InvalidOperationException("Upload receipt persistence pre-upload check did not match the requested id.");
+        }
+
+        var receivedAtUtc = DateTimeOffset.UtcNow;
+        var receiptId = Guid.NewGuid();
+        var analysisJobId = Guid.NewGuid();
+        var correlationId = $"upload-receipt-{receiptId:N}";
+
+        var receipt = new VideoUploadReceipt
+        {
+            Id = receiptId,
+            PreUploadCheckId = request.PreUploadCheckId,
+            UserId = request.UserId,
+            DeviceId = request.DeviceId,
+            GroupNodeId = request.GroupNodeId,
+            ExternalVideoId = request.ExternalVideoId,
+            StorageKey = request.StorageKey,
+            SiteStatus = request.SiteStatus,
+            SizeBytes = request.SizeBytes,
+            ByteSha256 = request.ByteSha256,
+            IdempotencyKey = request.IdempotencyKey,
+            ReceiptStatus = VideoUploadReceiptStatuses.Accepted,
+            AnalysisJobStatus = "queued",
+            UploadedAtUtc = request.UploadedAtUtc,
+            ReceivedAtUtc = receivedAtUtc
+        };
+
+        var job = new VideoUploadReceiptAnalysisJob
+        {
+            Id = analysisJobId,
+            UploadReceiptId = receiptId,
+            PreUploadCheckId = request.PreUploadCheckId,
+            CommandName = DeepAnalysisCommandName,
+            Status = "queued",
+            EnqueuedAtUtc = receivedAtUtc
+        };
+
+        var auditPayload = JsonSerializer.Serialize(new
+        {
+            receipt.Id,
+            receipt.PreUploadCheckId,
+            receipt.UserId,
+            receipt.DeviceId,
+            receipt.GroupNodeId,
+            receipt.ExternalVideoId,
+            receipt.StorageKey,
+            receipt.ByteSha256,
+            receipt.SizeBytes
+        });
+
+        var audit = new VideoUploadReceiptAuditRecord
+        {
+            Id = Guid.NewGuid(),
+            UploadReceiptId = receiptId,
+            Category = ReceiptAuditCategory,
+            Action = request.AuditAction,
+            CorrelationId = correlationId,
+            PayloadJson = auditPayload,
+            CreatedAtUtc = receivedAtUtc
+        };
+
+        if (preUploadCheckToCreate is not null)
+        {
+            dbContext.VideoUploadPreUploadChecks.Add(preUploadCheckToCreate);
+        }
+
+        dbContext.VideoUploadReceipts.Add(receipt);
+        dbContext.VideoUploadReceiptAnalysisJobs.Add(job);
+        dbContext.VideoUploadReceiptAuditRecords.Add(audit);
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return new UploadReceiptPersistResult(
+            Response: new VideoUploadReceiptResponseDto(
+                UploadReceiptId: receipt.Id,
+                PreUploadCheckId: receipt.PreUploadCheckId,
+                Status: VideoUploadReceiptStatuses.Accepted,
+                Accepted: true,
+                WasAlreadyAccepted: false,
+                Message: request.AcceptedMessage,
+                AnalysisJobStatus: receipt.AnalysisJobStatus,
+                ReceivedAtUtc: receipt.ReceivedAtUtc),
+            UploadReceiptId: receipt.Id,
+            PreUploadCheckId: receipt.PreUploadCheckId,
+            AnalysisJobId: analysisJobId);
+    }
+
+    private static void ValidateUploadReceiptFields(
+        Guid userId,
+        string externalVideoId,
+        string storageKey,
+        string siteStatus,
+        long sizeBytes,
+        string byteSha256,
+        string idempotencyKey)
+    {
+        if (userId == Guid.Empty)
+        {
+            throw new ArgumentException("UserId is required.", RequestParamName);
+        }
+
+        if (string.IsNullOrWhiteSpace(externalVideoId))
+        {
+            throw new ArgumentException("ExternalVideoId is required.", RequestParamName);
+        }
+
+        if (string.IsNullOrWhiteSpace(storageKey))
+        {
+            throw new ArgumentException("StorageKey is required.", RequestParamName);
+        }
+
+        if (string.IsNullOrWhiteSpace(siteStatus))
+        {
+            throw new ArgumentException("SiteStatus is required.", RequestParamName);
+        }
+
+        ValidateSizeBytes(sizeBytes, long.MaxValue, RequestParamName);
+        ValidateByteSha256(byteSha256, RequestParamName);
+
+        if (string.IsNullOrWhiteSpace(idempotencyKey))
+        {
+            throw new ArgumentException("IdempotencyKey is required.", RequestParamName);
+        }
+    }
+
+    private static void ValidateSizeBytes(long sizeBytes, long maxSizeBytes, string paramName)
+    {
+        if (sizeBytes <= 0)
+        {
+            throw new ArgumentException("SizeBytes must be positive.", paramName);
+        }
+
+        if (sizeBytes > maxSizeBytes)
+        {
+            throw new ArgumentException("SizeBytes exceeds the configured PreUploadCheck limit.", paramName);
+        }
+    }
+
+    private static void ValidateByteSha256(string byteSha256, string paramName)
+    {
+        if (string.IsNullOrWhiteSpace(byteSha256))
+        {
+            throw new ArgumentException("ByteSha256 is required.", paramName);
+        }
+
+        var normalizedHash = byteSha256.Trim();
+        if (normalizedHash.Length != 64 || !normalizedHash.All(Uri.IsHexDigit))
+        {
+            throw new ArgumentException("ByteSha256 must be a 64-character hexadecimal SHA-256 value.", paramName);
+        }
+    }
+}
+
+public sealed class UploadReceiptSyncService(
+    PlatformDbContext dbContext,
+    IOptions<VideoUploadOptions> options,
+    IAuditService auditService,
+    ILogger<UploadReceiptSyncService> logger) : IUploadReceiptSyncService
+{
+    private const string SyncReasonCode = "late_sync_reconciled";
+    private const string SyncReasonCodeNeedsReview = "late_sync_context_incomplete";
+
+    public async Task<VideoUploadReceiptResponseDto> AcceptAsync(
+        VideoUploadReceiptSyncRequestDto request,
+        AuthenticatedVideoUploadScope authenticatedScope,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var value = options.Value;
+            if (!value.UploadReceiptSyncEnabled)
+            {
+                throw new InvalidOperationException("UploadReceiptSync is disabled.");
+            }
+
+            VideoUploadRequestSupport.ValidateUploadReceiptSyncRequest(request, value);
+            ValidateScope(request, authenticatedScope);
+
+            var normalizedHash = VideoUploadRequestSupport.NormalizeHash(request.ByteSha256);
+            var normalizedBusinessObjectKey = VideoUploadRequestSupport.NormalizeRequired(request.BusinessObjectKey);
+            var normalizedFileName = VideoUploadRequestSupport.NormalizeRequired(request.FileName);
+            var normalizedContentType = VideoUploadRequestSupport.NormalizeOptional(request.ContentType);
+            var normalizedExternalVideoId = VideoUploadRequestSupport.NormalizeRequired(request.ExternalVideoId);
+            var normalizedStorageKey = VideoUploadRequestSupport.NormalizeRequired(request.StorageKey);
+            var normalizedSiteStatus = VideoUploadRequestSupport.NormalizeRequired(request.SiteStatus).ToLowerInvariant();
+            var normalizedIdempotencyKey = VideoUploadRequestSupport.NormalizeRequired(request.IdempotencyKey);
+
+            var existingByIdempotency = await dbContext.VideoUploadReceipts
+                .AsNoTracking()
+                .SingleOrDefaultAsync(
+                    item => item.IdempotencyKey == normalizedIdempotencyKey,
+                    cancellationToken);
+
+            if (existingByIdempotency is not null)
+            {
+                logger.LogInformation(
+                    "UploadReceiptSync idempotency hit. UploadReceiptId={UploadReceiptId} PreUploadCheckId={PreUploadCheckId}",
+                    existingByIdempotency.Id,
+                    existingByIdempotency.PreUploadCheckId);
+
+                var response = VideoUploadRequestSupport.CreateAlreadyAcceptedResponse(
+                    existingByIdempotency,
+                    "Upload receipt sync already accepted.");
+
+                await TryWriteAuditAsync(
+                    "upload_receipt_sync_already_accepted",
+                    request,
+                    authenticatedScope,
+                    existingByIdempotency.Id,
+                    new
+                    {
+                        existingByIdempotency.Id,
+                        existingByIdempotency.PreUploadCheckId,
+                        existingByIdempotency.IdempotencyKey,
+                        MatchKind = "idempotency_key"
+                    },
+                    cancellationToken);
+
+                return response;
+            }
+
+            var existingByNaturalKey = await dbContext.VideoUploadReceipts
+                .AsNoTracking()
+                .Where(item =>
+                    item.UserId == authenticatedScope.UserId &&
+                    item.DeviceId == request.DeviceId &&
+                    item.GroupNodeId == request.GroupNodeId &&
+                    item.ExternalVideoId == normalizedExternalVideoId &&
+                    item.StorageKey == normalizedStorageKey &&
+                    item.ByteSha256 == normalizedHash &&
+                    item.SizeBytes == request.SizeBytes)
+                .OrderBy(item => item.ReceivedAtUtc)
+                .ThenBy(item => item.Id)
+                .FirstOrDefaultAsync(cancellationToken);
+
+            if (existingByNaturalKey is not null)
+            {
+                logger.LogInformation(
+                    "UploadReceiptSync natural-key idempotency hit. UploadReceiptId={UploadReceiptId} PreUploadCheckId={PreUploadCheckId}",
+                    existingByNaturalKey.Id,
+                    existingByNaturalKey.PreUploadCheckId);
+
+                var response = VideoUploadRequestSupport.CreateAlreadyAcceptedResponse(
+                    existingByNaturalKey,
+                    "Upload receipt sync already accepted.");
+
+                await TryWriteAuditAsync(
+                    "upload_receipt_sync_already_accepted",
+                    request,
+                    authenticatedScope,
+                    existingByNaturalKey.Id,
+                    new
+                    {
+                        existingByNaturalKey.Id,
+                        existingByNaturalKey.PreUploadCheckId,
+                        existingByNaturalKey.ExternalVideoId,
+                        existingByNaturalKey.StorageKey,
+                        MatchKind = "natural_receipt_key"
+                    },
+                    cancellationToken);
+
+                return response;
+            }
+
+            var existingPreUploadCheck = await dbContext.VideoUploadPreUploadChecks
+                .AsNoTracking()
+                .Where(item =>
+                    item.CanUploadToSite &&
+                    item.UserId == authenticatedScope.UserId &&
+                    item.DeviceId == request.DeviceId &&
+                    item.GroupNodeId == request.GroupNodeId &&
+                    item.BusinessObjectKey == normalizedBusinessObjectKey &&
+                    item.ExternalVideoId == normalizedExternalVideoId &&
+                    item.StorageKey == normalizedStorageKey &&
+                    item.ByteSha256 == normalizedHash &&
+                    item.SizeBytes == request.SizeBytes)
+                .OrderBy(item => item.CheckedAtUtc)
+                .ThenBy(item => item.Id)
+                .FirstOrDefaultAsync(cancellationToken);
+
+            var preUploadCheckToCreate = existingPreUploadCheck is null
+                ? await CreateLateSyncPreUploadCheckAsync(
+                    request,
+                    authenticatedScope,
+                    normalizedBusinessObjectKey,
+                    normalizedFileName,
+                    normalizedContentType,
+                    normalizedExternalVideoId,
+                    normalizedStorageKey,
+                    normalizedHash,
+                    value.SiteProvider,
+                    cancellationToken)
+                : null;
+
+            var persisted = await VideoUploadRequestSupport.PersistAcceptedReceiptAsync(
+                dbContext,
+                new UploadReceiptPersistRequest(
+                    PreUploadCheckId: existingPreUploadCheck?.Id ?? preUploadCheckToCreate!.Id,
+                    UserId: authenticatedScope.UserId,
+                    DeviceId: request.DeviceId,
+                    GroupNodeId: request.GroupNodeId,
+                    ExternalVideoId: normalizedExternalVideoId,
+                    StorageKey: normalizedStorageKey,
+                    SiteStatus: normalizedSiteStatus,
+                    SizeBytes: request.SizeBytes,
+                    ByteSha256: normalizedHash,
+                    IdempotencyKey: normalizedIdempotencyKey,
+                    UploadedAtUtc: request.UploadedAtUtc,
+                    AuditAction: "upload_receipt_sync_accepted",
+                    AcceptedMessage: "Upload receipt sync accepted and analysis job queued."),
+                preUploadCheckToCreate,
+                cancellationToken);
+
+            logger.LogInformation(
+                "UploadReceiptSync accepted. UploadReceiptId={UploadReceiptId} PreUploadCheckId={PreUploadCheckId} ExternalVideoId={ExternalVideoId}",
+                persisted.UploadReceiptId,
+                persisted.PreUploadCheckId,
+                normalizedExternalVideoId);
+
+            await TryWriteAuditAsync(
+                "upload_receipt_sync_accepted",
+                request,
+                authenticatedScope,
+                persisted.UploadReceiptId,
+                new
+                {
+                    persisted.UploadReceiptId,
+                    persisted.PreUploadCheckId,
+                    ReusedPreUploadCheck = existingPreUploadCheck is not null
+                },
+                cancellationToken);
+
+            await TryWriteAuditAsync(
+                "upload_receipt_sync_analysis_job_queued",
+                request,
+                authenticatedScope,
+                persisted.UploadReceiptId,
+                new
+                {
+                    persisted.UploadReceiptId,
+                    persisted.PreUploadCheckId,
+                    persisted.AnalysisJobId
+                },
+                cancellationToken);
+
+            return persisted.Response;
+        }
+        catch (ArgumentException exception)
+        {
+            await TryWriteAuditAsync(
+                "upload_receipt_sync_rejected",
+                request,
+                authenticatedScope,
+                null,
+                new
+                {
+                    Error = exception.Message,
+                    RejectionKind = "invalid_request"
+                },
+                cancellationToken);
+
+            throw;
+        }
+        catch (InvalidOperationException exception)
+        {
+            await TryWriteAuditAsync(
+                "upload_receipt_sync_rejected",
+                request,
+                authenticatedScope,
+                null,
+                new
+                {
+                    Error = exception.Message,
+                    RejectionKind = "conflict"
+                },
+                cancellationToken);
+
+            throw;
+        }
+    }
+
+    private async Task<VideoUploadPreUploadCheck> CreateLateSyncPreUploadCheckAsync(
+        VideoUploadReceiptSyncRequestDto request,
+        AuthenticatedVideoUploadScope authenticatedScope,
+        string normalizedBusinessObjectKey,
+        string normalizedFileName,
+        string? normalizedContentType,
+        string normalizedExternalVideoId,
+        string normalizedStorageKey,
+        string normalizedHash,
+        string siteProvider,
+        CancellationToken cancellationToken)
+    {
+        var relatedPreUploadCheckId = await dbContext.VideoUploadPreUploadChecks
+            .AsNoTracking()
+            .Where(item =>
+                item.UserId == authenticatedScope.UserId &&
+                item.ByteSha256 == normalizedHash &&
+                item.SizeBytes == request.SizeBytes)
+            .OrderBy(item => item.CheckedAtUtc)
+            .ThenBy(item => item.Id)
+            .Select(item => (Guid?)item.Id)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        var allowWithReview = request.DeviceId is null || request.GroupNodeId is null;
+
+        return new VideoUploadPreUploadCheck
+        {
+            Id = Guid.NewGuid(),
+            UserId = authenticatedScope.UserId,
+            DeviceId = request.DeviceId,
+            GroupNodeId = request.GroupNodeId,
+            BusinessObjectKey = normalizedBusinessObjectKey,
+            FileName = normalizedFileName,
+            SizeBytes = request.SizeBytes,
+            ByteSha256 = normalizedHash,
+            ContentType = normalizedContentType,
+            CapturedAtUtc = request.CapturedAtUtc,
+            Decision = allowWithReview
+                ? PreUploadCheckDecisions.AllowWithReview
+                : PreUploadCheckDecisions.Allow,
+            CanUploadToSite = true,
+            ReasonCode = allowWithReview
+                ? SyncReasonCodeNeedsReview
+                : SyncReasonCode,
+            ExistingPreUploadCheckId = relatedPreUploadCheckId,
+            RequiredNextSteps = "RECEIVE_UPLOAD_RECEIPT_SYNC,QUEUE_ANALYSIS",
+            SiteProvider = siteProvider,
+            ExternalVideoId = normalizedExternalVideoId,
+            StorageKey = normalizedStorageKey,
+            CheckedAtUtc = DateTimeOffset.UtcNow
+        };
+    }
+
+    private static void ValidateScope(
+        VideoUploadReceiptSyncRequestDto request,
+        AuthenticatedVideoUploadScope authenticatedScope)
+    {
+        if (request.UserId != authenticatedScope.UserId)
+        {
+            throw new InvalidOperationException("UploadReceiptSync user context does not match bearer token.");
+        }
+
+        if (authenticatedScope.DeviceId.HasValue && request.DeviceId != authenticatedScope.DeviceId)
+        {
+            throw new InvalidOperationException("UploadReceiptSync device context does not match bearer token.");
+        }
+
+        if (authenticatedScope.GroupNodeId.HasValue && request.GroupNodeId != authenticatedScope.GroupNodeId)
+        {
+            throw new InvalidOperationException("UploadReceiptSync group context does not match bearer token.");
+        }
+    }
+
+    private async Task TryWriteAuditAsync(
+        string action,
+        VideoUploadReceiptSyncRequestDto request,
+        AuthenticatedVideoUploadScope authenticatedScope,
+        Guid? uploadReceiptId,
+        object extraPayload,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await auditService.WriteAsync(
+                new AuditWriteEntry(
+                    AuditCategories.VideoUpload,
+                    action,
+                    authenticatedScope.UserId,
+                    request.DeviceId ?? authenticatedScope.DeviceId,
+                    "video_upload_receipt_sync",
+                    uploadReceiptId?.ToString("D") ?? VideoUploadRequestSupport.NormalizeRequired(request.IdempotencyKey),
+                    new
+                    {
+                        request.UserId,
+                        request.DeviceId,
+                        request.GroupNodeId,
+                        request.BusinessObjectKey,
+                        request.FileName,
+                        request.ExternalVideoId,
+                        request.StorageKey,
+                        request.SiteStatus,
+                        request.SizeBytes,
+                        request.ByteSha256,
+                        request.IdempotencyKey,
+                        request.CapturedAtUtc,
+                        request.UploadedAtUtc,
+                        AuthenticatedUserId = authenticatedScope.UserId,
+                        AuthenticatedDeviceId = authenticatedScope.DeviceId,
+                        AuthenticatedGroupNodeId = authenticatedScope.GroupNodeId,
+                        Extra = extraPayload
+                    }),
+                cancellationToken);
+        }
+        catch (Exception exception)
+        {
+            logger.LogError(
+                exception,
+                "UploadReceiptSync audit write failed. Action={Action} IdempotencyKey={IdempotencyKey}",
+                action,
+                request.IdempotencyKey);
+        }
+    }
+}

--- a/src/Modules/VideoUpload/VideoUploadModule.cs
+++ b/src/Modules/VideoUpload/VideoUploadModule.cs
@@ -22,6 +22,7 @@ public sealed class VideoUploadOptions
 
     public bool PreUploadCheckEnabled { get; set; } = true;
     public bool UploadReceiptEnabled { get; set; } = true;
+    public bool UploadReceiptSyncEnabled { get; set; } = true;
     public long MaxFastAllowSizeBytes { get; set; } = 5L * 1024L * 1024L * 1024L;
     public string SiteProvider { get; set; } = "Stub";
     public string ExternalVideoIdPrefix { get; set; } = "site-video";
@@ -190,41 +191,13 @@ public sealed class PreUploadCheckService(
 
     private static void ValidateRequest(VideoPreUploadCheckRequestDto request, VideoUploadOptions options)
     {
-        if (request.UserId == Guid.Empty)
-        {
-            throw new ArgumentException("UserId is required.", nameof(request));
-        }
-
-        if (string.IsNullOrWhiteSpace(request.BusinessObjectKey))
-        {
-            throw new ArgumentException("BusinessObjectKey is required.", nameof(request));
-        }
-
-        if (string.IsNullOrWhiteSpace(request.FileName))
-        {
-            throw new ArgumentException("FileName is required.", nameof(request));
-        }
-
-        if (request.SizeBytes <= 0)
-        {
-            throw new ArgumentException("SizeBytes must be positive.", nameof(request));
-        }
-
-        if (request.SizeBytes > options.MaxFastAllowSizeBytes)
-        {
-            throw new ArgumentException("SizeBytes exceeds the configured PreUploadCheck limit.", nameof(request));
-        }
-
-        if (string.IsNullOrWhiteSpace(request.ByteSha256))
-        {
-            throw new ArgumentException("ByteSha256 is required.", nameof(request));
-        }
-
-        var normalizedHash = request.ByteSha256.Trim();
-        if (normalizedHash.Length != 64 || !normalizedHash.All(Uri.IsHexDigit))
-        {
-            throw new ArgumentException("ByteSha256 must be a 64-character hexadecimal SHA-256 value.", nameof(request));
-        }
+        VideoUploadRequestSupport.ValidatePreUploadRequest(
+            request.UserId,
+            request.BusinessObjectKey,
+            request.FileName,
+            request.SizeBytes,
+            request.ByteSha256,
+            options);
     }
 }
 
@@ -243,13 +216,13 @@ public sealed class UploadReceiptService(
             throw new InvalidOperationException("UploadReceipt is disabled.");
         }
 
-        ValidateRequest(request);
+        VideoUploadRequestSupport.ValidateUploadReceiptRequest(request);
 
-        var normalizedHash = request.ByteSha256.Trim().ToLowerInvariant();
-        var normalizedIdempotencyKey = request.IdempotencyKey.Trim();
-        var normalizedExternalVideoId = request.ExternalVideoId.Trim();
-        var normalizedStorageKey = request.StorageKey.Trim();
-        var normalizedSiteStatus = request.SiteStatus.Trim().ToLowerInvariant();
+        var normalizedHash = VideoUploadRequestSupport.NormalizeHash(request.ByteSha256);
+        var normalizedIdempotencyKey = VideoUploadRequestSupport.NormalizeRequired(request.IdempotencyKey);
+        var normalizedExternalVideoId = VideoUploadRequestSupport.NormalizeRequired(request.ExternalVideoId);
+        var normalizedStorageKey = VideoUploadRequestSupport.NormalizeRequired(request.StorageKey);
+        var normalizedSiteStatus = VideoUploadRequestSupport.NormalizeRequired(request.SiteStatus).ToLowerInvariant();
 
         var existing = await dbContext.VideoUploadReceipts
             .AsNoTracking()
@@ -264,15 +237,9 @@ public sealed class UploadReceiptService(
                 existing.Id,
                 existing.PreUploadCheckId);
 
-            return new VideoUploadReceiptResponseDto(
-                UploadReceiptId: existing.Id,
-                PreUploadCheckId: existing.PreUploadCheckId,
-                Status: VideoUploadReceiptStatuses.AlreadyAccepted,
-                Accepted: true,
-                WasAlreadyAccepted: true,
-                Message: "Upload receipt already accepted.",
-                AnalysisJobStatus: existing.AnalysisJobStatus,
-                ReceivedAtUtc: existing.ReceivedAtUtc);
+            return VideoUploadRequestSupport.CreateAlreadyAcceptedResponse(
+                existing,
+                "Upload receipt already accepted.");
         }
 
         var preUploadCheck = await dbContext.VideoUploadPreUploadChecks
@@ -318,133 +285,32 @@ public sealed class UploadReceiptService(
             throw new InvalidOperationException("UploadReceipt storage key does not match PreUploadCheck.");
         }
 
-        var receivedAtUtc = DateTimeOffset.UtcNow;
-        var receiptId = Guid.NewGuid();
-        var correlationId = $"upload-receipt-{receiptId:N}";
-
-        var receipt = new VideoUploadReceipt
-        {
-            Id = receiptId,
-            PreUploadCheckId = request.PreUploadCheckId,
-            UserId = request.UserId,
-            DeviceId = request.DeviceId,
-            GroupNodeId = request.GroupNodeId,
-            ExternalVideoId = normalizedExternalVideoId,
-            StorageKey = normalizedStorageKey,
-            SiteStatus = normalizedSiteStatus,
-            SizeBytes = request.SizeBytes,
-            ByteSha256 = normalizedHash,
-            IdempotencyKey = normalizedIdempotencyKey,
-            ReceiptStatus = VideoUploadReceiptStatuses.Accepted,
-            AnalysisJobStatus = "queued",
-            UploadedAtUtc = request.UploadedAtUtc,
-            ReceivedAtUtc = receivedAtUtc
-        };
-
-        var job = new VideoUploadReceiptAnalysisJob
-        {
-            Id = Guid.NewGuid(),
-            UploadReceiptId = receiptId,
-            PreUploadCheckId = request.PreUploadCheckId,
-            CommandName = "video-upload.deep-analysis",
-            Status = "queued",
-            EnqueuedAtUtc = receivedAtUtc
-        };
-
-        var auditPayload = JsonSerializer.Serialize(new
-        {
-            receipt.Id,
-            receipt.PreUploadCheckId,
-            receipt.UserId,
-            receipt.DeviceId,
-            receipt.GroupNodeId,
-            receipt.ExternalVideoId,
-            receipt.StorageKey,
-            receipt.ByteSha256,
-            receipt.SizeBytes
-        });
-
-        var audit = new VideoUploadReceiptAuditRecord
-        {
-            Id = Guid.NewGuid(),
-            UploadReceiptId = receiptId,
-            Category = "video_upload",
-            Action = "upload_receipt_accepted",
-            CorrelationId = correlationId,
-            PayloadJson = auditPayload,
-            CreatedAtUtc = receivedAtUtc
-        };
-
-        dbContext.VideoUploadReceipts.Add(receipt);
-        dbContext.VideoUploadReceiptAnalysisJobs.Add(job);
-        dbContext.VideoUploadReceiptAuditRecords.Add(audit);
-
-        await dbContext.SaveChangesAsync(cancellationToken);
+        var persisted = await VideoUploadRequestSupport.PersistAcceptedReceiptAsync(
+            dbContext,
+            new UploadReceiptPersistRequest(
+                PreUploadCheckId: request.PreUploadCheckId,
+                UserId: request.UserId,
+                DeviceId: request.DeviceId,
+                GroupNodeId: request.GroupNodeId,
+                ExternalVideoId: normalizedExternalVideoId,
+                StorageKey: normalizedStorageKey,
+                SiteStatus: normalizedSiteStatus,
+                SizeBytes: request.SizeBytes,
+                ByteSha256: normalizedHash,
+                IdempotencyKey: normalizedIdempotencyKey,
+                UploadedAtUtc: request.UploadedAtUtc,
+                AuditAction: "upload_receipt_accepted",
+                AcceptedMessage: "Upload receipt accepted and analysis job queued."),
+            preUploadCheckToCreate: null,
+            cancellationToken);
 
         logger.LogInformation(
             "UploadReceipt accepted. UploadReceiptId={UploadReceiptId} PreUploadCheckId={PreUploadCheckId} ExternalVideoId={ExternalVideoId}",
-            receipt.Id,
-            receipt.PreUploadCheckId,
-            receipt.ExternalVideoId);
+            persisted.UploadReceiptId,
+            persisted.PreUploadCheckId,
+            normalizedExternalVideoId);
 
-        return new VideoUploadReceiptResponseDto(
-            UploadReceiptId: receipt.Id,
-            PreUploadCheckId: receipt.PreUploadCheckId,
-            Status: VideoUploadReceiptStatuses.Accepted,
-            Accepted: true,
-            WasAlreadyAccepted: false,
-            Message: "Upload receipt accepted and analysis job queued.",
-            AnalysisJobStatus: receipt.AnalysisJobStatus,
-            ReceivedAtUtc: receipt.ReceivedAtUtc);
-    }
-
-    private static void ValidateRequest(VideoUploadReceiptRequestDto request)
-    {
-        if (request.PreUploadCheckId == Guid.Empty)
-        {
-            throw new ArgumentException("PreUploadCheckId is required.", nameof(request));
-        }
-
-        if (request.UserId == Guid.Empty)
-        {
-            throw new ArgumentException("UserId is required.", nameof(request));
-        }
-
-        if (string.IsNullOrWhiteSpace(request.ExternalVideoId))
-        {
-            throw new ArgumentException("ExternalVideoId is required.", nameof(request));
-        }
-
-        if (string.IsNullOrWhiteSpace(request.StorageKey))
-        {
-            throw new ArgumentException("StorageKey is required.", nameof(request));
-        }
-
-        if (string.IsNullOrWhiteSpace(request.SiteStatus))
-        {
-            throw new ArgumentException("SiteStatus is required.", nameof(request));
-        }
-
-        if (request.SizeBytes <= 0)
-        {
-            throw new ArgumentException("SizeBytes must be positive.", nameof(request));
-        }
-
-        if (string.IsNullOrWhiteSpace(request.ByteSha256))
-        {
-            throw new ArgumentException("ByteSha256 is required.", nameof(request));
-        }
-
-        var normalizedHash = request.ByteSha256.Trim();
-        if (normalizedHash.Length != 64 || !normalizedHash.All(Uri.IsHexDigit))
-        {
-            throw new ArgumentException("ByteSha256 must be a 64-character hexadecimal SHA-256 value.", nameof(request));
-        }
-
-        if (string.IsNullOrWhiteSpace(request.IdempotencyKey))
-        {
-            throw new ArgumentException("IdempotencyKey is required.", nameof(request));
-        }
+        return persisted.Response;
     }
 }
 
@@ -467,6 +333,11 @@ public static class VideoUploadModule
                 if (bool.TryParse(section["UploadReceiptEnabled"], out var uploadReceiptEnabled))
                 {
                     options.UploadReceiptEnabled = uploadReceiptEnabled;
+                }
+
+                if (bool.TryParse(section["UploadReceiptSyncEnabled"], out var uploadReceiptSyncEnabled))
+                {
+                    options.UploadReceiptSyncEnabled = uploadReceiptSyncEnabled;
                 }
 
                 if (long.TryParse(
@@ -506,6 +377,7 @@ public static class VideoUploadModule
 
         services.AddScoped<IPreUploadCheckService, PreUploadCheckService>();
         services.AddScoped<IUploadReceiptService, UploadReceiptService>();
+        services.AddScoped<IUploadReceiptSyncService, UploadReceiptSyncService>();
 
         return services;
     }
@@ -537,6 +409,46 @@ public static class VideoUploadModule
                     return Results.BadRequest(new
                     {
                         error = "invalid_pre_upload_check_request",
+                        message = exception.Message
+                    });
+                }
+            })
+            .RequireAuthorization();
+
+        endpoints.MapPost(
+            "/api/video/upload-receipt-sync",
+            async Task<IResult> (
+                VideoUploadReceiptSyncRequestDto request,
+                HttpContext httpContext,
+                IUploadReceiptSyncService service,
+                CancellationToken cancellationToken) =>
+            {
+                try
+                {
+                    var authenticatedScope = AuthenticatedVideoUploadScope.FromClaimsPrincipal(httpContext.User);
+                    var result = await service.AcceptAsync(request, authenticatedScope, cancellationToken);
+                    return Results.Ok(result);
+                }
+                catch (InvalidOperationException exception)
+                    when (exception.Message.Contains("disabled", StringComparison.OrdinalIgnoreCase))
+                {
+                    return Results.Problem(
+                        detail: exception.Message,
+                        statusCode: StatusCodes.Status503ServiceUnavailable,
+                        title: "UploadReceiptSync unavailable");
+                }
+                catch (InvalidOperationException exception)
+                {
+                    return Results.Problem(
+                        detail: exception.Message,
+                        statusCode: StatusCodes.Status409Conflict,
+                        title: "UploadReceiptSync rejected");
+                }
+                catch (ArgumentException exception)
+                {
+                    return Results.BadRequest(new
+                    {
+                        error = "invalid_upload_receipt_sync_request",
                         message = exception.Message
                     });
                 }

--- a/tests/Integration/App.Api/UploadControlPlaneAuthorizationTests.cs
+++ b/tests/Integration/App.Api/UploadControlPlaneAuthorizationTests.cs
@@ -8,16 +8,25 @@ using System.Text.RegularExpressions;
 
 using BuildingBlocks.Contracts.Auth;
 using BuildingBlocks.Contracts.VideoUpload;
+using BuildingBlocks.Contracts.WorkerPipeline;
 using BuildingBlocks.Infrastructure.Persistence;
 using BuildingBlocks.Infrastructure.Persistence.Entities.Auth;
+using BuildingBlocks.Infrastructure.Persistence.Entities.GroupTree;
 
 using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+
+using Modules.WorkerPipeline;
 
 namespace App.Api.IntegrationTests;
 
 public sealed class UploadControlPlaneAuthorizationTests(AppApiFactory factory) : IClassFixture<AppApiFactory>
 {
+    private static readonly Guid BranchGroupNodeId = Guid.Parse("D4D74008-0ED5-4E46-B0A1-91E0628079C0");
+    private static readonly Guid RootGroupNodeId = Guid.Parse("C15EE7FE-7C9A-4B31-8B7E-C278B59F318C");
+    private static readonly Guid BranchAdminUserId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
     [Fact]
     public async Task PreUploadCheckRejectsAnonymous()
     {
@@ -38,6 +47,18 @@ public sealed class UploadControlPlaneAuthorizationTests(AppApiFactory factory) 
         using HttpResponseMessage response = await client.PostAsJsonAsync(
             "/api/video/upload-receipt",
             CreateAnonymousUploadReceiptRequest());
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UploadReceiptSyncRejectsAnonymous()
+    {
+        using HttpClient client = factory.CreateClient();
+
+        using HttpResponseMessage response = await client.PostAsJsonAsync(
+            "/api/video/upload-receipt-sync",
+            CreateAnonymousUploadReceiptSyncRequest());
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
@@ -129,10 +150,185 @@ public sealed class UploadControlPlaneAuthorizationTests(AppApiFactory factory) 
         Assert.Equal(firstBody.AnalysisJobStatus, secondBody.AnalysisJobStatus);
     }
 
+    [Fact]
+    public async Task UploadReceiptSyncAllowsAuthenticatedLateSyncReceipt()
+    {
+        using HttpClient client = factory.CreateClient();
+        var auth = await SignInWithContextAsync(client);
+
+        VideoUploadReceiptSyncRequestDto request = CreateUploadReceiptSyncRequest(
+            auth,
+            CreateHex64(),
+            Guid.NewGuid().ToString("N"));
+
+        using HttpResponseMessage response = await client.PostAsJsonAsync(
+            "/api/video/upload-receipt-sync",
+            request);
+
+        await AssertStatusCodeAsync("upload receipt sync", HttpStatusCode.OK, response);
+
+        VideoUploadReceiptResponseDto? body =
+            await response.Content.ReadFromJsonAsync<VideoUploadReceiptResponseDto>();
+
+        Assert.NotNull(body);
+        Assert.Equal(VideoUploadReceiptStatuses.Accepted, body.Status);
+        Assert.True(body.Accepted);
+        Assert.False(body.WasAlreadyAccepted);
+
+        using IServiceScope scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<PlatformDbContext>();
+        var precheck = await db.VideoUploadPreUploadChecks.SingleAsync(item => item.Id == body.PreUploadCheckId);
+
+        Assert.Equal("late_sync_reconciled", precheck.ReasonCode);
+        Assert.Equal(1, await db.VideoUploadReceipts.CountAsync(item => item.Id == body.UploadReceiptId));
+        Assert.Equal(1, await db.VideoUploadReceiptAnalysisJobs.CountAsync(item => item.UploadReceiptId == body.UploadReceiptId));
+    }
+
+    [Fact]
+    public async Task UploadReceiptSyncIsIdempotentByIdempotencyKey()
+    {
+        using HttpClient client = factory.CreateClient();
+        var auth = await SignInWithContextAsync(client);
+
+        string idempotencyKey = Guid.NewGuid().ToString("N");
+        VideoUploadReceiptSyncRequestDto request = CreateUploadReceiptSyncRequest(
+            auth,
+            CreateHex64(),
+            idempotencyKey);
+
+        using HttpResponseMessage firstResponse = await client.PostAsJsonAsync(
+            "/api/video/upload-receipt-sync",
+            request);
+
+        await AssertStatusCodeAsync("first upload receipt sync", HttpStatusCode.OK, firstResponse);
+
+        using HttpResponseMessage secondResponse = await client.PostAsJsonAsync(
+            "/api/video/upload-receipt-sync",
+            request);
+
+        await AssertStatusCodeAsync("second upload receipt sync", HttpStatusCode.OK, secondResponse);
+
+        VideoUploadReceiptResponseDto? firstBody =
+            await firstResponse.Content.ReadFromJsonAsync<VideoUploadReceiptResponseDto>();
+        VideoUploadReceiptResponseDto? secondBody =
+            await secondResponse.Content.ReadFromJsonAsync<VideoUploadReceiptResponseDto>();
+
+        Assert.NotNull(firstBody);
+        Assert.NotNull(secondBody);
+        Assert.Equal(VideoUploadReceiptStatuses.Accepted, firstBody.Status);
+        Assert.Equal(VideoUploadReceiptStatuses.AlreadyAccepted, secondBody.Status);
+        Assert.Equal(firstBody.UploadReceiptId, secondBody.UploadReceiptId);
+
+        using IServiceScope scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<PlatformDbContext>();
+
+        Assert.Equal(1, await db.VideoUploadReceipts.CountAsync(item => item.IdempotencyKey == idempotencyKey));
+        Assert.Equal(1, await db.VideoUploadReceiptAnalysisJobs.CountAsync(item => item.UploadReceiptId == firstBody.UploadReceiptId));
+    }
+
+    [Fact]
+    public async Task UploadReceiptSyncCanTriggerDuplicateCandidateAndIncidentPath()
+    {
+        await EnsureBranchAdminRoutingAsync();
+
+        using HttpClient client = factory.CreateClient();
+        var auth = await SignInWithContextAsync(client);
+        string duplicateHash = CreateHex64();
+
+        VideoUploadReceiptSyncRequestDto firstRequest = CreateUploadReceiptSyncRequest(
+            auth,
+            duplicateHash,
+            idempotencyKey: "sync-duplicate-1",
+            groupNodeId: BranchGroupNodeId,
+            businessObjectKey: $"business-object-{Guid.NewGuid():N}");
+
+        VideoUploadReceiptSyncRequestDto secondRequest = CreateUploadReceiptSyncRequest(
+            auth,
+            duplicateHash,
+            idempotencyKey: "sync-duplicate-2",
+            groupNodeId: BranchGroupNodeId,
+            businessObjectKey: $"business-object-{Guid.NewGuid():N}");
+
+        using HttpResponseMessage firstResponse = await client.PostAsJsonAsync(
+            "/api/video/upload-receipt-sync",
+            firstRequest);
+        using HttpResponseMessage secondResponse = await client.PostAsJsonAsync(
+            "/api/video/upload-receipt-sync",
+            secondRequest);
+
+        await AssertStatusCodeAsync("first duplicate upload receipt sync", HttpStatusCode.OK, firstResponse);
+        await AssertStatusCodeAsync("second duplicate upload receipt sync", HttpStatusCode.OK, secondResponse);
+
+        VideoUploadReceiptResponseDto? firstBody =
+            await firstResponse.Content.ReadFromJsonAsync<VideoUploadReceiptResponseDto>();
+        VideoUploadReceiptResponseDto? secondBody =
+            await secondResponse.Content.ReadFromJsonAsync<VideoUploadReceiptResponseDto>();
+
+        Assert.NotNull(firstBody);
+        Assert.NotNull(secondBody);
+
+        using IServiceScope scope = factory.Services.CreateScope();
+        var bridge = scope.ServiceProvider.GetRequiredService<IUploadReceiptPipelineBridgeService>();
+        var db = scope.ServiceProvider.GetRequiredService<PlatformDbContext>();
+        var targetReceiptIds = new[] { firstBody.UploadReceiptId, secondBody.UploadReceiptId };
+
+        for (var attempt = 0; attempt < 16; attempt++)
+        {
+            _ = await bridge.ProcessNextQueuedAsync(CancellationToken.None);
+
+            var completedTargetCount = await db.VideoUploadReceipts
+                .CountAsync(
+                    item => targetReceiptIds.Contains(item.Id) &&
+                        item.AnalysisJobStatus == WorkerPipelineJobStatusesV1.Completed);
+
+            if (completedTargetCount == targetReceiptIds.Length)
+            {
+                break;
+            }
+        }
+
+        var targetAssetIds = await db.VideoDuplicateAssets
+            .Where(item => targetReceiptIds.Contains(item.UploadReceiptId))
+            .Select(item => item.Id)
+            .ToArrayAsync();
+
+        var duplicateCandidate = await db.VideoDuplicateCandidates.SingleAsync(
+            item => targetAssetIds.Contains(item.SourceVideoAssetId) || targetAssetIds.Contains(item.MatchedVideoAssetId));
+        var incident = await db.DuplicateIncidentRecords.SingleAsync(item => item.DuplicateCandidateId == duplicateCandidate.Id);
+        var assignment = await db.DuplicateIncidentAssignmentRecords.SingleAsync(item => item.IncidentId == incident.Id);
+
+        Assert.Equal(2, targetAssetIds.Length);
+        Assert.Equal(duplicateCandidate.Id, incident.DuplicateCandidateId);
+        Assert.Equal(BranchAdminUserId, assignment.AssignedAdminUserId);
+        Assert.Equal(2, await db.VideoUploadReceipts.CountAsync(item => item.ByteSha256 == duplicateHash));
+    }
+
+    [Fact]
+    public async Task UploadReceiptOnlinePathStrictValidationRemainsUnchanged()
+    {
+        using HttpClient client = factory.CreateClient();
+        var auth = await SignInWithContextAsync(client);
+
+        using HttpResponseMessage response = await client.PostAsJsonAsync(
+            "/api/video/upload-receipt",
+            CreateInvalidOnlineUploadReceiptRequest(auth));
+
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+
+        string responseBody = await response.Content.ReadAsStringAsync();
+        Assert.Contains("PreUploadCheck was not found.", responseBody, StringComparison.Ordinal);
+    }
+
     private async Task<Guid> SignInAsync(HttpClient client)
+    {
+        return (await SignInWithContextAsync(client)).UserId;
+    }
+
+    private async Task<AuthenticatedClientContext> SignInWithContextAsync(HttpClient client)
     {
         string login = $"s2-15-user-{Guid.NewGuid():N}";
         const string password = "S2-15-test-password!";
+        Guid deviceId = Guid.NewGuid();
 
         await SeedUserAsync(login, password);
 
@@ -141,7 +337,7 @@ public sealed class UploadControlPlaneAuthorizationTests(AppApiFactory factory) 
             new SignInRequestDto(
                 Login: login,
                 Password: password,
-                DeviceId: Guid.NewGuid()));
+                DeviceId: deviceId));
 
         await AssertStatusCodeAsync("sign in", HttpStatusCode.OK, signInResponse);
 
@@ -153,7 +349,7 @@ public sealed class UploadControlPlaneAuthorizationTests(AppApiFactory factory) 
 
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
 
-        return signInBody.User.UserId;
+        return new AuthenticatedClientContext(signInBody.User.UserId, deviceId);
     }
 
     private async Task SeedUserAsync(string login, string password)
@@ -236,9 +432,119 @@ public sealed class UploadControlPlaneAuthorizationTests(AppApiFactory factory) 
             UploadedAtUtc: DateTimeOffset.UtcNow);
     }
 
+    private static VideoUploadReceiptSyncRequestDto CreateAnonymousUploadReceiptSyncRequest()
+    {
+        return new VideoUploadReceiptSyncRequestDto(
+            UserId: Guid.NewGuid(),
+            DeviceId: Guid.NewGuid(),
+            GroupNodeId: Guid.NewGuid(),
+            BusinessObjectKey: $"business-object-{Guid.NewGuid():N}",
+            FileName: $"offline-{Guid.NewGuid():N}.mp4",
+            ContentType: "video/mp4",
+            ExternalVideoId: $"site-video-{Guid.NewGuid():N}",
+            StorageKey: $"videos/site-video-{Guid.NewGuid():N}.mp4",
+            SiteStatus: "uploaded",
+            SizeBytes: 1024,
+            ByteSha256: CreateHex64(),
+            IdempotencyKey: Guid.NewGuid().ToString("N"),
+            CapturedAtUtc: DateTimeOffset.UtcNow,
+            UploadedAtUtc: DateTimeOffset.UtcNow);
+    }
+
+    private static VideoUploadReceiptSyncRequestDto CreateUploadReceiptSyncRequest(
+        AuthenticatedClientContext auth,
+        string hash,
+        string idempotencyKey,
+        Guid? groupNodeId = null,
+        string? businessObjectKey = null)
+    {
+        string externalVideoId = $"site-video-sync-{Guid.NewGuid():N}";
+
+        return new VideoUploadReceiptSyncRequestDto(
+            UserId: auth.UserId,
+            DeviceId: auth.DeviceId,
+            GroupNodeId: groupNodeId ?? Guid.NewGuid(),
+            BusinessObjectKey: businessObjectKey ?? $"business-object-{Guid.NewGuid():N}",
+            FileName: $"offline-{Guid.NewGuid():N}.mp4",
+            ContentType: "video/mp4",
+            ExternalVideoId: externalVideoId,
+            StorageKey: $"videos/{externalVideoId}.mp4",
+            SiteStatus: "uploaded",
+            SizeBytes: 1024,
+            ByteSha256: hash,
+            IdempotencyKey: idempotencyKey,
+            CapturedAtUtc: DateTimeOffset.UtcNow,
+            UploadedAtUtc: DateTimeOffset.UtcNow);
+    }
+
+    private static VideoUploadReceiptRequestDto CreateInvalidOnlineUploadReceiptRequest(
+        AuthenticatedClientContext auth)
+    {
+        string externalVideoId = $"site-video-{Guid.NewGuid():N}";
+
+        return new VideoUploadReceiptRequestDto(
+            PreUploadCheckId: Guid.NewGuid(),
+            UserId: auth.UserId,
+            DeviceId: auth.DeviceId,
+            GroupNodeId: Guid.NewGuid(),
+            ExternalVideoId: externalVideoId,
+            StorageKey: $"videos/{externalVideoId}.mp4",
+            SiteStatus: "uploaded",
+            SizeBytes: 1024,
+            ByteSha256: CreateHex64(),
+            IdempotencyKey: Guid.NewGuid().ToString("N"),
+            UploadedAtUtc: DateTimeOffset.UtcNow);
+    }
+
     private static string CreateHex64()
     {
         return $"{Guid.NewGuid():N}{Guid.NewGuid():N}";
+    }
+
+    private async Task EnsureBranchAdminRoutingAsync()
+    {
+        using IServiceScope scope = factory.Services.CreateScope();
+
+        var db = scope.ServiceProvider.GetRequiredService<PlatformDbContext>();
+
+        if (!await db.GroupNodes.AnyAsync(item => item.Id == RootGroupNodeId))
+        {
+            db.GroupNodes.Add(new GroupNode
+            {
+                Id = RootGroupNodeId,
+                ParentNodeId = null,
+                Code = "root",
+                Name = "Root",
+                Depth = 0,
+                IsActive = true
+            });
+        }
+
+        if (!await db.GroupNodes.AnyAsync(item => item.Id == BranchGroupNodeId))
+        {
+            db.GroupNodes.Add(new GroupNode
+            {
+                Id = BranchGroupNodeId,
+                ParentNodeId = RootGroupNodeId,
+                Code = "branch-a",
+                Name = "Branch A",
+                Depth = 1,
+                IsActive = true
+            });
+        }
+
+        if (!await db.GroupAdminAssignments.AnyAsync(
+                item => item.GroupNodeId == BranchGroupNodeId && item.UserId == BranchAdminUserId))
+        {
+            db.GroupAdminAssignments.Add(new GroupAdminAssignment
+            {
+                GroupNodeId = BranchGroupNodeId,
+                UserId = BranchAdminUserId,
+                AssignedAtUtc = DateTimeOffset.UtcNow
+            });
+        }
+
+        await db.SaveChangesAsync();
     }
 
     private static async Task AssertStatusCodeAsync(
@@ -335,4 +641,6 @@ public sealed class UploadControlPlaneAuthorizationTests(AppApiFactory factory) 
         return string.Equals(propertyName, "accessToken", StringComparison.OrdinalIgnoreCase)
             || string.Equals(propertyName, "refreshToken", StringComparison.OrdinalIgnoreCase);
     }
+
+    private sealed record AuthenticatedClientContext(Guid UserId, Guid DeviceId);
 }

--- a/tests/Integration/VideoUpload/PreUploadCheckServiceTests.cs
+++ b/tests/Integration/VideoUpload/PreUploadCheckServiceTests.cs
@@ -1,4 +1,5 @@
 using BuildingBlocks.Contracts.VideoUpload;
+using BuildingBlocks.Infrastructure.Observability;
 using BuildingBlocks.Infrastructure.Persistence;
 
 using Microsoft.EntityFrameworkCore;
@@ -16,6 +17,7 @@ public sealed class PreUploadCheckServiceTests
         var settings = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
         {
             ["Modules:VideoUpload:PreUploadCheckEnabled"] = "true",
+            ["Modules:VideoUpload:UploadReceiptSyncEnabled"] = "true",
             ["Modules:VideoUpload:MaxFastAllowSizeBytes"] = "5368709120",
             ["Modules:VideoUpload:SiteProvider"] = "Stub",
             ["Modules:VideoUpload:ExternalVideoIdPrefix"] = "site-video",
@@ -30,6 +32,7 @@ public sealed class PreUploadCheckServiceTests
         services.AddLogging();
         services.AddDbContext<PlatformDbContext>(
             options => options.UseInMemoryDatabase(Guid.NewGuid().ToString("N")));
+        services.AddAuditObservabilityFoundation();
         services.AddVideoUploadModule(configuration);
 
         return services.BuildServiceProvider(

--- a/tests/Integration/VideoUpload/UploadReceiptServiceTests.cs
+++ b/tests/Integration/VideoUpload/UploadReceiptServiceTests.cs
@@ -1,4 +1,5 @@
 using BuildingBlocks.Contracts.VideoUpload;
+using BuildingBlocks.Infrastructure.Observability;
 using BuildingBlocks.Infrastructure.Persistence;
 
 using Microsoft.EntityFrameworkCore;
@@ -17,6 +18,7 @@ public sealed class UploadReceiptServiceTests
         {
             ["Modules:VideoUpload:PreUploadCheckEnabled"] = "true",
             ["Modules:VideoUpload:UploadReceiptEnabled"] = "true",
+            ["Modules:VideoUpload:UploadReceiptSyncEnabled"] = "true",
             ["Modules:VideoUpload:MaxFastAllowSizeBytes"] = "5368709120",
             ["Modules:VideoUpload:SiteProvider"] = "Stub",
             ["Modules:VideoUpload:ExternalVideoIdPrefix"] = "site-video",
@@ -31,6 +33,7 @@ public sealed class UploadReceiptServiceTests
         services.AddLogging();
         services.AddDbContext<PlatformDbContext>(
             options => options.UseInMemoryDatabase(Guid.NewGuid().ToString("N")));
+        services.AddAuditObservabilityFoundation();
         services.AddVideoUploadModule(configuration);
 
         return services.BuildServiceProvider(
@@ -113,6 +116,72 @@ public sealed class UploadReceiptServiceTests
             () => receipts.AcceptAsync(request, CancellationToken.None));
     }
 
+    [Fact]
+    public async Task AcceptSyncAsyncCreatesPreUploadReceiptJobAndAudit()
+    {
+        using var provider = CreateProvider();
+        using var scope = provider.CreateScope();
+
+        var syncReceipts = scope.ServiceProvider.GetRequiredService<IUploadReceiptSyncService>();
+        var db = scope.ServiceProvider.GetRequiredService<PlatformDbContext>();
+
+        var request = CreateSyncRequest(
+            hash: "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+            idempotencyKey: "sync-idem-1");
+
+        var receipt = await syncReceipts.AcceptAsync(
+            request,
+            new AuthenticatedVideoUploadScope(UserId, DeviceId, null),
+            CancellationToken.None);
+
+        var precheck = await db.VideoUploadPreUploadChecks.SingleAsync();
+        var job = await db.VideoUploadReceiptAnalysisJobs.SingleAsync();
+
+        Assert.Equal(VideoUploadReceiptStatuses.Accepted, receipt.Status);
+        Assert.Equal(precheck.Id, receipt.PreUploadCheckId);
+        Assert.Equal(PreUploadCheckDecisions.Allow, precheck.Decision);
+        Assert.Equal("late_sync_reconciled", precheck.ReasonCode);
+        Assert.Equal("video-upload.deep-analysis", job.CommandName);
+        Assert.Equal(1, await db.VideoUploadReceipts.CountAsync());
+        Assert.Equal(1, await db.VideoUploadReceiptAnalysisJobs.CountAsync());
+        Assert.Equal(1, await db.VideoUploadReceiptAuditRecords.CountAsync());
+        Assert.Equal(2, await db.AuditRecords.CountAsync());
+    }
+
+    [Fact]
+    public async Task AcceptSyncAsyncIsIdempotentByNaturalReceiptKey()
+    {
+        using var provider = CreateProvider();
+        using var scope = provider.CreateScope();
+
+        var syncReceipts = scope.ServiceProvider.GetRequiredService<IUploadReceiptSyncService>();
+        var db = scope.ServiceProvider.GetRequiredService<PlatformDbContext>();
+
+        var request = CreateSyncRequest(
+            hash: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+            idempotencyKey: "sync-idem-2");
+
+        var first = await syncReceipts.AcceptAsync(
+            request,
+            new AuthenticatedVideoUploadScope(UserId, DeviceId, null),
+            CancellationToken.None);
+
+        var second = await syncReceipts.AcceptAsync(
+            request with
+            {
+                IdempotencyKey = "sync-idem-3"
+            },
+            new AuthenticatedVideoUploadScope(UserId, DeviceId, null),
+            CancellationToken.None);
+
+        Assert.Equal(first.UploadReceiptId, second.UploadReceiptId);
+        Assert.Equal(VideoUploadReceiptStatuses.AlreadyAccepted, second.Status);
+        Assert.True(second.WasAlreadyAccepted);
+        Assert.Equal(1, await db.VideoUploadPreUploadChecks.CountAsync());
+        Assert.Equal(1, await db.VideoUploadReceipts.CountAsync());
+        Assert.Equal(1, await db.VideoUploadReceiptAnalysisJobs.CountAsync());
+    }
+
     private static readonly Guid UserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
     private static readonly Guid DeviceId = Guid.Parse("22222222-2222-2222-2222-222222222222");
     private static readonly Guid GroupNodeId = Guid.Parse("33333333-3333-3333-3333-333333333333");
@@ -150,6 +219,27 @@ public sealed class UploadReceiptServiceTests
             SizeBytes: 12345,
             ByteSha256: hash,
             IdempotencyKey: idempotencyKey,
+            UploadedAtUtc: FixedTime);
+    }
+
+    private static VideoUploadReceiptSyncRequestDto CreateSyncRequest(string hash, string idempotencyKey)
+    {
+        var externalVideoId = $"site-video-sync-{Guid.NewGuid():N}";
+
+        return new VideoUploadReceiptSyncRequestDto(
+            UserId: UserId,
+            DeviceId: DeviceId,
+            GroupNodeId: GroupNodeId,
+            BusinessObjectKey: "demo-business-object",
+            FileName: "offline-demo.mp4",
+            ContentType: "video/mp4",
+            ExternalVideoId: externalVideoId,
+            StorageKey: $"videos/{externalVideoId}.mp4",
+            SiteStatus: "uploaded",
+            SizeBytes: 12345,
+            ByteSha256: hash,
+            IdempotencyKey: idempotencyKey,
+            CapturedAtUtc: FixedTime,
             UploadedAtUtc: FixedTime);
     }
 }

--- a/tests/Integration/WorkerPipeline/UploadReceiptPipelineBridgeTests.cs
+++ b/tests/Integration/WorkerPipeline/UploadReceiptPipelineBridgeTests.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 
 using BuildingBlocks.Contracts.WorkerPipeline;
 using BuildingBlocks.Contracts.VideoUpload;
+using BuildingBlocks.Infrastructure.Observability;
 using BuildingBlocks.Infrastructure.Persistence;
 using BuildingBlocks.Infrastructure.Persistence.Entities.GroupTree;
 using BuildingBlocks.Infrastructure.Persistence.Entities.VideoUpload;
@@ -225,6 +226,7 @@ public sealed class UploadReceiptPipelineBridgeTests
         {
             ["Modules:VideoUpload:PreUploadCheckEnabled"] = "true",
             ["Modules:VideoUpload:UploadReceiptEnabled"] = "true",
+            ["Modules:VideoUpload:UploadReceiptSyncEnabled"] = "true",
             ["Modules:VideoUpload:MaxFastAllowSizeBytes"] = "5368709120",
             ["Modules:VideoUpload:SiteProvider"] = "Stub",
             ["Modules:VideoUpload:ExternalVideoIdPrefix"] = "site-video",
@@ -247,6 +249,7 @@ public sealed class UploadReceiptPipelineBridgeTests
         services.AddLogging();
         services.AddDbContext<PlatformDbContext>(
             options => options.UseInMemoryDatabase(databaseName));
+        services.AddAuditObservabilityFoundation();
         services.AddGroupTreeModule(configuration, new TestHostEnvironment());
         services.AddVideoUploadModule(configuration);
         services.AddVideoDuplicatesModule(configuration);


### PR DESCRIPTION
﻿## Goal

Implement S2-26 Late Sync Upload Receipt Intake.

## Module / Scope

App.Api / VideoUpload / Auth / WorkerPipeline / VideoDuplicates / Incidents.

## Changes

- Adds additive bearer-protected endpoint:
  - `POST /api/video/upload-receipt-sync`
- Adds additive shared request DTO:
  - `VideoUploadReceiptSyncRequestDto`
- Reuses existing `VideoUploadReceiptResponseDto`.
- Keeps existing `POST /api/video/upload-receipt` strict and unchanged for online receipt flow.
- Adds late/offline receipt sync intake without routing video bytes through App.Api.
- Validates user/device/group scope from bearer claims.
- Reconciles or creates server-side `PreUploadCheck` state for approved late/offline receipt sync.
- Adds sync-specific idempotency to avoid duplicate receipt/job/incident spam.
- Reuses existing durable analysis job path and S2-22 worker bridge.
- Adds audit events for accepted / already accepted / rejected / enqueued sync intake.

## Contracts

Additive contract change:
- New `VideoUploadReceiptSyncRequestDto`.
- New route `POST /api/video/upload-receipt-sync`.

No breaking contract changes:
- Existing `VideoUploadReceiptRequestDto` unchanged.
- Existing `VideoUploadReceiptResponseDto` unchanged.
- Existing `VideoUploadReceiptStatuses` unchanged.
- Existing `POST /api/video/upload-receipt` route unchanged.
- Existing online receipt validation is not weakened.

## Migration

No database migration.

Existing tables are sufficient:
- `video_upload_pre_upload_checks`;
- `video_upload_receipts`;
- `video_upload_receipt_analysis_jobs`;
- `video_upload_receipt_audit_records`;
- `audit_records`.

## Feature flag

New feature flag:
- `Modules:VideoUpload:UploadReceiptSyncEnabled`

Reason:
- this is a new public late/offline sync intake path;
- it needs a per-module kill switch independent from the existing online `UploadReceiptEnabled`.

## Security

- Endpoint requires bearer authentication.
- User/device/group scope is validated from bearer claims.
- No password logging.
- No accessToken/refreshToken logging.
- No hidden auth bypass.
- No video bytes through App.Api as a required proxy.
- No secrets added.

## Tests

Local validation:
- `dotnet restore AnalyticsAutomation-Core.sln -nologo`
- `dotnet build AnalyticsAutomation-Core.sln --no-restore -nologo -v minimal`
- `dotnet test tests\Integration\App.Api\App.Api.IntegrationTests.csproj -nologo -v minimal`
- `dotnet test tests\Integration\VideoUpload\VideoUpload.IntegrationTests.csproj -nologo -v minimal`
- `dotnet test tests\Integration\WorkerPipeline\WorkerPipeline.IntegrationTests.csproj -nologo -v minimal`
- `dotnet test tests\Integration\VideoDuplicates\VideoDuplicates.IntegrationTests.csproj -nologo -v minimal`
- `dotnet test tests\Integration\Incidents\Incidents.IntegrationTests.csproj -nologo -v minimal`
- `dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore`
- `git diff --check`

Expected PR CI:
- restore;
- format;
- build;
- unit-tests;
- integration-tests.

## Rollback

Revert this PR.

If deployed and runtime behavior must be disabled before revert:
- set `Modules:VideoUpload:UploadReceiptSyncEnabled=false`.

Existing online upload receipt flow remains available through `POST /api/video/upload-receipt`.

## Production deploy

Not triggered by this PR.
Deploy workflow is not run from this PR.
