### PR TITLE
add S2-18 upload control plane baseline

### DIFF
--- a/docs/handoffs/C2_S2_18_WEB_UPLOAD_CONTROL_PLANE_HANDOFF.md
+++ b/docs/handoffs/C2_S2_18_WEB_UPLOAD_CONTROL_PLANE_HANDOFF.md
@@ -1,0 +1,142 @@
+# C2 S2-18 Web Upload Control Plane Handoff
+
+Status: local increment ready for PR readiness.
+
+Branch:
+feature/web-upload-control-plane-s2-18
+
+Owner:
+Coder 2 / Web
+
+## Goal
+
+Implement Web/PWA upload control plane baseline:
+
+sign-in -> group tree -> pre-upload check -> local direct-site stub boundary -> upload receipt.
+
+## What changed
+
+- Added web-only upload control plane client adapter baseline:
+  - sign-in endpoint constant
+  - refresh endpoint constant
+  - group tree nodes endpoint constant
+  - routing preview endpoint constant
+  - in-memory session store
+  - sanitized session shape
+  - token/body redaction helper
+  - HttpUploadControlPlaneApi
+- Made HttpVideoUploadApi session-aware:
+  - PreUploadCheck adds Authorization header when an in-memory session exists.
+  - UploadReceipt adds Authorization header when an in-memory session exists.
+  - error body text is redacted before surfacing.
+- Extended /upload UI:
+  - sign-in form
+  - sanitized session summary
+  - group tree load
+  - group node selection
+  - pre-upload check
+  - local direct-site stub boundary
+  - upload receipt boundary
+- Added explicit local/client direct-site stub:
+  - does not call App.Api
+  - does not send video bytes through App.Api
+  - produces deterministic external video id / storage key / site status for UploadReceipt boundary
+- Added App.Web unit tests for:
+  - control plane endpoint constants
+  - redaction
+  - in-memory session store
+  - session factory
+  - bearer header behavior in HttpVideoUploadApi
+  - local direct-site stub behavior
+
+## What did not change
+
+- No backend route changes.
+- No App.Api changes.
+- No shared DTO / BuildingBlocks.Contracts changes.
+- No database migration.
+- No Android code.
+- No deploy workflow changes.
+- No SSH or server-side operation.
+- No production direct-site provider implementation.
+- No video byte proxy through App.Api.
+
+## Security and redaction
+
+Password is not stored in source code or docs.
+
+Token values must not be logged or pasted into GitHub / ChatGPT / screenshots.
+
+The UI displays only sanitized session metadata:
+- user id
+- display name
+- access token available: true/false
+- refresh token available: true/false
+
+Error bodies are sanitized with UploadControlPlaneErrorRedactor before being surfaced.
+
+## Manual smoke notes
+
+Live smoke was not executed by this local code step.
+
+When owner approves live smoke, use only local browser interaction and do not paste secrets into logs.
+
+Suggested sanitized smoke path:
+
+1. Run App.Web locally.
+2. Open /upload.
+3. Enter integration login manually.
+4. Enter password manually from out-of-band source.
+5. Submit sign-in.
+6. Confirm session summary appears and no token values are displayed.
+7. Load group tree.
+8. Select a group node and confirm GroupNodeId is copied into the upload form.
+9. Fill local metadata for pre-upload check:
+   - user id
+   - device id
+   - group node id
+   - business object key
+   - file name
+   - size bytes
+   - byte sha256
+   - content type
+   - captured at UTC
+10. Run PreUploadCheck.
+11. Confirm the backend decision is displayed.
+12. Run local direct-site upload stub boundary.
+13. Confirm the message explicitly says no video bytes were sent through App.Api.
+14. Submit UploadReceipt.
+15. Submit UploadReceipt again without clearing result if idempotency behavior needs manual confirmation.
+16. Do not paste token values or password into notes.
+
+## Expected PR scope
+
+Allowed changed areas:
+- docs/task-cards/C2-S2-18_web-upload-control-plane-integration.txt
+- docs/handoffs/C2_S2_18_WEB_UPLOAD_CONTROL_PLANE_HANDOFF.md
+- src/App.Web/**
+- tests/Unit/App.Web.Tests/**
+
+Disallowed changed areas:
+- src/App.Api/**
+- src/Modules/**
+- src/BuildingBlocks/Contracts/**
+- src/App.Mobile.Android/**
+- .github/workflows/**
+- infra/**
+- DB migrations
+
+## Local validation
+
+Expected commands for this Web-only branch on a machine without MAUI workload:
+
+dotnet restore src/App.Web/App.Web.csproj
+dotnet restore tests/Unit/App.Web.Tests/App.Web.Tests.csproj
+dotnet format whitespace src/App.Web/App.Web.csproj --verify-no-changes --no-restore
+dotnet format whitespace tests/Unit/App.Web.Tests/App.Web.Tests.csproj --verify-no-changes --no-restore
+dotnet build src/App.Web/App.Web.csproj
+dotnet build tests/Unit/App.Web.Tests/App.Web.Tests.csproj
+dotnet test tests/Unit/App.Web.Tests/App.Web.Tests.csproj --no-build
+git diff --check
+
+Solution-wide restore/format is intentionally not required on this local machine because App.Mobile.Android requires the maui-android workload and Android is out of scope for S2-18 Web.

--- a/docs/task-cards/C2-S2-18_web-upload-control-plane-integration.txt
+++ b/docs/task-cards/C2-S2-18_web-upload-control-plane-integration.txt
@@ -1,0 +1,81 @@
+TASK CARD: C2-S2-18 Web/PWA Upload Control Plane Integration Increment 1
+
+Owner:
+Coder 2 / Web
+
+Branch:
+feature/web-upload-control-plane-s2-18
+
+Base:
+main after PR #74 merge and S2-17/S2-19/S2-21 backend handoffs present in main.
+
+Goal:
+Implement Web/PWA client-side upload control plane baseline:
+sign-in -> group tree -> pre-upload check -> local/direct-site adapter boundary -> upload receipt.
+
+Korobochka LAN API:
+- API root: http://192.168.1.66/
+- health: http://192.168.1.66/health/ready
+- version: http://192.168.1.66/api/system/version
+
+Integration account:
+- login: integration-web-android
+- password: out-of-band only
+
+Security:
+- do not write password to GitHub, ChatGPT, logs, screenshots, or docs
+- do not print accessToken or refreshToken
+- redact tokens in all errors
+- report only status codes and sanitized response bodies
+
+Required Web flow:
+1. POST /api/auth/sign-in
+2. Store/use bearer token only in safe dev/session path
+3. GET /api/group-tree/nodes with bearer
+4. Build minimal pre-upload request from local metadata:
+   - userId
+   - deviceId
+   - groupNodeId
+   - businessObjectKey
+   - fileName
+   - sizeBytes
+   - byteSha256
+   - contentType
+   - capturedAtUtc
+5. POST /api/video/pre-upload-check with bearer
+6. Display decision and sitePlan safely
+7. Do not send video bytes through App.Api
+8. If direct-site upload adapter is not ready, keep direct-site step as local/client stub only
+9. POST /api/video/upload-receipt with bearer after direct-site step/stub
+10. Verify idempotent repeat with same idempotencyKey if practical
+
+In scope:
+- App.Web client-side upload control plane baseline
+- reuse existing App.Web upload adapter/UI structure
+- web-side smoke/dev notes if suitable docs area exists
+- tests only if existing App.Web test structure supports them without new infrastructure
+
+Out of scope:
+- backend routes
+- BuildingBlocks.Contracts changes
+- App.Api changes
+- DB migrations
+- deploy-korobochka workflow
+- Android code
+- SSH to Korobochka
+- production site video byte proxy through App.Api
+- unapproved packages
+
+Checks:
+- dotnet build affected Web/shared UI projects
+- dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore when applicable
+- git diff --check
+
+Definition of done:
+- App.Web upload control plane baseline compiles
+- token/password redaction rules respected
+- video bytes are not routed through App.Api
+- direct-site step remains explicit local/client stub if adapter is not ready
+- upload receipt submission is wired only after control-plane/direct-site boundary
+- manual smoke notes include sanitized outputs only
+- no backend/contracts/migrations/deploy/Android changes

--- a/src/App.Web/Features/Upload/Api/HttpVideoUploadApi.cs
+++ b/src/App.Web/Features/Upload/Api/HttpVideoUploadApi.cs
@@ -1,5 +1,8 @@
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
+
+using App.Web.Features.Upload.ControlPlane;
 
 using BuildingBlocks.Contracts.VideoUpload;
 
@@ -25,11 +28,16 @@ public sealed class HttpVideoUploadApi : IVideoUploadApi
 
     private readonly HttpClient _httpClient;
     private readonly ILogger<HttpVideoUploadApi> _logger;
+    private readonly IUploadControlPlaneSessionStore _sessionStore;
 
-    public HttpVideoUploadApi(HttpClient httpClient, ILogger<HttpVideoUploadApi> logger)
+    public HttpVideoUploadApi(
+        HttpClient httpClient,
+        ILogger<HttpVideoUploadApi> logger,
+        IUploadControlPlaneSessionStore sessionStore)
     {
         _httpClient = httpClient;
         _logger = logger;
+        _sessionStore = sessionStore;
     }
 
     public async Task<VideoPreUploadCheckResponseDto> CheckPreUploadAsync(
@@ -40,18 +48,20 @@ public sealed class HttpVideoUploadApi : IVideoUploadApi
 
         try
         {
-            using var response = await _httpClient.PostAsJsonAsync(
+            using var httpRequest = await CreateJsonRequestAsync(
+                HttpMethod.Post,
                 UploadApiEndpoints.PreUploadCheck,
                 request,
-                JsonOptions,
                 cancellationToken);
 
-            return await ReadRequiredJsonAsync<VideoPreUploadCheckResponseDto>(
+            using var response = await _httpClient.SendAsync(httpRequest, cancellationToken);
+
+            return await ReadJsonOrThrowAsync<VideoPreUploadCheckResponseDto>(
                 response,
                 UploadApiEndpoints.PreUploadCheck,
                 cancellationToken);
         }
-        catch (Exception exception) when (exception is not OperationCanceledException)
+        catch (Exception exception) when (exception is not HttpRequestException)
         {
             LogPreUploadCheckApiCallFailed(_logger, exception);
             throw;
@@ -66,38 +76,76 @@ public sealed class HttpVideoUploadApi : IVideoUploadApi
 
         try
         {
-            using var response = await _httpClient.PostAsJsonAsync(
+            using var httpRequest = await CreateJsonRequestAsync(
+                HttpMethod.Post,
                 UploadApiEndpoints.UploadReceipt,
                 request,
-                JsonOptions,
                 cancellationToken);
 
-            return await ReadRequiredJsonAsync<VideoUploadReceiptResponseDto>(
+            using var response = await _httpClient.SendAsync(httpRequest, cancellationToken);
+
+            return await ReadJsonOrThrowAsync<VideoUploadReceiptResponseDto>(
                 response,
                 UploadApiEndpoints.UploadReceipt,
                 cancellationToken);
         }
-        catch (Exception exception) when (exception is not OperationCanceledException)
+        catch (Exception exception) when (exception is not HttpRequestException)
         {
             LogUploadReceiptApiCallFailed(_logger, exception);
             throw;
         }
     }
 
-    private static async Task<TResponse> ReadRequiredJsonAsync<TResponse>(
+    private async Task<HttpRequestMessage> CreateJsonRequestAsync<T>(
+        HttpMethod method,
+        string endpoint,
+        T payload,
+        CancellationToken cancellationToken)
+    {
+        var request = new HttpRequestMessage(method, endpoint)
+        {
+            Content = JsonContent.Create(payload, options: JsonOptions)
+        };
+
+        var session = await _sessionStore.GetAsync(cancellationToken);
+
+        if (session is not null && !string.IsNullOrWhiteSpace(session.AccessToken))
+        {
+            request.Headers.Authorization = new AuthenticationHeaderValue(
+                "Bearer",
+                session.AccessToken);
+        }
+
+        return request;
+    }
+
+    private static async Task<T> ReadJsonOrThrowAsync<T>(
         HttpResponseMessage response,
         string endpoint,
         CancellationToken cancellationToken)
-        where TResponse : class
     {
         if (!response.IsSuccessStatusCode)
         {
-            var body = await response.Content.ReadAsStringAsync(cancellationToken);
-            var message = $"Upload API call to {endpoint} failed with HTTP {(int)response.StatusCode} {response.ReasonPhrase}: {body}";
-            throw new HttpRequestException(message, null, response.StatusCode);
+            var rawBody = await response.Content.ReadAsStringAsync(cancellationToken);
+            var sanitizedBody = UploadControlPlaneErrorRedactor.Redact(rawBody);
+            var statusCode = (int)response.StatusCode;
+
+            throw new HttpRequestException(
+                $"Upload API request failed for {endpoint}. Status={statusCode}. Body={sanitizedBody}",
+                inner: null,
+                response.StatusCode);
         }
 
-        var result = await response.Content.ReadFromJsonAsync<TResponse>(JsonOptions, cancellationToken);
-        return result ?? throw new InvalidOperationException($"Upload API call to {endpoint} returned an empty response body.");
+        var payload = await response.Content.ReadFromJsonAsync<T>(
+            JsonOptions,
+            cancellationToken);
+
+        if (payload is not null)
+        {
+            return payload;
+        }
+
+        throw new InvalidOperationException(
+            $"Upload API response for {endpoint} was empty.");
     }
 }

--- a/src/App.Web/Features/Upload/ControlPlane/HttpUploadControlPlaneApi.cs
+++ b/src/App.Web/Features/Upload/ControlPlane/HttpUploadControlPlaneApi.cs
@@ -1,0 +1,127 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+using Microsoft.Extensions.Logging;
+
+namespace App.Web.Features.Upload.ControlPlane;
+
+public sealed class HttpUploadControlPlaneApi : IUploadControlPlaneApi
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    private static readonly Action<ILogger, string, int, Exception?> LogControlPlaneRequestFailed =
+        LoggerMessage.Define<string, int>(
+            LogLevel.Error,
+            new EventId(3001, nameof(LogControlPlaneRequestFailed)),
+            "Upload control plane request failed for {Endpoint} with HTTP status {StatusCode}.");
+
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<HttpUploadControlPlaneApi> _logger;
+
+    public HttpUploadControlPlaneApi(
+        HttpClient httpClient,
+        ILogger<HttpUploadControlPlaneApi> logger)
+    {
+        _httpClient = httpClient;
+        _logger = logger;
+    }
+
+    public async Task<UploadControlPlaneSignInResponse> SignInAsync(
+        UploadControlPlaneSignInRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        using var response = await _httpClient.PostAsJsonAsync(
+            UploadControlPlaneEndpoints.SignIn,
+            request,
+            JsonOptions,
+            cancellationToken);
+
+        return await ReadJsonOrThrowAsync<UploadControlPlaneSignInResponse>(
+            response,
+            UploadControlPlaneEndpoints.SignIn,
+            cancellationToken);
+    }
+
+    public async Task<UploadControlPlaneSignInResponse> RefreshAsync(
+        UploadControlPlaneRefreshRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        using var response = await _httpClient.PostAsJsonAsync(
+            UploadControlPlaneEndpoints.Refresh,
+            request,
+            JsonOptions,
+            cancellationToken);
+
+        return await ReadJsonOrThrowAsync<UploadControlPlaneSignInResponse>(
+            response,
+            UploadControlPlaneEndpoints.Refresh,
+            cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<UploadControlPlaneGroupNode>> GetGroupTreeNodesAsync(
+        string accessToken,
+        CancellationToken cancellationToken = default)
+    {
+        using var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            UploadControlPlaneEndpoints.GroupTreeNodes);
+
+        request.Headers.Authorization = new AuthenticationHeaderValue(
+            "Bearer",
+            RequiredToken(accessToken));
+
+        using var response = await _httpClient.SendAsync(request, cancellationToken);
+
+        return await ReadJsonOrThrowAsync<IReadOnlyList<UploadControlPlaneGroupNode>>(
+            response,
+            UploadControlPlaneEndpoints.GroupTreeNodes,
+            cancellationToken);
+    }
+
+    private async Task<T> ReadJsonOrThrowAsync<T>(
+        HttpResponseMessage response,
+        string endpoint,
+        CancellationToken cancellationToken)
+    {
+        if (!response.IsSuccessStatusCode)
+        {
+            var rawBody = await response.Content.ReadAsStringAsync(cancellationToken);
+            var sanitizedBody = UploadControlPlaneErrorRedactor.Redact(rawBody);
+            var statusCode = (int)response.StatusCode;
+
+            LogControlPlaneRequestFailed(_logger, endpoint, statusCode, null);
+
+            throw new HttpRequestException(
+                $"Upload control plane request failed for {endpoint}. Status={statusCode}. Body={sanitizedBody}",
+                inner: null,
+                response.StatusCode);
+        }
+
+        var payload = await response.Content.ReadFromJsonAsync<T>(
+            JsonOptions,
+            cancellationToken);
+
+        if (payload is not null)
+        {
+            return payload;
+        }
+
+        throw new InvalidOperationException(
+            $"Upload control plane response for {endpoint} was empty.");
+    }
+
+    private static string RequiredToken(string accessToken)
+    {
+        if (!string.IsNullOrWhiteSpace(accessToken))
+        {
+            return accessToken;
+        }
+
+        throw new InvalidOperationException("Access token is required for upload control plane request.");
+    }
+}

--- a/src/App.Web/Features/Upload/ControlPlane/IUploadControlPlaneApi.cs
+++ b/src/App.Web/Features/Upload/ControlPlane/IUploadControlPlaneApi.cs
@@ -1,0 +1,16 @@
+namespace App.Web.Features.Upload.ControlPlane;
+
+public interface IUploadControlPlaneApi
+{
+    Task<UploadControlPlaneSignInResponse> SignInAsync(
+        UploadControlPlaneSignInRequest request,
+        CancellationToken cancellationToken = default);
+
+    Task<UploadControlPlaneSignInResponse> RefreshAsync(
+        UploadControlPlaneRefreshRequest request,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<UploadControlPlaneGroupNode>> GetGroupTreeNodesAsync(
+        string accessToken,
+        CancellationToken cancellationToken = default);
+}

--- a/src/App.Web/Features/Upload/ControlPlane/IUploadControlPlaneSessionStore.cs
+++ b/src/App.Web/Features/Upload/ControlPlane/IUploadControlPlaneSessionStore.cs
@@ -1,0 +1,12 @@
+namespace App.Web.Features.Upload.ControlPlane;
+
+public interface IUploadControlPlaneSessionStore
+{
+    ValueTask SetAsync(
+        UploadControlPlaneSession session,
+        CancellationToken cancellationToken = default);
+
+    ValueTask<UploadControlPlaneSession?> GetAsync(CancellationToken cancellationToken = default);
+
+    ValueTask ClearAsync(CancellationToken cancellationToken = default);
+}

--- a/src/App.Web/Features/Upload/ControlPlane/InMemoryUploadControlPlaneSessionStore.cs
+++ b/src/App.Web/Features/Upload/ControlPlane/InMemoryUploadControlPlaneSessionStore.cs
@@ -1,0 +1,34 @@
+namespace App.Web.Features.Upload.ControlPlane;
+
+public sealed class InMemoryUploadControlPlaneSessionStore : IUploadControlPlaneSessionStore
+{
+    private UploadControlPlaneSession? _session;
+
+    public ValueTask SetAsync(
+        UploadControlPlaneSession session,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        _session = session;
+
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask<UploadControlPlaneSession?> GetAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return ValueTask.FromResult(_session);
+    }
+
+    public ValueTask ClearAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        _session = null;
+
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/App.Web/Features/Upload/ControlPlane/UploadControlPlaneEndpoints.cs
+++ b/src/App.Web/Features/Upload/ControlPlane/UploadControlPlaneEndpoints.cs
@@ -1,0 +1,12 @@
+namespace App.Web.Features.Upload.ControlPlane;
+
+public static class UploadControlPlaneEndpoints
+{
+    public const string SignIn = "/api/auth/sign-in";
+
+    public const string Refresh = "/api/auth/refresh";
+
+    public const string GroupTreeNodes = "/api/group-tree/nodes";
+
+    public const string GroupTreeRoutingPreview = "/api/group-tree/routing-preview";
+}

--- a/src/App.Web/Features/Upload/ControlPlane/UploadControlPlaneErrorRedactor.cs
+++ b/src/App.Web/Features/Upload/ControlPlane/UploadControlPlaneErrorRedactor.cs
@@ -1,0 +1,32 @@
+using System.Text.RegularExpressions;
+
+namespace App.Web.Features.Upload.ControlPlane;
+
+public static partial class UploadControlPlaneErrorRedactor
+{
+    private const int MaxSanitizedLength = 2048;
+
+    public static string Redact(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return string.Empty;
+        }
+
+        var sanitized = SensitiveJsonPropertyRegex().Replace(value, "$1***REDACTED***$2");
+        sanitized = BearerTokenRegex().Replace(sanitized, "Bearer ***REDACTED***");
+
+        if (sanitized.Length <= MaxSanitizedLength)
+        {
+            return sanitized;
+        }
+
+        return sanitized[..MaxSanitizedLength] + "...";
+    }
+
+    [GeneratedRegex("""(?i)("(?:accessToken|refreshToken|password|token)"\s*:\s*")[^"]*(")""")]
+    private static partial Regex SensitiveJsonPropertyRegex();
+
+    [GeneratedRegex(@"(?i)\bBearer\s+[A-Za-z0-9\-._~+/]+=*")]
+    private static partial Regex BearerTokenRegex();
+}

--- a/src/App.Web/Features/Upload/ControlPlane/UploadControlPlaneModels.cs
+++ b/src/App.Web/Features/Upload/ControlPlane/UploadControlPlaneModels.cs
@@ -1,0 +1,83 @@
+namespace App.Web.Features.Upload.ControlPlane;
+
+public sealed class UploadControlPlaneSignInRequest
+{
+    public string Login { get; init; } = string.Empty;
+
+    public string Password { get; init; } = string.Empty;
+}
+
+public sealed class UploadControlPlaneRefreshRequest
+{
+    public string RefreshToken { get; init; } = string.Empty;
+}
+
+public sealed class UploadControlPlaneUserSummary
+{
+    public Guid? UserId { get; init; }
+
+    public string? DisplayName { get; init; }
+
+    public IReadOnlyList<string> Roles { get; init; } = Array.Empty<string>();
+
+    public IReadOnlyList<string> Permissions { get; init; } = Array.Empty<string>();
+}
+
+public sealed class UploadControlPlaneSignInResponse
+{
+    public string? AccessToken { get; init; }
+
+    public string? RefreshToken { get; init; }
+
+    public Guid? UserId { get; init; }
+
+    public string? DisplayName { get; init; }
+
+    public IReadOnlyList<string> Roles { get; init; } = Array.Empty<string>();
+
+    public IReadOnlyList<string> Permissions { get; init; } = Array.Empty<string>();
+
+    public UploadControlPlaneUserSummary? User { get; init; }
+
+    public Guid? EffectiveUserId => User?.UserId ?? UserId;
+
+    public string? EffectiveDisplayName => User?.DisplayName ?? DisplayName;
+}
+
+public sealed class UploadControlPlaneGroupNode
+{
+    public Guid? Id { get; init; }
+
+    public Guid? ParentId { get; init; }
+
+    public string? Name { get; init; }
+
+    public string? Code { get; init; }
+
+    public string? Path { get; init; }
+
+    public bool? IsSelectable { get; init; }
+}
+
+public sealed record UploadControlPlaneSession(
+    Guid? UserId,
+    string? DisplayName,
+    string AccessToken,
+    string? RefreshToken,
+    DateTimeOffset CreatedAtUtc)
+{
+    public UploadControlPlaneSanitizedSession ToSanitized() =>
+        new(
+            UserId,
+            DisplayName,
+            HasAccessToken: !string.IsNullOrWhiteSpace(AccessToken),
+            HasRefreshToken: !string.IsNullOrWhiteSpace(RefreshToken),
+            CreatedAtUtc);
+}
+
+public sealed record UploadControlPlaneSanitizedSession(
+    Guid? UserId,
+    string? DisplayName,
+    bool HasAccessToken,
+    bool HasRefreshToken,
+    DateTimeOffset CreatedAtUtc);

--- a/src/App.Web/Features/Upload/ControlPlane/UploadControlPlaneSessionFactory.cs
+++ b/src/App.Web/Features/Upload/ControlPlane/UploadControlPlaneSessionFactory.cs
@@ -1,0 +1,40 @@
+namespace App.Web.Features.Upload.ControlPlane;
+
+public static class UploadControlPlaneSessionFactory
+{
+    public static UploadControlPlaneSignInRequest CreateSignInRequest(
+        UploadControlPlaneSignInFormModel form)
+    {
+        ArgumentNullException.ThrowIfNull(form);
+
+        return new UploadControlPlaneSignInRequest
+        {
+            Login = Required(form.Login, nameof(form.Login)),
+            Password = Required(form.Password, nameof(form.Password))
+        };
+    }
+
+    public static UploadControlPlaneSession CreateSession(
+        UploadControlPlaneSignInResponse response,
+        DateTimeOffset createdAtUtc)
+    {
+        ArgumentNullException.ThrowIfNull(response);
+
+        return new UploadControlPlaneSession(
+            response.EffectiveUserId,
+            response.EffectiveDisplayName,
+            Required(response.AccessToken, nameof(response.AccessToken)),
+            response.RefreshToken,
+            createdAtUtc);
+    }
+
+    private static string Required(string? value, string fieldName)
+    {
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            return value.Trim();
+        }
+
+        throw new InvalidOperationException($"{fieldName} is required.");
+    }
+}

--- a/src/App.Web/Features/Upload/ControlPlane/UploadControlPlaneSignInFormModel.cs
+++ b/src/App.Web/Features/Upload/ControlPlane/UploadControlPlaneSignInFormModel.cs
@@ -1,0 +1,8 @@
+namespace App.Web.Features.Upload.ControlPlane;
+
+public sealed class UploadControlPlaneSignInFormModel
+{
+    public string Login { get; set; } = string.Empty;
+
+    public string Password { get; set; } = string.Empty;
+}

--- a/src/App.Web/Features/Upload/Pages/UploadPage.razor
+++ b/src/App.Web/Features/Upload/Pages/UploadPage.razor
@@ -10,7 +10,7 @@
 
     <div class="alert alert-info" role="alert">
         This screen uses the backend as a control plane only. Video bytes must not be sent through App.Api.
-        The direct site upload adapter remains an explicit local/client boundary until a real site provider is configured.
+        The direct site upload adapter is currently an explicit local/client stub boundary until a real site provider is configured.
     </div>
 
     <section class="card border-0 shadow-sm mb-4">
@@ -209,7 +209,7 @@
                 }
 
                 <button type="button" class="btn btn-outline-primary" disabled="@(!CanRunDirectUploadBoundary)" @onclick="RunDirectSiteUploadBoundaryAsync">
-                    Run direct site upload adapter boundary
+                    Run local direct-site upload stub boundary
                 </button>
             </div>
         </div>
@@ -228,6 +228,7 @@
         <div class="card border-0 shadow-sm mt-3">
             <div class="card-body d-grid gap-2">
                 <div class="fw-semibold">UploadReceipt boundary payload</div>
+                <div class="text-body-secondary small">Submitting again reuses the same idempotency key until the result is cleared.</div>
 
                 <dl class="row mb-0">
                     <dt class="col-12 col-md-4">PreUploadCheckId</dt>

--- a/src/App.Web/Features/Upload/Pages/UploadPage.razor
+++ b/src/App.Web/Features/Upload/Pages/UploadPage.razor
@@ -1,20 +1,117 @@
 @page "/upload"
+@using global::App.Web.Features.Upload.ControlPlane
 @using Microsoft.AspNetCore.Components.Forms
 
 <div class="container py-4">
     <div class="mb-4">
         <h1 class="h3">Upload</h1>
-        <p class="text-body-secondary mb-0">Pre-upload check, direct site upload boundary, and upload receipt boundary.</p>
+        <p class="text-body-secondary mb-0">Control plane sign-in, group selection, PreUploadCheck, direct site upload boundary, and UploadReceipt boundary.</p>
     </div>
 
     <div class="alert alert-info" role="alert">
-        This screen runs PreUploadCheck and prepares UploadReceipt only after a direct site upload adapter reports success.
-        The registered direct upload adapter is still disabled in this bounded step.
+        This screen uses the backend as a control plane only. Video bytes must not be sent through App.Api.
+        The direct site upload adapter remains an explicit local/client boundary until a real site provider is configured.
     </div>
+
+    <section class="card border-0 shadow-sm mb-4">
+        <div class="card-body">
+            <h2 class="h5">Control plane session</h2>
+            <p class="text-body-secondary">
+                Sign in stores a temporary in-memory session for this page flow. Token values are never displayed.
+            </p>
+
+            <EditForm Model="_signInForm" OnValidSubmit="SignInControlPlaneAsync">
+                <div class="row g-3">
+                    <div class="col-12 col-lg-4">
+                        <label class="form-label" for="control-plane-login">Login</label>
+                        <InputText id="control-plane-login" class="form-control" @bind-Value="_signInForm.Login" autocomplete="username" />
+                    </div>
+
+                    <div class="col-12 col-lg-4">
+                        <label class="form-label" for="control-plane-password">Password</label>
+                        <input id="control-plane-password" type="password" class="form-control" @bind="_signInForm.Password" autocomplete="current-password" />
+                    </div>
+
+                    <div class="col-12 col-lg-4 d-flex align-items-end gap-2">
+                        <button type="submit" class="btn btn-primary" disabled="@_isControlPlaneSubmitting">
+                            @(_isControlPlaneSubmitting ? "Signing in..." : "Sign in")
+                        </button>
+
+                        <button type="button" class="btn btn-outline-secondary" @onclick="ClearControlPlaneSessionAsync" disabled="@_isControlPlaneSubmitting">
+                            Clear
+                        </button>
+                    </div>
+                </div>
+            </EditForm>
+
+            @if (_sessionSummary is not null)
+            {
+                <div class="alert alert-success mt-3" role="alert">
+                    <div class="fw-semibold">Session ready</div>
+                    <div>UserId: @_sessionSummary.UserId</div>
+                    <div>DisplayName: @_sessionSummary.DisplayName</div>
+                    <div>Access token available: @_sessionSummary.HasAccessToken</div>
+                    <div>Refresh token available: @_sessionSummary.HasRefreshToken</div>
+                </div>
+
+                <button type="button" class="btn btn-outline-primary" @onclick="LoadGroupTreeNodesAsync" disabled="@_isControlPlaneSubmitting">
+                    Load group tree
+                </button>
+            }
+
+            @if (!string.IsNullOrWhiteSpace(_controlPlaneMessage))
+            {
+                <div class="alert alert-info mt-3" role="alert">@_controlPlaneMessage</div>
+            }
+
+            @if (!string.IsNullOrWhiteSpace(_controlPlaneErrorMessage))
+            {
+                <div class="alert alert-danger mt-3" role="alert">
+                    <div class="fw-semibold">Control plane step failed</div>
+                    <div>@_controlPlaneErrorMessage</div>
+                </div>
+            }
+
+            @if (_groupNodes.Count > 0)
+            {
+                <div class="table-responsive mt-3">
+                    <table class="table table-sm align-middle">
+                        <thead>
+                            <tr>
+                                <th>Name</th>
+                                <th>Code</th>
+                                <th>Path</th>
+                                <th>Selectable</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var node in _groupNodes)
+                            {
+                                <tr>
+                                    <td>@node.Name</td>
+                                    <td>@node.Code</td>
+                                    <td>@node.Path</td>
+                                    <td>@node.IsSelectable</td>
+                                    <td>
+                                        <button type="button" class="btn btn-sm btn-outline-secondary" disabled="@(!node.Id.HasValue)" @onclick="() => UseGroupNode(node)">
+                                            Use
+                                        </button>
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+            }
+        </div>
+    </section>
 
     <EditForm Model="_form" OnValidSubmit="RunPreUploadCheckAsync">
         <div class="card border-0 shadow-sm">
             <div class="card-body">
+                <h2 class="h5">PreUploadCheck</h2>
+
                 <div class="row g-3">
                     <div class="col-12 col-lg-4">
                         <label class="form-label" for="upload-user-id">UserId</label>

--- a/src/App.Web/Features/Upload/Pages/UploadPage.razor.cs
+++ b/src/App.Web/Features/Upload/Pages/UploadPage.razor.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 
 using App.Web.Features.Upload.Api;
+using App.Web.Features.Upload.ControlPlane;
 using App.Web.Features.Upload.Models;
 using App.Web.Features.Upload.Presentation;
 using App.Web.Features.Upload.SiteGateway;
@@ -50,6 +51,18 @@ public partial class UploadPage
             new EventId(2006, nameof(LogUploadReceiptSubmissionFailed)),
             "Upload receipt submission failed.");
 
+    private static readonly Action<ILogger, Exception?> LogControlPlaneSignInFailed =
+        LoggerMessage.Define(
+            LogLevel.Error,
+            new EventId(2101, nameof(LogControlPlaneSignInFailed)),
+            "Upload control plane sign-in failed.");
+
+    private static readonly Action<ILogger, Exception?> LogControlPlaneGroupTreeLoadFailed =
+        LoggerMessage.Define(
+            LogLevel.Error,
+            new EventId(2102, nameof(LogControlPlaneGroupTreeLoadFailed)),
+            "Upload control plane group tree load failed.");
+
     private readonly UploadPreCheckFormModel _form = new()
     {
         UserId = "11111111-1111-1111-1111-111111111111",
@@ -63,20 +76,33 @@ public partial class UploadPage
         CapturedAtUtc = "2026-04-20T12:00:00Z"
     };
 
+    private readonly UploadControlPlaneSignInFormModel _signInForm = new();
+
     private bool _isSubmitting;
+    private bool _isControlPlaneSubmitting;
     private string? _errorMessage;
+    private string? _controlPlaneMessage;
+    private string? _controlPlaneErrorMessage;
     private VideoPreUploadCheckResponseDto? _preUploadResponse;
     private UploadDecisionPresentationModel? _decisionModel;
     private DirectSiteVideoUploadResult? _directUploadResult;
     private UploadReceiptFormModel? _receiptForm;
     private VideoUploadReceiptResponseDto? _receiptResponse;
     private UploadReceiptPresentationModel? _receiptModel;
+    private UploadControlPlaneSanitizedSession? _sessionSummary;
+    private IReadOnlyList<UploadControlPlaneGroupNode> _groupNodes = Array.Empty<UploadControlPlaneGroupNode>();
 
     [Inject]
     public IVideoUploadApi VideoUploadApi { get; set; } = default!;
 
     [Inject]
     public IDirectSiteVideoUploadAdapter DirectSiteVideoUploadAdapter { get; set; } = default!;
+
+    [Inject]
+    public IUploadControlPlaneApi UploadControlPlaneApi { get; set; } = default!;
+
+    [Inject]
+    public IUploadControlPlaneSessionStore SessionStore { get; set; } = default!;
 
     [Inject]
     public ILogger<UploadPage> Logger { get; set; } = default!;
@@ -90,6 +116,95 @@ public partial class UploadPage
         !_isSubmitting &&
         _receiptForm is not null &&
         _directUploadResult?.Succeeded == true;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadStoredSessionSummaryAsync();
+    }
+
+    private async Task SignInControlPlaneAsync()
+    {
+        _isControlPlaneSubmitting = true;
+        _controlPlaneMessage = null;
+        _controlPlaneErrorMessage = null;
+
+        try
+        {
+            var request = UploadControlPlaneSessionFactory.CreateSignInRequest(_signInForm);
+            var response = await UploadControlPlaneApi.SignInAsync(request);
+            var session = UploadControlPlaneSessionFactory.CreateSession(
+                response,
+                DateTimeOffset.UtcNow);
+
+            await SessionStore.SetAsync(session);
+            _sessionSummary = session.ToSanitized();
+            _controlPlaneMessage = "Control plane session is ready. Token values are hidden.";
+        }
+        catch (Exception exception)
+        {
+            LogControlPlaneSignInFailed(Logger, exception);
+            _controlPlaneErrorMessage = SafeMessage(exception);
+        }
+        finally
+        {
+            _signInForm.Password = string.Empty;
+            _isControlPlaneSubmitting = false;
+        }
+    }
+
+    private async Task LoadGroupTreeNodesAsync()
+    {
+        _isControlPlaneSubmitting = true;
+        _controlPlaneMessage = null;
+        _controlPlaneErrorMessage = null;
+
+        try
+        {
+            var session = await SessionStore.GetAsync();
+
+            if (session is null || string.IsNullOrWhiteSpace(session.AccessToken))
+            {
+                _controlPlaneErrorMessage = "Control plane session is required before group tree load.";
+                return;
+            }
+
+            _groupNodes = await UploadControlPlaneApi.GetGroupTreeNodesAsync(session.AccessToken);
+            _controlPlaneMessage = $"{_groupNodes.Count} group tree nodes loaded.";
+        }
+        catch (Exception exception)
+        {
+            LogControlPlaneGroupTreeLoadFailed(Logger, exception);
+            _controlPlaneErrorMessage = SafeMessage(exception);
+        }
+        finally
+        {
+            _isControlPlaneSubmitting = false;
+        }
+    }
+
+    private void UseGroupNode(UploadControlPlaneGroupNode node)
+    {
+        if (!node.Id.HasValue)
+        {
+            _controlPlaneErrorMessage = "Selected group node does not have an id.";
+            return;
+        }
+
+        _form.GroupNodeId = node.Id.Value.ToString();
+        _controlPlaneMessage = $"GroupNodeId selected: {_form.GroupNodeId}";
+        _controlPlaneErrorMessage = null;
+    }
+
+    private async Task ClearControlPlaneSessionAsync()
+    {
+        await SessionStore.ClearAsync();
+
+        _sessionSummary = null;
+        _groupNodes = Array.Empty<UploadControlPlaneGroupNode>();
+        _controlPlaneMessage = "Control plane session cleared.";
+        _controlPlaneErrorMessage = null;
+        _signInForm.Password = string.Empty;
+    }
 
     private async Task RunPreUploadCheckAsync()
     {
@@ -118,8 +233,7 @@ public partial class UploadPage
         catch (Exception exception)
         {
             LogUploadScreenPreUploadCheckFailed(Logger, exception);
-
-            _errorMessage = exception.Message;
+            _errorMessage = SafeMessage(exception);
         }
         finally
         {
@@ -168,8 +282,7 @@ public partial class UploadPage
         catch (Exception exception)
         {
             LogDirectSiteUploadAdapterBoundaryFailed(Logger, exception);
-
-            _errorMessage = exception.Message;
+            _errorMessage = SafeMessage(exception);
         }
         finally
         {
@@ -206,8 +319,7 @@ public partial class UploadPage
         catch (Exception exception)
         {
             LogUploadReceiptSubmissionFailed(Logger, exception);
-
-            _errorMessage = exception.Message;
+            _errorMessage = SafeMessage(exception);
         }
         finally
         {
@@ -246,6 +358,15 @@ public partial class UploadPage
         _receiptResponse = null;
         _receiptModel = null;
     }
+
+    private async Task LoadStoredSessionSummaryAsync()
+    {
+        var session = await SessionStore.GetAsync();
+        _sessionSummary = session?.ToSanitized();
+    }
+
+    private static string SafeMessage(Exception exception) =>
+        UploadControlPlaneErrorRedactor.Redact(exception.Message);
 
     private static string AlertClass(string tone) => tone switch
     {

--- a/src/App.Web/Features/Upload/SiteGateway/LocalStubDirectSiteVideoUploadAdapter.cs
+++ b/src/App.Web/Features/Upload/SiteGateway/LocalStubDirectSiteVideoUploadAdapter.cs
@@ -1,0 +1,78 @@
+using System.Globalization;
+
+using Microsoft.Extensions.Logging;
+
+namespace App.Web.Features.Upload.SiteGateway;
+
+public sealed class LocalStubDirectSiteVideoUploadAdapter : IDirectSiteVideoUploadAdapter
+{
+    public const string LocalStubSiteStatus = "uploaded";
+
+    private static readonly Action<ILogger, Guid, Exception?> LogLocalStubCompleted =
+        LoggerMessage.Define<Guid>(
+            LogLevel.Information,
+            new EventId(4001, nameof(LogLocalStubCompleted)),
+            "Local direct-site upload stub completed for pre-upload check {PreUploadCheckId}. No video bytes were sent through App.Api.");
+
+    private readonly ILogger<LocalStubDirectSiteVideoUploadAdapter> _logger;
+
+    public LocalStubDirectSiteVideoUploadAdapter(
+        ILogger<LocalStubDirectSiteVideoUploadAdapter> logger)
+    {
+        _logger = logger;
+    }
+
+    public Task<DirectSiteVideoUploadResult> UploadAsync(
+        DirectSiteVideoUploadDraft draft,
+        Stream content,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(draft);
+        ArgumentNullException.ThrowIfNull(content);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!content.CanRead)
+        {
+            return Task.FromResult(new DirectSiteVideoUploadResult(
+                IsConfigured: true,
+                Succeeded: false,
+                ExternalVideoId: null,
+                StorageKey: null,
+                SiteStatus: null,
+                Message: "Local direct-site upload stub requires a readable content stream."));
+        }
+
+        var suffix = draft.PreUploadCheckId.ToString("N");
+        var safeFileName = SafeFileName(draft.FileName);
+
+        LogLocalStubCompleted(_logger, draft.PreUploadCheckId, null);
+
+        return Task.FromResult(new DirectSiteVideoUploadResult(
+            IsConfigured: true,
+            Succeeded: true,
+            ExternalVideoId: string.Create(CultureInfo.InvariantCulture, $"local-stub-{suffix}"),
+            StorageKey: string.Create(CultureInfo.InvariantCulture, $"local-stub/{suffix}/{safeFileName}"),
+            SiteStatus: LocalStubSiteStatus,
+            Message: "Local direct-site upload stub completed. No video bytes were sent through App.Api."));
+    }
+
+    private static string SafeFileName(string? fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            return "video.bin";
+        }
+
+        var invalid = Path.GetInvalidFileNameChars();
+        var sanitizedChars = fileName
+            .Trim()
+            .Select(character => invalid.Contains(character) ? '-' : character)
+            .ToArray();
+
+        var sanitized = new string(sanitizedChars);
+
+        return string.IsNullOrWhiteSpace(sanitized)
+            ? "video.bin"
+            : sanitized;
+    }
+}

--- a/src/App.Web/Program.cs
+++ b/src/App.Web/Program.cs
@@ -1,3 +1,4 @@
+using App.Web.Features.Upload.ControlPlane;
 using App.Web.Features.Upload.SiteGateway;
 using App.Web.Features.Upload.Api;
 using Microsoft.AspNetCore.Components.Web;
@@ -12,6 +13,8 @@ builder.RootComponents.Add<HeadOutlet>("head::after");
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 
 builder.Services.AddScoped<IVideoUploadApi, HttpVideoUploadApi>();
+builder.Services.AddScoped<IUploadControlPlaneApi, HttpUploadControlPlaneApi>();
+builder.Services.AddScoped<IUploadControlPlaneSessionStore, InMemoryUploadControlPlaneSessionStore>();
 builder.Services.AddScoped<IDirectSiteVideoUploadAdapter, DisabledDirectSiteVideoUploadAdapter>();
 
 await builder.Build().RunAsync();

--- a/src/App.Web/Program.cs
+++ b/src/App.Web/Program.cs
@@ -15,6 +15,6 @@ builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.
 builder.Services.AddScoped<IVideoUploadApi, HttpVideoUploadApi>();
 builder.Services.AddScoped<IUploadControlPlaneApi, HttpUploadControlPlaneApi>();
 builder.Services.AddScoped<IUploadControlPlaneSessionStore, InMemoryUploadControlPlaneSessionStore>();
-builder.Services.AddScoped<IDirectSiteVideoUploadAdapter, DisabledDirectSiteVideoUploadAdapter>();
+builder.Services.AddScoped<IDirectSiteVideoUploadAdapter, LocalStubDirectSiteVideoUploadAdapter>();
 
 await builder.Build().RunAsync();

--- a/tests/Unit/App.Web.Tests/DirectSiteVideoUploadAdapterTests.cs
+++ b/tests/Unit/App.Web.Tests/DirectSiteVideoUploadAdapterTests.cs
@@ -7,7 +7,7 @@ namespace App.Web.Tests;
 public sealed class DirectSiteVideoUploadAdapterTests
 {
     [Fact]
-    public async Task Disabled_adapter_does_not_claim_production_site_upload_success()
+    public async Task DisabledAdapterDoesNotClaimProductionSiteUploadSuccess()
     {
         var adapter = new DisabledDirectSiteVideoUploadAdapter();
         var draft = new DirectSiteVideoUploadDraft(
@@ -30,7 +30,7 @@ public sealed class DirectSiteVideoUploadAdapterTests
     }
 
     [Fact]
-    public async Task Disabled_adapter_still_validates_that_stream_is_readable()
+    public async Task DisabledAdapterStillValidatesThatStreamIsReadable()
     {
         var adapter = new DisabledDirectSiteVideoUploadAdapter();
         var draft = new DirectSiteVideoUploadDraft(

--- a/tests/Unit/App.Web.Tests/HttpVideoUploadApiAuthorizationTests.cs
+++ b/tests/Unit/App.Web.Tests/HttpVideoUploadApiAuthorizationTests.cs
@@ -1,0 +1,208 @@
+using System.Globalization;
+using System.Net;
+using System.Text.Json;
+
+using App.Web.Features.Upload.Api;
+using App.Web.Features.Upload.ControlPlane;
+
+using BuildingBlocks.Contracts.VideoUpload;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Xunit;
+
+namespace App.Web.Tests;
+
+public sealed class HttpVideoUploadApiAuthorizationTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    [Fact]
+    public async Task CheckPreUploadAddsBearerHeaderWhenSessionExists()
+    {
+        var handler = new CapturingHandler(CreatePreUploadResponse());
+        var sessionStore = new InMemoryUploadControlPlaneSessionStore();
+        await sessionStore.SetAsync(CreateSession());
+
+        var api = new HttpVideoUploadApi(
+            new HttpClient(handler)
+            {
+                BaseAddress = new Uri("https://api.example.test/")
+            },
+            NullLogger<HttpVideoUploadApi>.Instance,
+            sessionStore);
+
+        await api.CheckPreUploadAsync(CreatePreUploadRequest());
+
+        Assert.Equal("Bearer", handler.LastRequest?.Headers.Authorization?.Scheme);
+        Assert.Equal("alpha-sensitive-value", handler.LastRequest?.Headers.Authorization?.Parameter);
+    }
+
+    [Fact]
+    public async Task SubmitUploadReceiptAddsBearerHeaderWhenSessionExists()
+    {
+        var handler = new CapturingHandler(CreateReceiptResponse());
+        var sessionStore = new InMemoryUploadControlPlaneSessionStore();
+        await sessionStore.SetAsync(CreateSession());
+
+        var api = new HttpVideoUploadApi(
+            new HttpClient(handler)
+            {
+                BaseAddress = new Uri("https://api.example.test/")
+            },
+            NullLogger<HttpVideoUploadApi>.Instance,
+            sessionStore);
+
+        await api.SubmitUploadReceiptAsync(CreateReceiptRequest());
+
+        Assert.Equal("Bearer", handler.LastRequest?.Headers.Authorization?.Scheme);
+        Assert.Equal("alpha-sensitive-value", handler.LastRequest?.Headers.Authorization?.Parameter);
+    }
+
+    [Fact]
+    public async Task CheckPreUploadDoesNotAddBearerHeaderWhenSessionIsMissing()
+    {
+        var handler = new CapturingHandler(CreatePreUploadResponse());
+        var api = new HttpVideoUploadApi(
+            new HttpClient(handler)
+            {
+                BaseAddress = new Uri("https://api.example.test/")
+            },
+            NullLogger<HttpVideoUploadApi>.Instance,
+            new InMemoryUploadControlPlaneSessionStore());
+
+        await api.CheckPreUploadAsync(CreatePreUploadRequest());
+
+        Assert.Null(handler.LastRequest?.Headers.Authorization);
+    }
+
+    [Fact]
+    public async Task ErrorBodyIsRedactedBeforeExceptionMessageIsSurfaced()
+    {
+        var handler = new FailingHandler("""
+            {
+                "accessToken": "alpha-sensitive-value",
+                "refreshToken": "beta-sensitive-value"
+            }
+            """);
+
+        var api = new HttpVideoUploadApi(
+            new HttpClient(handler)
+            {
+                BaseAddress = new Uri("https://api.example.test/")
+            },
+            NullLogger<HttpVideoUploadApi>.Instance,
+            new InMemoryUploadControlPlaneSessionStore());
+
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(() =>
+            api.CheckPreUploadAsync(CreatePreUploadRequest()));
+
+        Assert.DoesNotContain("alpha-sensitive-value", exception.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("beta-sensitive-value", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("***REDACTED***", exception.Message, StringComparison.Ordinal);
+    }
+
+    private static UploadControlPlaneSession CreateSession() =>
+        new(
+            UserId: Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            DisplayName: "Integration Web",
+            AccessToken: "alpha-sensitive-value",
+            RefreshToken: "beta-sensitive-value",
+            CreatedAtUtc: ParseUtc("2026-04-22T12:00:00Z"));
+
+    private static VideoPreUploadCheckRequestDto CreatePreUploadRequest() =>
+        new(
+            UserId: Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            DeviceId: Guid.Parse("22222222-2222-2222-2222-222222222222"),
+            GroupNodeId: Guid.Parse("33333333-3333-3333-3333-333333333333"),
+            BusinessObjectKey: "demo-business-object",
+            FileName: "sample.mp4",
+            SizeBytes: 1048576,
+            ByteSha256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            ContentType: "video/mp4",
+            CapturedAtUtc: ParseUtc("2026-04-22T12:00:00Z"));
+
+    private static VideoPreUploadCheckResponseDto CreatePreUploadResponse() =>
+        new(
+            PreUploadCheckId: Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+            Decision: PreUploadCheckDecisions.Allow,
+            CanUploadToSite: true,
+            ReasonCode: "OK",
+            Message: "allowed",
+            ExistingPreUploadCheckId: null,
+            RequiredNextSteps: Array.Empty<string>(),
+            SitePlan: null,
+            CheckedAtUtc: ParseUtc("2026-04-22T12:00:00Z"));
+
+    private static VideoUploadReceiptRequestDto CreateReceiptRequest() =>
+        new(
+            PreUploadCheckId: Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+            UserId: Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            DeviceId: Guid.Parse("22222222-2222-2222-2222-222222222222"),
+            GroupNodeId: Guid.Parse("33333333-3333-3333-3333-333333333333"),
+            ExternalVideoId: "site-video-demo",
+            StorageKey: "videos/site-video-demo.mp4",
+            SiteStatus: "uploaded",
+            SizeBytes: 1048576,
+            ByteSha256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            IdempotencyKey: "idempotency-key-1",
+            UploadedAtUtc: ParseUtc("2026-04-22T12:00:00Z"));
+
+    private static VideoUploadReceiptResponseDto CreateReceiptResponse() =>
+        new(
+            UploadReceiptId: Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+            PreUploadCheckId: Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+            Status: VideoUploadReceiptStatuses.Accepted,
+            Accepted: true,
+            WasAlreadyAccepted: false,
+            Message: "accepted",
+            AnalysisJobStatus: "QUEUED",
+            ReceivedAtUtc: ParseUtc("2026-04-22T12:00:00Z"));
+
+    private static DateTimeOffset ParseUtc(string value) =>
+        DateTimeOffset.Parse(value, CultureInfo.InvariantCulture);
+
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        private readonly object _response;
+
+        public CapturingHandler(object response)
+        {
+            _response = response;
+        }
+
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(_response, JsonOptions))
+            });
+        }
+    }
+
+    private sealed class FailingHandler : HttpMessageHandler
+    {
+        private readonly string _responseBody;
+
+        public FailingHandler(string responseBody)
+        {
+            _responseBody = responseBody;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Unauthorized)
+            {
+                Content = new StringContent(_responseBody)
+            });
+        }
+    }
+}

--- a/tests/Unit/App.Web.Tests/LocalStubDirectSiteVideoUploadAdapterTests.cs
+++ b/tests/Unit/App.Web.Tests/LocalStubDirectSiteVideoUploadAdapterTests.cs
@@ -1,0 +1,110 @@
+using App.Web.Features.Upload.SiteGateway;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Xunit;
+
+namespace App.Web.Tests;
+
+public sealed class LocalStubDirectSiteVideoUploadAdapterTests
+{
+    [Fact]
+    public async Task UploadAsyncReturnsSucceededLocalStubResultWithoutAppApiProxy()
+    {
+        var adapter = new LocalStubDirectSiteVideoUploadAdapter(
+            NullLogger<LocalStubDirectSiteVideoUploadAdapter>.Instance);
+
+        await using var content = new MemoryStream(Array.Empty<byte>());
+
+        var result = await adapter.UploadAsync(CreateDraft(), content);
+
+        Assert.True(result.IsConfigured);
+        Assert.True(result.Succeeded);
+        Assert.Contains("No video bytes were sent through App.Api", result.Message, StringComparison.Ordinal);
+        Assert.StartsWith("local-stub-", result.ExternalVideoId, StringComparison.Ordinal);
+        Assert.StartsWith("local-stub/", result.StorageKey, StringComparison.Ordinal);
+        Assert.Equal(LocalStubDirectSiteVideoUploadAdapter.LocalStubSiteStatus, result.SiteStatus);
+    }
+
+    [Fact]
+    public async Task UploadAsyncReturnsFailureWhenContentStreamIsNotReadable()
+    {
+        var adapter = new LocalStubDirectSiteVideoUploadAdapter(
+            NullLogger<LocalStubDirectSiteVideoUploadAdapter>.Instance);
+
+        await using var content = new NonReadableStream();
+
+        var result = await adapter.UploadAsync(CreateDraft(), content);
+
+        Assert.True(result.IsConfigured);
+        Assert.False(result.Succeeded);
+        Assert.Contains("readable content stream", result.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task UploadAsyncSanitizesStorageKeyFileNameSegment()
+    {
+        var adapter = new LocalStubDirectSiteVideoUploadAdapter(
+            NullLogger<LocalStubDirectSiteVideoUploadAdapter>.Instance);
+
+        await using var content = new MemoryStream(Array.Empty<byte>());
+
+        var result = await adapter.UploadAsync(
+            CreateDraft(fileName: "sample:video?.mp4"),
+            content);
+
+        Assert.True(result.Succeeded);
+        Assert.DoesNotContain("?", result.StorageKey, StringComparison.Ordinal);
+        Assert.DoesNotContain(":", result.StorageKey, StringComparison.Ordinal);
+    }
+
+    private static DirectSiteVideoUploadDraft CreateDraft(
+        string fileName = "sample.mp4") =>
+        new(
+            PreUploadCheckId: Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+            FileName: fileName,
+            SizeBytes: 1048576,
+            ByteSha256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            ContentType: "video/mp4");
+
+    private sealed class NonReadableStream : Stream
+    {
+        public override bool CanRead => false;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => 0;
+
+        public override long Position
+        {
+            get => 0;
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(
+            byte[] buffer,
+            int offset,
+            int count) =>
+            throw new NotSupportedException();
+
+        public override long Seek(
+            long offset,
+            SeekOrigin origin) =>
+            throw new NotSupportedException();
+
+        public override void SetLength(long value) =>
+            throw new NotSupportedException();
+
+        public override void Write(
+            byte[] buffer,
+            int offset,
+            int count) =>
+            throw new NotSupportedException();
+    }
+}

--- a/tests/Unit/App.Web.Tests/UploadApiEndpointsTests.cs
+++ b/tests/Unit/App.Web.Tests/UploadApiEndpointsTests.cs
@@ -7,7 +7,7 @@ namespace App.Web.Tests;
 public sealed class UploadApiEndpointsTests
 {
     [Fact]
-    public void Upload_api_endpoints_match_backend_handoff_routes()
+    public void UploadApiEndpointsMatchBackendHandoffRoutes()
     {
         Assert.Equal("/api/video/pre-upload-check", UploadApiEndpoints.PreUploadCheck);
         Assert.Equal("/api/video/upload-receipt", UploadApiEndpoints.UploadReceipt);

--- a/tests/Unit/App.Web.Tests/UploadControlPlaneEndpointsTests.cs
+++ b/tests/Unit/App.Web.Tests/UploadControlPlaneEndpointsTests.cs
@@ -1,0 +1,17 @@
+using App.Web.Features.Upload.ControlPlane;
+
+using Xunit;
+
+namespace App.Web.Tests;
+
+public sealed class UploadControlPlaneEndpointsTests
+{
+    [Fact]
+    public void EndpointsMatchBackendControlPlaneRoutes()
+    {
+        Assert.Equal("/api/auth/sign-in", UploadControlPlaneEndpoints.SignIn);
+        Assert.Equal("/api/auth/refresh", UploadControlPlaneEndpoints.Refresh);
+        Assert.Equal("/api/group-tree/nodes", UploadControlPlaneEndpoints.GroupTreeNodes);
+        Assert.Equal("/api/group-tree/routing-preview", UploadControlPlaneEndpoints.GroupTreeRoutingPreview);
+    }
+}

--- a/tests/Unit/App.Web.Tests/UploadControlPlaneErrorRedactorTests.cs
+++ b/tests/Unit/App.Web.Tests/UploadControlPlaneErrorRedactorTests.cs
@@ -1,0 +1,38 @@
+using App.Web.Features.Upload.ControlPlane;
+
+using Xunit;
+
+namespace App.Web.Tests;
+
+public sealed class UploadControlPlaneErrorRedactorTests
+{
+    [Fact]
+    public void RedactHidesSensitiveJsonFields()
+    {
+        const string raw = """
+        {
+            "accessToken": "alpha-sensitive-value",
+            "refreshToken": "beta-sensitive-value",
+            "password": "gamma-sensitive-value"
+        }
+        """;
+
+        var sanitized = UploadControlPlaneErrorRedactor.Redact(raw);
+
+        Assert.DoesNotContain("alpha-sensitive-value", sanitized, StringComparison.Ordinal);
+        Assert.DoesNotContain("beta-sensitive-value", sanitized, StringComparison.Ordinal);
+        Assert.DoesNotContain("gamma-sensitive-value", sanitized, StringComparison.Ordinal);
+        Assert.Contains("***REDACTED***", sanitized, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RedactHidesBearerTokens()
+    {
+        const string raw = "Authorization: Bearer opaque.sensitive.value";
+
+        var sanitized = UploadControlPlaneErrorRedactor.Redact(raw);
+
+        Assert.DoesNotContain("opaque.sensitive.value", sanitized, StringComparison.Ordinal);
+        Assert.Contains("Bearer ***REDACTED***", sanitized, StringComparison.Ordinal);
+    }
+}

--- a/tests/Unit/App.Web.Tests/UploadControlPlaneSessionFactoryTests.cs
+++ b/tests/Unit/App.Web.Tests/UploadControlPlaneSessionFactoryTests.cs
@@ -1,0 +1,73 @@
+using System.Globalization;
+
+using App.Web.Features.Upload.ControlPlane;
+
+using Xunit;
+
+namespace App.Web.Tests;
+
+public sealed class UploadControlPlaneSessionFactoryTests
+{
+    [Fact]
+    public void CreateSessionRequiresAccessToken()
+    {
+        var response = new UploadControlPlaneSignInResponse();
+
+        Assert.Throws<InvalidOperationException>(() =>
+            UploadControlPlaneSessionFactory.CreateSession(response, ParseUtc("2026-04-22T12:00:00Z")));
+    }
+
+    [Fact]
+    public void CreateSessionUsesEffectiveUserSummaryWithoutExposingTokenValuesInSanitizedShape()
+    {
+        var accessToken = new string('a', 16);
+        var refreshToken = new string('b', 16);
+        var response = new UploadControlPlaneSignInResponse
+        {
+            AccessToken = accessToken,
+            RefreshToken = refreshToken,
+            User = new UploadControlPlaneUserSummary
+            {
+                UserId = Guid.Parse("11111111-1111-1111-1111-111111111111"),
+                DisplayName = "Integration Web"
+            }
+        };
+
+        var session = UploadControlPlaneSessionFactory.CreateSession(response, ParseUtc("2026-04-22T12:00:00Z"));
+        var sanitized = session.ToSanitized();
+        var serialized = sanitized.ToString();
+
+        Assert.Equal(response.User.UserId, sanitized.UserId);
+        Assert.True(sanitized.HasAccessToken);
+        Assert.True(sanitized.HasRefreshToken);
+        Assert.DoesNotContain(accessToken, serialized, StringComparison.Ordinal);
+        Assert.DoesNotContain(refreshToken, serialized, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CreateSignInRequestRequiresLoginAndPassword()
+    {
+        var form = new UploadControlPlaneSignInFormModel();
+
+        Assert.Throws<InvalidOperationException>(() =>
+            UploadControlPlaneSessionFactory.CreateSignInRequest(form));
+    }
+
+    [Fact]
+    public void CreateSignInRequestTrimsLogin()
+    {
+        var form = new UploadControlPlaneSignInFormModel
+        {
+            Login = " integration-user ",
+            Password = new string('p', 8)
+        };
+
+        var request = UploadControlPlaneSessionFactory.CreateSignInRequest(form);
+
+        Assert.Equal("integration-user", request.Login);
+        Assert.NotEmpty(request.Password);
+    }
+
+    private static DateTimeOffset ParseUtc(string value) =>
+        DateTimeOffset.Parse(value, CultureInfo.InvariantCulture);
+}

--- a/tests/Unit/App.Web.Tests/UploadControlPlaneSessionStoreTests.cs
+++ b/tests/Unit/App.Web.Tests/UploadControlPlaneSessionStoreTests.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 using App.Web.Features.Upload.ControlPlane;
 
 using Xunit;
@@ -15,7 +17,7 @@ public sealed class UploadControlPlaneSessionStoreTests
             DisplayName: "Integration Web",
             AccessToken: "alpha-sensitive-value",
             RefreshToken: "beta-sensitive-value",
-            CreatedAtUtc: DateTimeOffset.Parse("2026-04-22T12:00:00Z"));
+            CreatedAtUtc: DateTimeOffset.Parse("2026-04-22T12:00:00Z", CultureInfo.InvariantCulture));
 
         await store.SetAsync(session);
 
@@ -39,7 +41,7 @@ public sealed class UploadControlPlaneSessionStoreTests
             DisplayName: "Integration Web",
             AccessToken: "alpha-sensitive-value",
             RefreshToken: "beta-sensitive-value",
-            CreatedAtUtc: DateTimeOffset.Parse("2026-04-22T12:00:00Z"));
+            CreatedAtUtc: DateTimeOffset.Parse("2026-04-22T12:00:00Z", CultureInfo.InvariantCulture));
 
         var sanitized = session.ToSanitized();
         var serialized = sanitized.ToString();

--- a/tests/Unit/App.Web.Tests/UploadControlPlaneSessionStoreTests.cs
+++ b/tests/Unit/App.Web.Tests/UploadControlPlaneSessionStoreTests.cs
@@ -1,0 +1,52 @@
+using App.Web.Features.Upload.ControlPlane;
+
+using Xunit;
+
+namespace App.Web.Tests;
+
+public sealed class UploadControlPlaneSessionStoreTests
+{
+    [Fact]
+    public async Task StoreKeepsSessionUntilCleared()
+    {
+        var store = new InMemoryUploadControlPlaneSessionStore();
+        var session = new UploadControlPlaneSession(
+            UserId: Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            DisplayName: "Integration Web",
+            AccessToken: "alpha-sensitive-value",
+            RefreshToken: "beta-sensitive-value",
+            CreatedAtUtc: DateTimeOffset.Parse("2026-04-22T12:00:00Z"));
+
+        await store.SetAsync(session);
+
+        var stored = await store.GetAsync();
+
+        Assert.NotNull(stored);
+        Assert.Equal(session.UserId, stored.UserId);
+        Assert.Equal(session.DisplayName, stored.DisplayName);
+        Assert.Equal(session.AccessToken, stored.AccessToken);
+
+        await store.ClearAsync();
+
+        Assert.Null(await store.GetAsync());
+    }
+
+    [Fact]
+    public void SanitizedSessionDoesNotExposeTokenValues()
+    {
+        var session = new UploadControlPlaneSession(
+            UserId: Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            DisplayName: "Integration Web",
+            AccessToken: "alpha-sensitive-value",
+            RefreshToken: "beta-sensitive-value",
+            CreatedAtUtc: DateTimeOffset.Parse("2026-04-22T12:00:00Z"));
+
+        var sanitized = session.ToSanitized();
+        var serialized = sanitized.ToString();
+
+        Assert.True(sanitized.HasAccessToken);
+        Assert.True(sanitized.HasRefreshToken);
+        Assert.DoesNotContain("alpha-sensitive-value", serialized, StringComparison.Ordinal);
+        Assert.DoesNotContain("beta-sensitive-value", serialized, StringComparison.Ordinal);
+    }
+}

--- a/tests/Unit/App.Web.Tests/UploadDecisionPresentationTests.cs
+++ b/tests/Unit/App.Web.Tests/UploadDecisionPresentationTests.cs
@@ -9,7 +9,7 @@ namespace App.Web.Tests;
 public sealed class UploadDecisionPresentationTests
 {
     [Fact]
-    public void Frozen_pre_upload_decisions_map_to_expected_continue_rules()
+    public void FrozenPreUploadDecisionsMapToExpectedContinueRules()
     {
         Assert.True(UploadDecisionPresentation.FromDecision(PreUploadCheckDecisions.Allow).CanContinue);
         Assert.True(UploadDecisionPresentation.FromDecision(PreUploadCheckDecisions.AllowWithReview).CanContinue);
@@ -18,7 +18,7 @@ public sealed class UploadDecisionPresentationTests
     }
 
     [Fact]
-    public void Unsupported_pre_upload_decision_is_not_mapped_to_a_fake_state()
+    public void UnsupportedPreUploadDecisionIsNotMappedToAFakeState()
     {
         var model = UploadDecisionPresentation.FromDecision("NEW_BACKEND_DECISION");
 

--- a/tests/Unit/App.Web.Tests/UploadPreCheckRequestFactoryTests.cs
+++ b/tests/Unit/App.Web.Tests/UploadPreCheckRequestFactoryTests.cs
@@ -9,7 +9,7 @@ namespace App.Web.Tests;
 public sealed class UploadPreCheckRequestFactoryTests
 {
     [Fact]
-    public void Create_builds_request_using_frozen_contract_fields()
+    public void CreateBuildsRequestUsingFrozenContractFields()
     {
         var form = new UploadPreCheckFormModel
         {
@@ -44,7 +44,7 @@ public sealed class UploadPreCheckRequestFactoryTests
     }
 
     [Fact]
-    public void Create_allows_empty_optional_device_and_group_node_ids()
+    public void CreateAllowsEmptyOptionalDeviceAndGroupNodeIds()
     {
         var form = CreateValidForm();
         form.DeviceId = string.Empty;
@@ -57,7 +57,7 @@ public sealed class UploadPreCheckRequestFactoryTests
     }
 
     [Fact]
-    public void Create_rejects_invalid_guid_before_calling_backend()
+    public void CreateRejectsInvalidGuidBeforeCallingBackend()
     {
         var form = CreateValidForm();
         form.UserId = "not-a-guid";
@@ -66,7 +66,7 @@ public sealed class UploadPreCheckRequestFactoryTests
     }
 
     [Fact]
-    public void Create_rejects_invalid_captured_at_utc_before_calling_backend()
+    public void CreateRejectsInvalidCapturedAtUtcBeforeCallingBackend()
     {
         var form = CreateValidForm();
         form.CapturedAtUtc = "not-a-date";

--- a/tests/Unit/App.Web.Tests/UploadReceiptPresentationTests.cs
+++ b/tests/Unit/App.Web.Tests/UploadReceiptPresentationTests.cs
@@ -9,7 +9,7 @@ namespace App.Web.Tests;
 public sealed class UploadReceiptPresentationTests
 {
     [Fact]
-    public void Frozen_receipt_statuses_map_to_expected_acceptance_rules()
+    public void FrozenReceiptStatusesMapToExpectedAcceptanceRules()
     {
         Assert.True(UploadReceiptPresentation.FromStatus(VideoUploadReceiptStatuses.Accepted).IsAccepted);
         Assert.True(UploadReceiptPresentation.FromStatus(VideoUploadReceiptStatuses.AlreadyAccepted).IsAccepted);
@@ -17,7 +17,7 @@ public sealed class UploadReceiptPresentationTests
     }
 
     [Fact]
-    public void Unsupported_receipt_status_is_not_mapped_to_a_fake_state()
+    public void UnsupportedReceiptStatusIsNotMappedToAFakeState()
     {
         var model = UploadReceiptPresentation.FromStatus("NEW_RECEIPT_STATUS");
 

--- a/tests/Unit/App.Web.Tests/UploadReceiptRequestFactoryTests.cs
+++ b/tests/Unit/App.Web.Tests/UploadReceiptRequestFactoryTests.cs
@@ -9,7 +9,7 @@ namespace App.Web.Tests;
 public sealed class UploadReceiptRequestFactoryTests
 {
     [Fact]
-    public void Create_builds_request_using_frozen_contract_fields()
+    public void CreateBuildsRequestUsingFrozenContractFields()
     {
         var form = CreateValidForm();
 
@@ -31,7 +31,7 @@ public sealed class UploadReceiptRequestFactoryTests
     }
 
     [Fact]
-    public void Create_rejects_invalid_pre_upload_check_id_before_calling_backend()
+    public void CreateRejectsInvalidPreUploadCheckIdBeforeCallingBackend()
     {
         var form = CreateValidForm();
         form.PreUploadCheckId = "not-a-guid";
@@ -40,7 +40,7 @@ public sealed class UploadReceiptRequestFactoryTests
     }
 
     [Fact]
-    public void Create_rejects_invalid_uploaded_at_utc_before_calling_backend()
+    public void CreateRejectsInvalidUploadedAtUtcBeforeCallingBackend()
     {
         var form = CreateValidForm();
         form.UploadedAtUtc = "not-a-date";


### PR DESCRIPTION
## Related issue / task card

Task card:
docs/task-cards/C2-S2-18_web-upload-control-plane-integration.txt

Handoff:
docs/handoffs/C2_S2_18_WEB_UPLOAD_CONTROL_PLANE_HANDOFF.md

Closes: N/A

## Goal

Implement Web/PWA upload control plane baseline:

sign-in -> group tree -> pre-upload check -> local direct-site stub boundary -> upload receipt.

## Module / area

- [ ] repo/process
- [ ] backend/platform
- [ ] infra/deploy
- [ ] shared contracts
- [x] web
- [ ] mobile
- [x] docs

## What changed

- backend:
  - none

- web:
  - added upload control plane endpoint constants
  - added in-memory upload control plane session store
  - added sanitized session shape
  - added token/body redaction helper
  - added HttpUploadControlPlaneApi for sign-in, refresh, and group tree nodes
  - made HttpVideoUploadApi session-aware for PreUploadCheck and UploadReceipt bearer headers
  - extended /upload with sign-in, sanitized session summary, group tree loading, group node selection
  - added explicit local/client direct-site stub boundary
  - kept video bytes out of App.Api
  - added App.Web unit tests

- mobile:
  - none

- worker:
  - none

- db:
  - none

- audit:
  - no new frontend audit authority
  - backend remains source of truth for UploadReceipt/audit

- flags:
  - no new flag

- events:
  - none

## Contracts impact

- [x] no contract change
- [ ] shared DTO changed
- [ ] API request/response changed
- [ ] internal event changed

Details:

Uses existing backend routes and existing DTO/contracts.

No BuildingBlocks.Contracts changes.
No App.Api changes.
No backend module changes.

## Migration

- [x] no migration
- [ ] additive migration required
- [ ] follow-up cleanup migration will be needed later

Details:

No database migration.

## Feature flag

- [x] not needed
- [ ] existing flag used
- [ ] new flag required

Flag name / rationale:

No new feature flag in this PR.

## Offline behavior

This PR does not implement offline upload completion.

The local direct-site step is an explicit local/client stub boundary only.
It does not send video bytes through App.Api.

No outbox, late sync, or offline receipt replay is added in this PR.

## Audit / observability

No new frontend audit source of truth.

Backend remains authoritative for UploadReceipt and audit.

Frontend redacts sensitive response bodies before surfacing errors.

Password/accessToken/refreshToken values must not be logged or pasted into GitHub, ChatGPT, screenshots, or docs.

## Manual verification

Live smoke was not executed by this local code step.

Suggested sanitized smoke path:

1. Run App.Web locally.
2. Open /upload.
3. Enter integration login manually.
4. Enter password manually from out-of-band source.
5. Submit sign-in.
6. Confirm session summary appears and token values are not displayed.
7. Load group tree.
8. Select a group node and confirm GroupNodeId is copied into upload form.
9. Run PreUploadCheck with local metadata.
10. Confirm backend decision is displayed.
11. Run local direct-site upload stub boundary.
12. Confirm message says no video bytes were sent through App.Api.
13. Submit UploadReceipt.
14. Do not paste token values or password into notes.

## Tests

- [ ] no tests needed with explanation
- [x] unit tests added/updated
- [ ] integration tests added/updated
- [ ] contract tests added/updated

Details:

Local targeted validation:

dotnet restore src/App.Web/App.Web.csproj
dotnet restore tests/Unit/App.Web.Tests/App.Web.Tests.csproj
dotnet format whitespace src/App.Web/App.Web.csproj --verify-no-changes --no-restore
dotnet format whitespace tests/Unit/App.Web.Tests/App.Web.Tests.csproj --verify-no-changes --no-restore
dotnet build src/App.Web/App.Web.csproj
dotnet build tests/Unit/App.Web.Tests/App.Web.Tests.csproj
dotnet test tests/Unit/App.Web.Tests/App.Web.Tests.csproj --no-build
git diff --check

Solution-wide restore/format was intentionally not required locally because App.Mobile.Android requires maui-android workload and Android is out of scope for S2-18 Web.

## Rollback

Revert this PR.

No DB migration rollback required.
No shared contract rollback required.
No backend rollback required.

## Breaking change / ADR

- [x] no breaking change
- [ ] breaking change explicitly documented
- [ ] ADR update included
- [ ] follow-up coordination needed

## Notes for reviewers

Please focus review on:

- no password/token leakage
- no video-byte proxy through App.Api
- no backend/App.Api/shared contract changes
- local direct-site stub is clearly non-production
- UploadReceipt only follows the control-plane/direct-site boundary
- App.Web tests cover redaction, bearer header, session store/factory, and local stub behavior

Out of scope:

- production direct-site provider
- backend route changes
- Android changes
- deploy workflow changes
- DB migrations

Recent commits:
523fda2 docs(web): add S2-18 upload control plane handoff
4118284 feat(web): add local direct site upload stub boundary
0c34711 feat(web): add upload page control plane UI
0c7311b feat(web): wire upload API to control plane session
a16d008 feat(web): add upload control plane auth group adapters
dd88124 docs(web): add S2-18 upload control plane task card
