### PR TITLE
S2-31 Incident Routing Admin Assignment Provisioning

### DIFF
--- a/docs/ops/s2-31-incident-routing-admin-assignment-provisioning.md
+++ b/docs/ops/s2-31-incident-routing-admin-assignment-provisioning.md
@@ -1,0 +1,147 @@
+# S2-31 Incident Routing Admin Assignment Provisioning
+
+Status: Implemented
+Owner: Coder 1 / Platform Owner
+Module: App.Maintenance / GroupTree / Incidents / Korobochka / Ops
+Type: maintenance tool + runbook
+Goal: safely provision a dedicated root incident-routing admin that is distinct from `integration-web-android`.
+Contracts: no shared DTO or public API route changes.
+Migration: none.
+Security: no passwords, password hashes, access tokens, or refresh tokens in repo, chat, docs, screenshots, or logs.
+Production deploy: not included.
+
+## Scope and guardrails
+
+- use a repo-tracked maintenance command instead of ad-hoc production SQL as the primary path;
+- create or update a dedicated login-capable routing admin for incident routing smoke and baseline ops;
+- keep the account distinct from uploader `integration-web-android`;
+- use the normal password hasher and normal auth model;
+- do not use `DevelopmentBootstrap`;
+- do not add hidden auth bypasses;
+- do not print the password, password hash, `accessToken`, or `refreshToken`.
+
+## Fixed provisioning target
+
+The maintenance command provisions one dedicated account with these fixed values:
+
+- login: `incident-routing-admin`;
+- display name: `Incident Routing Admin`;
+- role: `platform_owner`;
+- current group node: `root`;
+- root admin assignment: ensured in `app.group_admin_assignments`;
+- active: `true`.
+
+`platform_owner` remains the approved role because it already exists, is seeded, and matches the current maintenance/auth model.
+
+## Required environment variable
+
+The command requires exactly one secret input:
+
+- `AA_INCIDENT_ROUTING_ADMIN_PASSWORD`
+
+Set it only in the local PowerShell session on Korobochka.
+Do not save it in repo files, `appsettings`, `.env`, terminal transcripts, screenshots, PR comments, or chat.
+
+## Command usage
+
+Open PowerShell in the repository root on Korobochka:
+
+```powershell
+Set-Location C:\Codex\AnalyticsAutomation-Core
+```
+
+Read the password without echoing it:
+
+```powershell
+$securePassword = Read-Host 'Incident routing admin password' -AsSecureString
+$env:AA_INCIDENT_ROUTING_ADMIN_PASSWORD = [System.Net.NetworkCredential]::new('', $securePassword).Password
+```
+
+Run the maintenance command:
+
+```powershell
+dotnet run --project tools\App.Maintenance\App.Maintenance.csproj -- incident-routing-admin upsert
+```
+
+Expected safe output:
+
+```text
+login: incident-routing-admin
+status: created
+role: platform_owner
+role-link: created
+group-node: root
+assignment: created
+```
+
+or on repeat execution:
+
+```text
+login: incident-routing-admin
+status: updated
+role: platform_owner
+role-link: exists
+group-node: root
+assignment: exists
+```
+
+Clear the temporary environment variable after the run:
+
+```powershell
+Remove-Item Env:AA_INCIDENT_ROUTING_ADMIN_PASSWORD
+```
+
+## Verification
+
+Required verification is additive and secret-safe:
+
+1. Confirm the command completed with the safe output above and printed no password, password hash, `accessToken`, or `refreshToken`.
+2. Re-run the existing readonly evidence path and confirm `app.group_admin_assignments` now contains one row for root + `incident-routing-admin`.
+3. Re-run routing preview for the `root` node with uploader `integration-web-android` and confirm `resolvedAdminUserIds` is not empty.
+4. Re-run the duplicate incident runtime smoke from S2-28 and confirm:
+   - duplicate candidate is still created;
+   - duplicate incident is now created;
+   - duplicate incident assignment targets the dedicated routing admin;
+   - worker logs remain sanitized.
+
+The routing-preview and smoke verification must not print passwords or token payloads.
+If sign-in is used to obtain temporary user context during verification, keep the response in process memory only and do not write the full response object to the terminal.
+
+## No-secret rules
+
+- never echo `$env:AA_INCIDENT_ROUTING_ADMIN_PASSWORD`;
+- never print the raw `Invoke-RestMethod` sign-in response;
+- never paste `accessToken` or `refreshToken` into chat, docs, or screenshots;
+- never print password hashes from `app.auth_users`;
+- never commit secret files or local transcripts.
+
+## Idempotency and repeatability
+
+The command is safe to re-run.
+It will:
+
+- create the user if missing, otherwise update the existing user;
+- keep `incident-routing-admin` active and pinned to `root`;
+- overwrite the password hash from `AA_INCIDENT_ROUTING_ADMIN_PASSWORD`;
+- ensure the `platform_owner` role link exists exactly once;
+- ensure the root assignment exists exactly once.
+
+## Rollback
+
+Preferred rollback is operational and additive-first:
+
+1. if only password rotation is needed, re-run `incident-routing-admin upsert` with a new out-of-band password;
+2. if the routing baseline must be revoked, disable the dedicated user and remove the root assignment through the approved operator procedure for Korobochka;
+3. re-run readonly verification and confirm routing preview for uploader `integration-web-android` returns no resolved admins again if full rollback is intended.
+
+This PR intentionally does not add a destructive maintenance command.
+No migration rollback is required because the schema is unchanged.
+
+## Out of scope
+
+- public API route changes;
+- shared DTO or contract changes;
+- migrations;
+- deploy workflow changes;
+- `App.Web`, `App.Mobile.Android`, or `App.UI.Shared` changes;
+- SSH or direct host automation from this repository.

--- a/tests/Integration/App.Maintenance/AppMaintenanceProgramTests.cs
+++ b/tests/Integration/App.Maintenance/AppMaintenanceProgramTests.cs
@@ -1,0 +1,174 @@
+using App.Maintenance.IncidentRoutingAdmins;
+using App.Maintenance.IntegrationAccounts;
+
+using BuildingBlocks.Infrastructure.Persistence;
+using BuildingBlocks.Infrastructure.Persistence.Entities.Auth;
+using BuildingBlocks.Infrastructure.Persistence.Entities.GroupTree;
+
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+using Xunit;
+
+namespace App.Maintenance.Tests;
+
+public sealed class AppMaintenanceProgramTests
+{
+    [Fact]
+    public async Task RunAsyncIncidentRoutingAdminUpsertWritesSafeOutputOnly()
+    {
+        const string password = "S2-31-safe-output-password!";
+
+        using var passwordScope = new EnvironmentVariableScope(
+            IncidentRoutingAdminMaintenanceService.PasswordEnvironmentVariableName,
+            password);
+
+        var databaseName = $"app-maintenance-program-{Guid.NewGuid():N}";
+        var databaseRoot = new InMemoryDatabaseRoot();
+
+        await using (var setupContext = CreateDbContext(databaseName, databaseRoot))
+        {
+            await SeedRoleAndRootAsync(setupContext);
+        }
+
+        var stdout = new StringWriter();
+        var stderr = new StringWriter();
+
+        var exitCode = await AppMaintenanceProgram.RunAsync(
+            ["incident-routing-admin", "upsert"],
+            () => CreateHost(databaseName, databaseRoot),
+            stdout,
+            stderr,
+            CancellationToken.None);
+
+        await using var assertContext = CreateDbContext(databaseName, databaseRoot);
+        var user = await assertContext.AuthUsers
+            .SingleAsync(item => item.NormalizedLogin == "INCIDENT-ROUTING-ADMIN");
+
+        var standardOutput = stdout.ToString();
+        var errorOutput = stderr.ToString();
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(string.Empty, errorOutput);
+        Assert.Contains("login: incident-routing-admin", standardOutput, StringComparison.Ordinal);
+        Assert.Contains("status: created", standardOutput, StringComparison.Ordinal);
+        Assert.Contains("role: platform_owner", standardOutput, StringComparison.Ordinal);
+        Assert.Contains("role-link: created", standardOutput, StringComparison.Ordinal);
+        Assert.Contains("group-node: root", standardOutput, StringComparison.Ordinal);
+        Assert.Contains("assignment: created", standardOutput, StringComparison.Ordinal);
+        Assert.DoesNotContain(password, standardOutput, StringComparison.Ordinal);
+        Assert.DoesNotContain(user.PasswordHash, standardOutput, StringComparison.Ordinal);
+        Assert.DoesNotContain("accessToken", standardOutput, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("refreshToken", standardOutput, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task RunAsyncIncidentRoutingAdminUpsertFailsSafelyWhenPasswordIsMissing()
+    {
+        using var passwordScope = new EnvironmentVariableScope(
+            IncidentRoutingAdminMaintenanceService.PasswordEnvironmentVariableName,
+            null);
+
+        var databaseName = $"app-maintenance-program-missing-password-{Guid.NewGuid():N}";
+        var databaseRoot = new InMemoryDatabaseRoot();
+
+        await using (var setupContext = CreateDbContext(databaseName, databaseRoot))
+        {
+            await SeedRoleAndRootAsync(setupContext);
+        }
+
+        var stdout = new StringWriter();
+        var stderr = new StringWriter();
+
+        var exitCode = await AppMaintenanceProgram.RunAsync(
+            ["incident-routing-admin", "upsert"],
+            () => CreateHost(databaseName, databaseRoot),
+            stdout,
+            stderr,
+            CancellationToken.None);
+
+        var standardOutput = stdout.ToString();
+        var errorOutput = stderr.ToString();
+
+        await using var assertContext = CreateDbContext(databaseName, databaseRoot);
+
+        Assert.Equal(1, exitCode);
+        Assert.Equal(string.Empty, standardOutput);
+        Assert.Contains(
+            IncidentRoutingAdminMaintenanceService.PasswordEnvironmentVariableName,
+            errorOutput,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("accessToken", errorOutput, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("refreshToken", errorOutput, StringComparison.OrdinalIgnoreCase);
+        Assert.False(await assertContext.AuthUsers.AnyAsync());
+        Assert.False(await assertContext.GroupAdminAssignments.AnyAsync());
+    }
+
+    private static IHost CreateHost(
+        string databaseName,
+        InMemoryDatabaseRoot databaseRoot)
+    {
+        var builder = Host.CreateApplicationBuilder();
+        builder.Logging.ClearProviders();
+        builder.Services.AddDbContext<PlatformDbContext>(
+            options => options.UseInMemoryDatabase(databaseName, databaseRoot));
+        builder.Services.AddSingleton<IPasswordHasher<AuthUser>, PasswordHasher<AuthUser>>();
+        builder.Services.AddScoped<IncidentRoutingAdminMaintenanceService>();
+        builder.Services.AddScoped<IntegrationAccountMaintenanceService>();
+
+        return builder.Build();
+    }
+
+    private static async Task SeedRoleAndRootAsync(PlatformDbContext dbContext)
+    {
+        dbContext.AuthRoles.Add(new AuthRole
+        {
+            Id = Guid.NewGuid(),
+            Code = IncidentRoutingAdminMaintenanceService.PlatformOwnerRoleCode,
+            Name = "Platform Owner"
+        });
+        dbContext.GroupNodes.Add(new GroupNode
+        {
+            Id = Guid.NewGuid(),
+            Code = IncidentRoutingAdminMaintenanceService.RootGroupNodeCode,
+            Name = "Root",
+            Depth = 0,
+            IsActive = true
+        });
+
+        await dbContext.SaveChangesAsync();
+    }
+
+    private static PlatformDbContext CreateDbContext(
+        string databaseName,
+        InMemoryDatabaseRoot databaseRoot)
+    {
+        var options = new DbContextOptionsBuilder<PlatformDbContext>()
+            .UseInMemoryDatabase(databaseName, databaseRoot)
+            .Options;
+
+        return new PlatformDbContext(options);
+    }
+
+    private sealed class EnvironmentVariableScope : IDisposable
+    {
+        private readonly string name;
+        private readonly string? originalValue;
+
+        public EnvironmentVariableScope(string name, string? value)
+        {
+            this.name = name;
+            originalValue = Environment.GetEnvironmentVariable(name);
+            Environment.SetEnvironmentVariable(name, value);
+        }
+
+        public void Dispose()
+        {
+            Environment.SetEnvironmentVariable(name, originalValue);
+        }
+    }
+}

--- a/tests/Integration/App.Maintenance/IncidentRoutingAdminMaintenanceServiceTests.cs
+++ b/tests/Integration/App.Maintenance/IncidentRoutingAdminMaintenanceServiceTests.cs
@@ -1,0 +1,209 @@
+using App.Maintenance.IncidentRoutingAdmins;
+
+using BuildingBlocks.Infrastructure.Persistence;
+using BuildingBlocks.Infrastructure.Persistence.Entities.Auth;
+using BuildingBlocks.Infrastructure.Persistence.Entities.GroupTree;
+
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+
+using Xunit;
+
+namespace App.Maintenance.Tests;
+
+public sealed class IncidentRoutingAdminMaintenanceServiceTests
+{
+    [Fact]
+    public async Task UpsertAsyncCreatesIncidentRoutingAdminWithRootGroupRoleAndAssignment()
+    {
+        const string password = "S2-31-create-password!";
+        const string normalizedLogin = "INCIDENT-ROUTING-ADMIN";
+
+        using var passwordScope = new EnvironmentVariableScope(
+            IncidentRoutingAdminMaintenanceService.PasswordEnvironmentVariableName,
+            password);
+
+        using var dbContext = CreateDbContext();
+        var role = new AuthRole
+        {
+            Id = Guid.NewGuid(),
+            Code = IncidentRoutingAdminMaintenanceService.PlatformOwnerRoleCode,
+            Name = "Platform Owner"
+        };
+        var rootNode = new GroupNode
+        {
+            Id = Guid.NewGuid(),
+            Code = IncidentRoutingAdminMaintenanceService.RootGroupNodeCode,
+            Name = "Root",
+            Depth = 0,
+            IsActive = true
+        };
+
+        dbContext.AuthRoles.Add(role);
+        dbContext.GroupNodes.Add(rootNode);
+        await dbContext.SaveChangesAsync();
+
+        var passwordHasher = new PasswordHasher<AuthUser>();
+        var service = new IncidentRoutingAdminMaintenanceService(dbContext, passwordHasher);
+
+        var result = await service.UpsertAsync(CancellationToken.None);
+
+        dbContext.ChangeTracker.Clear();
+
+        var user = await dbContext.AuthUsers
+            .Include(item => item.UserRoles)
+            .SingleAsync(item => item.NormalizedLogin == normalizedLogin);
+        var assignment = await dbContext.GroupAdminAssignments
+            .SingleAsync(item => item.GroupNodeId == rootNode.Id && item.UserId == user.Id);
+
+        Assert.True(result.WasCreated);
+        Assert.True(result.WasRoleLinkCreated);
+        Assert.True(result.WasAssignmentCreated);
+        Assert.Equal(IncidentRoutingAdminMaintenanceService.IncidentRoutingAdminLogin, result.Login);
+        Assert.Equal(IncidentRoutingAdminMaintenanceService.PlatformOwnerRoleCode, result.AssignedRoleCode);
+        Assert.Equal(IncidentRoutingAdminMaintenanceService.RootGroupNodeCode, result.AssignedGroupNodeCode);
+        Assert.Equal(IncidentRoutingAdminMaintenanceService.IncidentRoutingAdminDisplayName, user.DisplayName);
+        Assert.True(user.IsActive);
+        Assert.Equal(rootNode.Id, user.CurrentGroupNodeId);
+        Assert.Single(user.UserRoles);
+        Assert.Equal(role.Id, user.UserRoles.Single().RoleId);
+        Assert.Equal(rootNode.Id, assignment.GroupNodeId);
+        Assert.Equal(user.Id, assignment.UserId);
+        Assert.NotEqual(
+            PasswordVerificationResult.Failed,
+            passwordHasher.VerifyHashedPassword(user, user.PasswordHash, password));
+    }
+
+    [Fact]
+    public async Task UpsertAsyncIsIdempotentOnSecondRun()
+    {
+        const string password = "S2-31-idempotent-password!";
+        const string databaseName = "incident-routing-admin-idempotent";
+
+        using var passwordScope = new EnvironmentVariableScope(
+            IncidentRoutingAdminMaintenanceService.PasswordEnvironmentVariableName,
+            password);
+
+        var databaseRoot = new InMemoryDatabaseRoot();
+
+        await using (var setupContext = CreateDbContext(databaseName, databaseRoot))
+        {
+            await SeedRoleAndRootAsync(setupContext);
+        }
+
+        IncidentRoutingAdminUpsertResult firstResult;
+        await using (var firstContext = CreateDbContext(databaseName, databaseRoot))
+        {
+            var service = new IncidentRoutingAdminMaintenanceService(
+                firstContext,
+                new PasswordHasher<AuthUser>());
+
+            firstResult = await service.UpsertAsync(CancellationToken.None);
+        }
+
+        IncidentRoutingAdminUpsertResult secondResult;
+        await using (var secondContext = CreateDbContext(databaseName, databaseRoot))
+        {
+            var service = new IncidentRoutingAdminMaintenanceService(
+                secondContext,
+                new PasswordHasher<AuthUser>());
+
+            secondResult = await service.UpsertAsync(CancellationToken.None);
+        }
+
+        await using var assertContext = CreateDbContext(databaseName, databaseRoot);
+        var user = await assertContext.AuthUsers
+            .Include(item => item.UserRoles)
+            .SingleAsync(item => item.NormalizedLogin == "INCIDENT-ROUTING-ADMIN");
+
+        Assert.True(firstResult.WasCreated);
+        Assert.True(firstResult.WasRoleLinkCreated);
+        Assert.True(firstResult.WasAssignmentCreated);
+        Assert.False(secondResult.WasCreated);
+        Assert.False(secondResult.WasRoleLinkCreated);
+        Assert.False(secondResult.WasAssignmentCreated);
+        Assert.True(user.IsActive);
+        Assert.Equal(1, await assertContext.AuthUsers.CountAsync());
+        Assert.Equal(1, await assertContext.AuthUserRoles.CountAsync());
+        Assert.Equal(1, await assertContext.GroupAdminAssignments.CountAsync());
+    }
+
+    [Fact]
+    public async Task UpsertAsyncThrowsWhenPasswordEnvironmentVariableIsMissing()
+    {
+        using var passwordScope = new EnvironmentVariableScope(
+            IncidentRoutingAdminMaintenanceService.PasswordEnvironmentVariableName,
+            null);
+
+        using var dbContext = CreateDbContext();
+        await SeedRoleAndRootAsync(dbContext);
+
+        var service = new IncidentRoutingAdminMaintenanceService(
+            dbContext,
+            new PasswordHasher<AuthUser>());
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.UpsertAsync(CancellationToken.None));
+
+        Assert.Equal(
+            $"Environment variable {IncidentRoutingAdminMaintenanceService.PasswordEnvironmentVariableName} is required. The tool does not prompt for a password.",
+            exception.Message);
+        Assert.False(await dbContext.AuthUsers.AnyAsync());
+        Assert.False(await dbContext.GroupAdminAssignments.AnyAsync());
+    }
+
+    private static async Task SeedRoleAndRootAsync(PlatformDbContext dbContext)
+    {
+        dbContext.AuthRoles.Add(new AuthRole
+        {
+            Id = Guid.NewGuid(),
+            Code = IncidentRoutingAdminMaintenanceService.PlatformOwnerRoleCode,
+            Name = "Platform Owner"
+        });
+        dbContext.GroupNodes.Add(new GroupNode
+        {
+            Id = Guid.NewGuid(),
+            Code = IncidentRoutingAdminMaintenanceService.RootGroupNodeCode,
+            Name = "Root",
+            Depth = 0,
+            IsActive = true
+        });
+
+        await dbContext.SaveChangesAsync();
+    }
+
+    private static PlatformDbContext CreateDbContext()
+    {
+        return CreateDbContext($"incident-routing-admin-tests-{Guid.NewGuid():N}", new InMemoryDatabaseRoot());
+    }
+
+    private static PlatformDbContext CreateDbContext(
+        string databaseName,
+        InMemoryDatabaseRoot databaseRoot)
+    {
+        var options = new DbContextOptionsBuilder<PlatformDbContext>()
+            .UseInMemoryDatabase(databaseName, databaseRoot)
+            .Options;
+
+        return new PlatformDbContext(options);
+    }
+
+    private sealed class EnvironmentVariableScope : IDisposable
+    {
+        private readonly string name;
+        private readonly string? originalValue;
+
+        public EnvironmentVariableScope(string name, string? value)
+        {
+            this.name = name;
+            originalValue = Environment.GetEnvironmentVariable(name);
+            Environment.SetEnvironmentVariable(name, value);
+        }
+
+        public void Dispose()
+        {
+            Environment.SetEnvironmentVariable(name, originalValue);
+        }
+    }
+}

--- a/tools/App.Maintenance/IncidentRoutingAdmins/IncidentRoutingAdminMaintenanceService.cs
+++ b/tools/App.Maintenance/IncidentRoutingAdmins/IncidentRoutingAdminMaintenanceService.cs
@@ -1,22 +1,23 @@
 using BuildingBlocks.Infrastructure.Persistence;
 using BuildingBlocks.Infrastructure.Persistence.Entities.Auth;
+using BuildingBlocks.Infrastructure.Persistence.Entities.GroupTree;
 
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 
-namespace App.Maintenance.IntegrationAccounts;
+namespace App.Maintenance.IncidentRoutingAdmins;
 
-public sealed class IntegrationAccountMaintenanceService(
+public sealed class IncidentRoutingAdminMaintenanceService(
     PlatformDbContext dbContext,
     IPasswordHasher<AuthUser> passwordHasher)
 {
-    public const string PasswordEnvironmentVariableName = "AA_INTEGRATION_ACCOUNT_PASSWORD";
-    public const string IntegrationAccountLogin = "integration-web-android";
-    public const string IntegrationAccountDisplayName = "Web/Android Integration Account";
+    public const string PasswordEnvironmentVariableName = "AA_INCIDENT_ROUTING_ADMIN_PASSWORD";
+    public const string IncidentRoutingAdminLogin = "incident-routing-admin";
+    public const string IncidentRoutingAdminDisplayName = "Incident Routing Admin";
     public const string PlatformOwnerRoleCode = "platform_owner";
     public const string RootGroupNodeCode = "root";
 
-    public async Task<IntegrationAccountUpsertResult> UpsertAsync(CancellationToken cancellationToken)
+    public async Task<IncidentRoutingAdminUpsertResult> UpsertAsync(CancellationToken cancellationToken)
     {
         var password = ReadRequiredPassword();
         var role = await dbContext.AuthRoles
@@ -33,7 +34,7 @@ public sealed class IntegrationAccountMaintenanceService(
             ?? throw new InvalidOperationException(
                 $"Group node '{RootGroupNodeCode}' was not found. Aborting without changes.");
 
-        var normalizedLogin = NormalizeLogin(IntegrationAccountLogin);
+        var normalizedLogin = NormalizeLogin(IncidentRoutingAdminLogin);
         var user = await dbContext.AuthUsers
             .Include(item => item.UserRoles)
             .SingleOrDefaultAsync(
@@ -52,13 +53,14 @@ public sealed class IntegrationAccountMaintenanceService(
             dbContext.AuthUsers.Add(user);
         }
 
-        user.Login = IntegrationAccountLogin;
+        user.Login = IncidentRoutingAdminLogin;
         user.NormalizedLogin = normalizedLogin;
-        user.DisplayName = IntegrationAccountDisplayName;
+        user.DisplayName = IncidentRoutingAdminDisplayName;
         user.IsActive = true;
         user.CurrentGroupNodeId = rootGroupNode.Id;
         user.PasswordHash = passwordHasher.HashPassword(user, password);
 
+        var wasRoleLinkCreated = false;
         if (!user.UserRoles.Any(item => item.RoleId == role.Id))
         {
             user.UserRoles.Add(new AuthUserRole
@@ -66,15 +68,35 @@ public sealed class IntegrationAccountMaintenanceService(
                 UserId = user.Id,
                 RoleId = role.Id
             });
+
+            wasRoleLinkCreated = true;
+        }
+
+        var assignment = await dbContext.GroupAdminAssignments
+            .SingleOrDefaultAsync(
+                item => item.GroupNodeId == rootGroupNode.Id && item.UserId == user.Id,
+                cancellationToken);
+
+        var wasAssignmentCreated = assignment is null;
+        if (assignment is null)
+        {
+            dbContext.GroupAdminAssignments.Add(new GroupAdminAssignment
+            {
+                GroupNodeId = rootGroupNode.Id,
+                UserId = user.Id,
+                AssignedAtUtc = DateTimeOffset.UtcNow
+            });
         }
 
         await dbContext.SaveChangesAsync(cancellationToken);
 
-        return new IntegrationAccountUpsertResult(
+        return new IncidentRoutingAdminUpsertResult(
             user.Login,
             wasCreated,
             role.Code,
-            rootGroupNode.Code);
+            wasRoleLinkCreated,
+            rootGroupNode.Code,
+            wasAssignmentCreated);
     }
 
     private static string ReadRequiredPassword()
@@ -95,8 +117,10 @@ public sealed class IntegrationAccountMaintenanceService(
     }
 }
 
-public sealed record IntegrationAccountUpsertResult(
+public sealed record IncidentRoutingAdminUpsertResult(
     string Login,
     bool WasCreated,
     string AssignedRoleCode,
-    string AssignedGroupNodeCode);
+    bool WasRoleLinkCreated,
+    string AssignedGroupNodeCode,
+    bool WasAssignmentCreated);

--- a/tools/App.Maintenance/Program.cs
+++ b/tools/App.Maintenance/Program.cs
@@ -1,4 +1,5 @@
 using App.Maintenance.Configuration;
+using App.Maintenance.IncidentRoutingAdmins;
 using App.Maintenance.IntegrationAccounts;
 
 using BuildingBlocks.Infrastructure.Persistence;
@@ -13,37 +14,66 @@ return await AppMaintenanceProgram.RunAsync(args);
 
 internal static class AppMaintenanceProgram
 {
-    public static async Task<int> RunAsync(string[] args)
+    public static Task<int> RunAsync(string[] args)
     {
-        if (!IsIntegrationAccountUpsertCommand(args))
+        return RunAsync(
+            args,
+            CreateHost,
+            Console.Out,
+            Console.Error,
+            CancellationToken.None);
+    }
+
+    internal static async Task<int> RunAsync(
+        string[] args,
+        Func<IHost> hostFactory,
+        TextWriter standardOutput,
+        TextWriter errorOutput,
+        CancellationToken cancellationToken)
+    {
+        if (!TryParseCommand(args, out var command))
         {
-            WriteUsage(Console.Error);
+            WriteUsage(errorOutput);
             return 1;
         }
 
         try
         {
-            using IHost host = CreateHost();
+            using IHost host = hostFactory();
             using IServiceScope scope = host.Services.CreateScope();
 
-            var service = scope.ServiceProvider.GetRequiredService<IntegrationAccountMaintenanceService>();
-            var result = await service.UpsertAsync(CancellationToken.None);
+            switch (command)
+            {
+                case MaintenanceCommand.IntegrationAccountUpsert:
+                    {
+                        var service = scope.ServiceProvider.GetRequiredService<IntegrationAccountMaintenanceService>();
+                        var result = await service.UpsertAsync(cancellationToken);
 
-            Console.Out.WriteLine($"login: {result.Login}");
-            Console.Out.WriteLine($"status: {(result.WasCreated ? "created" : "updated")}");
-            Console.Out.WriteLine($"role: {result.AssignedRoleCode}");
-            Console.Out.WriteLine($"group-node: {result.AssignedGroupNodeCode}");
+                        WriteIntegrationAccountResult(standardOutput, result);
+                        return 0;
+                    }
 
-            return 0;
+                case MaintenanceCommand.IncidentRoutingAdminUpsert:
+                    {
+                        var service = scope.ServiceProvider.GetRequiredService<IncidentRoutingAdminMaintenanceService>();
+                        var result = await service.UpsertAsync(cancellationToken);
+
+                        WriteIncidentRoutingAdminResult(standardOutput, result);
+                        return 0;
+                    }
+
+                default:
+                    throw new InvalidOperationException("Maintenance command is not supported.");
+            }
         }
         catch (InvalidOperationException ex)
         {
-            Console.Error.WriteLine(ex.Message);
+            errorOutput.WriteLine(ex.Message);
             return 1;
         }
         catch (Exception ex)
         {
-            Console.Error.WriteLine($"Maintenance command failed: {ex.Message}");
+            errorOutput.WriteLine($"Maintenance command failed: {ex.Message}");
             return 1;
         }
     }
@@ -57,21 +87,66 @@ internal static class AppMaintenanceProgram
         builder.Logging.ClearProviders();
         builder.Services.AddPlatformPersistence(databaseOptions);
         builder.Services.AddSingleton<IPasswordHasher<AuthUser>, PasswordHasher<AuthUser>>();
+        builder.Services.AddScoped<IncidentRoutingAdminMaintenanceService>();
         builder.Services.AddScoped<IntegrationAccountMaintenanceService>();
 
         return builder.Build();
     }
 
-    private static bool IsIntegrationAccountUpsertCommand(string[] args)
+    private static bool TryParseCommand(string[] args, out MaintenanceCommand command)
     {
-        return args.Length == 2
+        if (args.Length == 2
             && string.Equals(args[0], "integration-account", StringComparison.OrdinalIgnoreCase)
-            && string.Equals(args[1], "upsert", StringComparison.OrdinalIgnoreCase);
+            && string.Equals(args[1], "upsert", StringComparison.OrdinalIgnoreCase))
+        {
+            command = MaintenanceCommand.IntegrationAccountUpsert;
+            return true;
+        }
+
+        if (args.Length == 2
+            && string.Equals(args[0], "incident-routing-admin", StringComparison.OrdinalIgnoreCase)
+            && string.Equals(args[1], "upsert", StringComparison.OrdinalIgnoreCase))
+        {
+            command = MaintenanceCommand.IncidentRoutingAdminUpsert;
+            return true;
+        }
+
+        command = default;
+        return false;
+    }
+
+    private static void WriteIntegrationAccountResult(
+        TextWriter writer,
+        IntegrationAccountUpsertResult result)
+    {
+        writer.WriteLine($"login: {result.Login}");
+        writer.WriteLine($"status: {(result.WasCreated ? "created" : "updated")}");
+        writer.WriteLine($"role: {result.AssignedRoleCode}");
+        writer.WriteLine($"group-node: {result.AssignedGroupNodeCode}");
+    }
+
+    private static void WriteIncidentRoutingAdminResult(
+        TextWriter writer,
+        IncidentRoutingAdminUpsertResult result)
+    {
+        writer.WriteLine($"login: {result.Login}");
+        writer.WriteLine($"status: {(result.WasCreated ? "created" : "updated")}");
+        writer.WriteLine($"role: {result.AssignedRoleCode}");
+        writer.WriteLine($"role-link: {(result.WasRoleLinkCreated ? "created" : "exists")}");
+        writer.WriteLine($"group-node: {result.AssignedGroupNodeCode}");
+        writer.WriteLine($"assignment: {(result.WasAssignmentCreated ? "created" : "exists")}");
     }
 
     private static void WriteUsage(TextWriter writer)
     {
         writer.WriteLine("Usage:");
         writer.WriteLine("  dotnet run --project tools\\App.Maintenance\\App.Maintenance.csproj -- integration-account upsert");
+        writer.WriteLine("  dotnet run --project tools\\App.Maintenance\\App.Maintenance.csproj -- incident-routing-admin upsert");
+    }
+
+    private enum MaintenanceCommand
+    {
+        IntegrationAccountUpsert,
+        IncidentRoutingAdminUpsert
     }
 }

--- a/tools/App.Maintenance/Properties/AssemblyInfo.cs
+++ b/tools/App.Maintenance/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("App.Maintenance.Tests")]


### PR DESCRIPTION
﻿## Goal

Implement S2-31 Incident Routing Admin Assignment Provisioning.

## Module / Scope

App.Maintenance / GroupTree / Incidents / Auth / Korobochka ops.

## Changes

- Adds maintenance command:
  - `incident-routing-admin upsert`
- Creates or updates dedicated incident routing admin:
  - login: `incident-routing-admin`
  - display name: `Incident Routing Admin`
  - group: `root`
  - active: true
- Reads password only from:
  - `AA_INCIDENT_ROUTING_ADMIN_PASSWORD`
- Hashes password through existing `PasswordHasher<AuthUser>`.
- Ensures role:
  - `platform_owner`
- Ensures root group admin assignment in:
  - `app.group_admin_assignments`
- Makes provisioning idempotent.
- Adds safe CLI output without password/hash/token values.
- Adds integration tests for:
  - create path;
  - idempotent second run;
  - missing password env var safe failure;
  - no password/hash/token output.
- Adds ops runbook.

## Contracts

No shared DTO changes.
No public API route changes.
No response payload shape changes.
No enum/status changes.

This is a maintenance command, not a public client API.

## Migration

No database migration.

Reason:
- `group_admin_assignments` already exists;
- schema has the needed composite key/columns;
- existing `AuthUser`, `AuthUserRole`, `GroupNode`, and `GroupAdminAssignment` entities are sufficient.

## Feature flags

No new feature flag.

Reason:
- this is an explicit operator maintenance command, not an always-on runtime user-facing feature.

## Security

- Password is read only from `AA_INCIDENT_ROUTING_ADMIN_PASSWORD`.
- No password printed.
- No password hash printed.
- No accessToken/refreshToken printed.
- No DevelopmentBootstrap.
- No hidden auth bypass.
- No direct ad-hoc SQL provisioning as the primary path.
- No secrets added.

## Manual verification

Local validation:
- `dotnet restore AnalyticsAutomation-Core.sln -nologo`
- `dotnet build tools\App.Maintenance\App.Maintenance.csproj -nologo -v minimal`
- `dotnet test tests\Integration\App.Maintenance\App.Maintenance.Tests.csproj -nologo -v minimal`
- `dotnet test tests\Integration\Incidents\Incidents.IntegrationTests.csproj -nologo -v minimal`
- `dotnet test tests\Integration\App.Api\App.Api.IntegrationTests.csproj -nologo -v minimal`
- `dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore`
- `git diff --check`

Expected PR CI:
- restore;
- format;
- build;
- unit-tests;
- integration-tests.

## Runtime follow-up after merge/deploy

After merge and deploy, operator should run on Korobochka with the password supplied out-of-band:

- `AA_INCIDENT_ROUTING_ADMIN_PASSWORD=<secret>`
- `dotnet run --project tools/App.Maintenance/App.Maintenance.csproj -- incident-routing-admin upsert`

Then verify:
- root group admin assignment exists;
- routing-preview resolves admin for root + `integration-web-android`;
- duplicate incident runtime smoke creates incident/assignment.

## Rollback

Safe rollback is documented in the runbook:
- rotate by rerunning command with a new out-of-band password;
- revoke by approved operator procedure:
  - disable dedicated user;
  - remove root assignment;
  - repeat readonly verification/routing-preview.

No destructive maintenance command is added in this PR.

## Production deploy

Not triggered by this PR.
Deploy workflow is not run from this PR.
