### PR TITLE
S2-37 Admin Review API AuthZ Scope

### DIFF
--- a/src/Modules/Incidents/IncidentsModule.cs
+++ b/src/Modules/Incidents/IncidentsModule.cs
@@ -14,6 +14,7 @@ using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -38,8 +39,25 @@ public interface IDuplicateIncidentRoutingService
 
     Task<DuplicateIncidentV1Dto> RecordDecisionAsync(
         Guid incidentId,
+        Guid currentAdminUserId,
         DuplicateIncidentDecisionRequestV1Dto request,
         CancellationToken cancellationToken);
+}
+
+internal sealed record AuthenticatedDuplicateIncidentAdminScope(Guid UserId)
+{
+    public static AuthenticatedDuplicateIncidentAdminScope FromClaimsPrincipal(ClaimsPrincipal principal)
+    {
+        ArgumentNullException.ThrowIfNull(principal);
+
+        var userIdValue = principal.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        if (!Guid.TryParse(userIdValue, out var userId) || userId == Guid.Empty)
+        {
+            throw new InvalidOperationException("Authenticated user id claim is required.");
+        }
+
+        return new AuthenticatedDuplicateIncidentAdminScope(userId);
+    }
 }
 
 public sealed class DuplicateIncidentRoutingService(
@@ -191,6 +209,7 @@ public sealed class DuplicateIncidentRoutingService(
 
     public async Task<DuplicateIncidentV1Dto> RecordDecisionAsync(
         Guid incidentId,
+        Guid currentAdminUserId,
         DuplicateIncidentDecisionRequestV1Dto request,
         CancellationToken cancellationToken)
     {
@@ -204,7 +223,17 @@ public sealed class DuplicateIncidentRoutingService(
             throw new ArgumentException("IncidentId is required.", nameof(incidentId));
         }
 
+        if (currentAdminUserId == Guid.Empty)
+        {
+            throw new ArgumentException("CurrentAdminUserId is required.", nameof(currentAdminUserId));
+        }
+
         ValidateDecisionRequest(request);
+
+        if (request.DecidedByUserId != currentAdminUserId)
+        {
+            throw new UnauthorizedAccessException("DuplicateIncident decision cannot be recorded for another admin.");
+        }
 
         var incident = await dbContext.DuplicateIncidentRecords
             .SingleOrDefaultAsync(
@@ -216,13 +245,26 @@ public sealed class DuplicateIncidentRoutingService(
             throw new InvalidOperationException("DuplicateIncident was not found.");
         }
 
+        var isAssignedAdmin = await dbContext.DuplicateIncidentAssignmentRecords
+            .AsNoTracking()
+            .AnyAsync(
+                item => item.IncidentId == incidentId
+                    && item.AssignedAdminUserId == currentAdminUserId
+                    && item.IsActive,
+                cancellationToken);
+
+        if (!isAssignedAdmin)
+        {
+            throw new UnauthorizedAccessException("DuplicateIncident decision can only be recorded by the assigned admin.");
+        }
+
         var decidedAtUtc = DateTimeOffset.UtcNow;
 
         var decision = new DuplicateIncidentDecisionRecord
         {
             Id = Guid.NewGuid(),
             IncidentId = incidentId,
-            DecidedByUserId = request.DecidedByUserId,
+            DecidedByUserId = currentAdminUserId,
             Decision = request.Decision.Trim(),
             Notes = string.IsNullOrWhiteSpace(request.Notes)
                 ? null
@@ -439,28 +481,59 @@ public static class IncidentsModule
             });
 
         endpoints.MapGet(
-            "/api/incidents/duplicates/assigned/{assignedAdminUserId:guid}",
+            "/api/incidents/duplicates/assigned/me",
             async Task<IResult> (
-                Guid assignedAdminUserId,
+                HttpContext httpContext,
                 IDuplicateIncidentRoutingService service,
                 CancellationToken cancellationToken) =>
             {
+                var authenticatedScope = AuthenticatedDuplicateIncidentAdminScope.FromClaimsPrincipal(httpContext.User);
+                var result = await service.GetAssignedAsync(authenticatedScope.UserId, cancellationToken);
+                return Results.Ok(result);
+            })
+            .RequireAuthorization();
+
+        endpoints.MapGet(
+            "/api/incidents/duplicates/assigned/{assignedAdminUserId:guid}",
+            async Task<IResult> (
+                Guid assignedAdminUserId,
+                HttpContext httpContext,
+                IDuplicateIncidentRoutingService service,
+                CancellationToken cancellationToken) =>
+            {
+                var authenticatedScope = AuthenticatedDuplicateIncidentAdminScope.FromClaimsPrincipal(httpContext.User);
+                if (authenticatedScope.UserId != assignedAdminUserId)
+                {
+                    return Results.Forbid();
+                }
+
                 var result = await service.GetAssignedAsync(assignedAdminUserId, cancellationToken);
                 return Results.Ok(result);
-            });
+            })
+            .RequireAuthorization();
 
         endpoints.MapPost(
             "/api/incidents/duplicates/{incidentId:guid}/decision",
             async Task<IResult> (
                 Guid incidentId,
                 DuplicateIncidentDecisionRequestV1Dto request,
+                HttpContext httpContext,
                 IDuplicateIncidentRoutingService service,
                 CancellationToken cancellationToken) =>
             {
                 try
                 {
-                    var result = await service.RecordDecisionAsync(incidentId, request, cancellationToken);
+                    var authenticatedScope = AuthenticatedDuplicateIncidentAdminScope.FromClaimsPrincipal(httpContext.User);
+                    var result = await service.RecordDecisionAsync(
+                        incidentId,
+                        authenticatedScope.UserId,
+                        request,
+                        cancellationToken);
                     return Results.Ok(result);
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    return Results.Forbid();
                 }
                 catch (InvalidOperationException exception)
                 {
@@ -477,7 +550,8 @@ public static class IncidentsModule
                         message = exception.Message
                     });
                 }
-            });
+            })
+            .RequireAuthorization();
 
         return endpoints;
     }

--- a/tests/Integration/App.Api/DuplicateIncidentAuthorizationTests.cs
+++ b/tests/Integration/App.Api/DuplicateIncidentAuthorizationTests.cs
@@ -1,0 +1,272 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+using BuildingBlocks.Contracts.Auth;
+using BuildingBlocks.Contracts.Incidents;
+using BuildingBlocks.Infrastructure.Persistence;
+using BuildingBlocks.Infrastructure.Persistence.Entities.Auth;
+
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+using Modules.Incidents;
+
+namespace App.Api.IntegrationTests;
+
+public sealed class DuplicateIncidentAuthorizationTests(AppApiFactory factory) : IClassFixture<AppApiFactory>
+{
+    [Fact]
+    public async Task AssignedMeRejectsAnonymous()
+    {
+        using HttpClient client = factory.CreateClient();
+
+        using HttpResponseMessage response = await client.GetAsync("/api/incidents/duplicates/assigned/me");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task DecisionRejectsAnonymous()
+    {
+        using HttpClient client = factory.CreateClient();
+
+        using HttpResponseMessage response = await client.PostAsJsonAsync(
+            $"/api/incidents/duplicates/{Guid.NewGuid():D}/decision",
+            new DuplicateIncidentDecisionRequestV1Dto(
+                DecidedByUserId: Guid.NewGuid(),
+                Decision: DuplicateIncidentV1DecisionTypes.ConfirmDuplicate,
+                Notes: "Anonymous request should be rejected."));
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task AssignedAdminCanListOwnAssignedDuplicateIncidents()
+    {
+        using HttpClient assignedAdminClient = factory.CreateClient();
+        using HttpClient otherAdminClient = factory.CreateClient();
+
+        var assignedAdmin = await SignInWithContextAsync(assignedAdminClient);
+        var otherAdmin = await SignInWithContextAsync(otherAdminClient);
+
+        var ownIncident = await CreateAssignedIncidentAsync(assignedAdmin.UserId);
+        _ = await CreateAssignedIncidentAsync(otherAdmin.UserId);
+
+        using HttpResponseMessage response = await assignedAdminClient.GetAsync("/api/incidents/duplicates/assigned/me");
+
+        await AssertStatusCodeAsync("assigned incidents me", HttpStatusCode.OK, response);
+
+        AssignedDuplicateIncidentsResponseV1Dto? body =
+            await response.Content.ReadFromJsonAsync<AssignedDuplicateIncidentsResponseV1Dto>();
+
+        Assert.NotNull(body);
+        Assert.Equal(assignedAdmin.UserId, body.AssignedAdminUserId);
+        Assert.Single(body.Incidents);
+        Assert.Equal(ownIncident.IncidentId, body.Incidents.Single().IncidentId);
+        Assert.Equal(assignedAdmin.UserId, body.Incidents.Single().Assignments.Single().AssignedAdminUserId);
+    }
+
+    [Fact]
+    public async Task CallerCannotReadAnotherAdminAssignedIncidentsByRouteIdSubstitution()
+    {
+        using HttpClient assignedAdminClient = factory.CreateClient();
+        using HttpClient callerClient = factory.CreateClient();
+
+        var assignedAdmin = await SignInWithContextAsync(assignedAdminClient);
+        _ = await SignInWithContextAsync(callerClient);
+
+        _ = await CreateAssignedIncidentAsync(assignedAdmin.UserId);
+
+        using HttpResponseMessage response = await callerClient.GetAsync(
+            $"/api/incidents/duplicates/assigned/{assignedAdmin.UserId:D}");
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task AssignedAdminCanRecordDecision()
+    {
+        using HttpClient assignedAdminClient = factory.CreateClient();
+
+        var assignedAdmin = await SignInWithContextAsync(assignedAdminClient);
+        var incident = await CreateAssignedIncidentAsync(assignedAdmin.UserId);
+
+        using HttpResponseMessage response = await assignedAdminClient.PostAsJsonAsync(
+            $"/api/incidents/duplicates/{incident.IncidentId:D}/decision",
+            new DuplicateIncidentDecisionRequestV1Dto(
+                DecidedByUserId: assignedAdmin.UserId,
+                Decision: DuplicateIncidentV1DecisionTypes.ConfirmDuplicate,
+                Notes: "Confirmed by assigned admin."));
+
+        await AssertStatusCodeAsync("record duplicate incident decision", HttpStatusCode.OK, response);
+
+        DuplicateIncidentV1Dto? body = await response.Content.ReadFromJsonAsync<DuplicateIncidentV1Dto>();
+
+        Assert.NotNull(body);
+        Assert.Equal(DuplicateIncidentV1Statuses.Resolved, body.Status);
+        Assert.NotNull(body.LatestDecision);
+        Assert.Equal(assignedAdmin.UserId, body.LatestDecision!.DecidedByUserId);
+
+        using IServiceScope scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<PlatformDbContext>();
+        var decision = await db.DuplicateIncidentDecisionRecords.SingleAsync(item => item.IncidentId == incident.IncidentId);
+
+        Assert.Equal(assignedAdmin.UserId, decision.DecidedByUserId);
+    }
+
+    [Fact]
+    public async Task NonAssignedUserCannotRecordDecision()
+    {
+        using HttpClient assignedAdminClient = factory.CreateClient();
+        using HttpClient callerClient = factory.CreateClient();
+
+        var assignedAdmin = await SignInWithContextAsync(assignedAdminClient);
+        var caller = await SignInWithContextAsync(callerClient);
+        var incident = await CreateAssignedIncidentAsync(assignedAdmin.UserId);
+
+        using HttpResponseMessage response = await callerClient.PostAsJsonAsync(
+            $"/api/incidents/duplicates/{incident.IncidentId:D}/decision",
+            new DuplicateIncidentDecisionRequestV1Dto(
+                DecidedByUserId: caller.UserId,
+                Decision: DuplicateIncidentV1DecisionTypes.ConfirmDuplicate,
+                Notes: "Caller is not assigned."));
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        Assert.Equal(0, await CountDecisionRecordsAsync(incident.IncidentId));
+    }
+
+    [Fact]
+    public async Task MismatchedDecidedByUserIdCannotSpoofAnotherAdmin()
+    {
+        using HttpClient assignedAdminClient = factory.CreateClient();
+        using HttpClient spoofedAdminClient = factory.CreateClient();
+
+        var assignedAdmin = await SignInWithContextAsync(assignedAdminClient);
+        var spoofedAdmin = await SignInWithContextAsync(spoofedAdminClient);
+        var incident = await CreateAssignedIncidentAsync(assignedAdmin.UserId);
+
+        using HttpResponseMessage response = await assignedAdminClient.PostAsJsonAsync(
+            $"/api/incidents/duplicates/{incident.IncidentId:D}/decision",
+            new DuplicateIncidentDecisionRequestV1Dto(
+                DecidedByUserId: spoofedAdmin.UserId,
+                Decision: DuplicateIncidentV1DecisionTypes.ConfirmDuplicate,
+                Notes: "Spoof another admin id."));
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        Assert.Equal(0, await CountDecisionRecordsAsync(incident.IncidentId));
+    }
+
+    private async Task<DuplicateIncidentV1Dto> CreateAssignedIncidentAsync(Guid assignedAdminUserId)
+    {
+        using IServiceScope scope = factory.Services.CreateScope();
+
+        var service = scope.ServiceProvider.GetRequiredService<IDuplicateIncidentRoutingService>();
+
+        return await service.CreateFromCandidateAsync(
+            new DuplicateIncidentCreateRequestV1Dto(
+                DuplicateCandidateId: Guid.NewGuid(),
+                SourceVideoAssetId: Guid.NewGuid(),
+                MatchedVideoAssetId: Guid.NewGuid(),
+                UploaderUserId: Guid.NewGuid(),
+                UploaderGroupNodeId: Guid.NewGuid(),
+                IsUploaderBranchAdmin: false,
+                BranchAdminUserIds: new[] { assignedAdminUserId },
+                HigherAdminUserIds: new[] { Guid.NewGuid() },
+                MatchKind: "HARD_DUPLICATE",
+                ReasonCode: "exact_byte_sha256_size_match",
+                DetectedAtUtc: DateTimeOffset.UtcNow),
+            CancellationToken.None);
+    }
+
+    private async Task<int> CountDecisionRecordsAsync(Guid incidentId)
+    {
+        using IServiceScope scope = factory.Services.CreateScope();
+
+        var db = scope.ServiceProvider.GetRequiredService<PlatformDbContext>();
+
+        return await db.DuplicateIncidentDecisionRecords.CountAsync(item => item.IncidentId == incidentId);
+    }
+
+    private async Task<AuthenticatedAdminClientContext> SignInWithContextAsync(HttpClient client)
+    {
+        string login = $"s2-37-user-{Guid.NewGuid():N}";
+        const string password = "S2-37-test-password!";
+        Guid deviceId = Guid.NewGuid();
+
+        await SeedUserAsync(login, password);
+
+        using HttpResponseMessage signInResponse = await client.PostAsJsonAsync(
+            "/api/auth/sign-in",
+            new SignInRequestDto(
+                Login: login,
+                Password: password,
+                DeviceId: deviceId));
+
+        await AssertStatusCodeAsync("sign in", HttpStatusCode.OK, signInResponse);
+
+        SignInResponseDto? signInBody = await signInResponse.Content.ReadFromJsonAsync<SignInResponseDto>();
+
+        Assert.NotNull(signInBody);
+        Assert.NotNull(signInBody.AccessToken);
+
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", signInBody.AccessToken);
+
+        return new AuthenticatedAdminClientContext(signInBody.User.UserId);
+    }
+
+    private async Task SeedUserAsync(string login, string password)
+    {
+        using IServiceScope scope = factory.Services.CreateScope();
+
+        var dbContext = scope.ServiceProvider.GetRequiredService<PlatformDbContext>();
+        var passwordHasher = scope.ServiceProvider.GetRequiredService<IPasswordHasher<AuthUser>>();
+
+        string normalizedLogin = login.Trim().ToUpperInvariant();
+
+        var user = new AuthUser
+        {
+            Id = Guid.NewGuid(),
+            Login = login,
+            NormalizedLogin = normalizedLogin,
+            DisplayName = "S2-37 Test User",
+            IsActive = true,
+            CreatedAtUtc = DateTimeOffset.UtcNow
+        };
+
+        user.PasswordHash = passwordHasher.HashPassword(user, password);
+
+        dbContext.AuthUsers.Add(user);
+        await dbContext.SaveChangesAsync();
+    }
+
+    private static async Task AssertStatusCodeAsync(
+        string stepName,
+        HttpStatusCode expectedStatus,
+        HttpResponseMessage response)
+    {
+        if (response.StatusCode == expectedStatus)
+        {
+            return;
+        }
+
+        string responseBody = await response.Content.ReadAsStringAsync();
+
+        Assert.Fail(
+            $"""
+            Step: {stepName}
+            Expected status: {expectedStatus} ({(int)expectedStatus})
+            Actual status: {response.StatusCode} ({(int)response.StatusCode})
+            Response body:
+            {responseBody}
+            """);
+    }
+
+    private sealed record AuthenticatedAdminClientContext(Guid UserId);
+}

--- a/tests/Integration/Incidents/DuplicateIncidentRoutingServiceTests.cs
+++ b/tests/Integration/Incidents/DuplicateIncidentRoutingServiceTests.cs
@@ -83,11 +83,13 @@ public sealed class DuplicateIncidentRoutingServiceTests
         var created = await service.CreateFromCandidateAsync(
             CreateRequest(isUploaderBranchAdmin: false),
             CancellationToken.None);
+        var assignedAdminUserId = created.Assignments.Single().AssignedAdminUserId;
 
         var decided = await service.RecordDecisionAsync(
             created.IncidentId,
+            assignedAdminUserId,
             new DuplicateIncidentDecisionRequestV1Dto(
-                DecidedByUserId: Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc"),
+                DecidedByUserId: assignedAdminUserId,
                 Decision: DuplicateIncidentV1DecisionTypes.ConfirmDuplicate,
                 Notes: "Confirmed by test."),
             CancellationToken.None);
@@ -95,6 +97,56 @@ public sealed class DuplicateIncidentRoutingServiceTests
         Assert.Equal(DuplicateIncidentV1Statuses.Resolved, decided.Status);
         Assert.NotNull(decided.LatestDecision);
         Assert.Equal(DuplicateIncidentV1DecisionTypes.ConfirmDuplicate, decided.LatestDecision!.Decision);
+        Assert.Equal(assignedAdminUserId, decided.LatestDecision.DecidedByUserId);
+    }
+
+    [Fact]
+    public async Task RecordDecisionAsyncRejectsNonAssignedUser()
+    {
+        using var provider = CreateProvider();
+        using var scope = provider.CreateScope();
+
+        var service = scope.ServiceProvider.GetRequiredService<IDuplicateIncidentRoutingService>();
+        var created = await service.CreateFromCandidateAsync(
+            CreateRequest(isUploaderBranchAdmin: false),
+            CancellationToken.None);
+
+        var exception = await Assert.ThrowsAsync<UnauthorizedAccessException>(
+            () => service.RecordDecisionAsync(
+                created.IncidentId,
+                Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd"),
+                new DuplicateIncidentDecisionRequestV1Dto(
+                    DecidedByUserId: Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd"),
+                    Decision: DuplicateIncidentV1DecisionTypes.ConfirmDuplicate,
+                    Notes: "Rejected by test."),
+                CancellationToken.None));
+
+        Assert.Equal("DuplicateIncident decision can only be recorded by the assigned admin.", exception.Message);
+    }
+
+    [Fact]
+    public async Task RecordDecisionAsyncRejectsSpoofedDecidedByUserId()
+    {
+        using var provider = CreateProvider();
+        using var scope = provider.CreateScope();
+
+        var service = scope.ServiceProvider.GetRequiredService<IDuplicateIncidentRoutingService>();
+        var created = await service.CreateFromCandidateAsync(
+            CreateRequest(isUploaderBranchAdmin: false),
+            CancellationToken.None);
+        var assignedAdminUserId = created.Assignments.Single().AssignedAdminUserId;
+
+        var exception = await Assert.ThrowsAsync<UnauthorizedAccessException>(
+            () => service.RecordDecisionAsync(
+                created.IncidentId,
+                assignedAdminUserId,
+                new DuplicateIncidentDecisionRequestV1Dto(
+                    DecidedByUserId: Guid.Parse("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"),
+                    Decision: DuplicateIncidentV1DecisionTypes.ConfirmDuplicate,
+                    Notes: "Spoof attempt."),
+                CancellationToken.None));
+
+        Assert.Equal("DuplicateIncident decision cannot be recorded for another admin.", exception.Message);
     }
 
     private static ServiceProvider CreateProvider()


### PR DESCRIPTION
﻿## Coder
Coder 1 / Platform Owner

## Task ID
S2-37

## Module
Incidents / Auth / App.Api

## Scope
Backend-only authz hardening for duplicate incident admin review.

## Changed areas
- `src/Modules/Incidents/IncidentsModule.cs`
- `tests/Integration/Incidents/DuplicateIncidentRoutingServiceTests.cs`
- `tests/Integration/App.Api/DuplicateIncidentAuthorizationTests.cs`

## Contracts
No shared DTO/contracts changes.

## Migrations
No.

## Feature flags
No new feature flag.

Reason:
- this is security hardening of an existing duplicate-incident review surface;
- it must not become an optional authz bypass;
- existing `Modules:Incidents:DuplicateIncidentRoutingEnabled` remains the module-level gate.

## API impact
Additive and authz-hardening only:
- adds `GET /api/incidents/duplicates/assigned/me`
- protects `GET /api/incidents/duplicates/assigned/{assignedAdminUserId}` from route-id spoofing via `403`
- makes `POST /api/incidents/duplicates/{incidentId}/decision` bearer-only
- allows decision only by active assigned admin
- rejects spoofing through `request.DecidedByUserId`
- uses current bearer user id for decision recording

## Web impact
No Web code changes in this PR.

## Android impact
No Android code changes in this PR.

## Offline behavior
No offline behavior change.
Admin review remains online backend/admin scope.

## Rollback
Revert:
- `src/Modules/Incidents/IncidentsModule.cs`
- `tests/Integration/Incidents/DuplicateIncidentRoutingServiceTests.cs`
- `tests/Integration/App.Api/DuplicateIncidentAuthorizationTests.cs`

## Validation
Local validation already passed:
- `dotnet restore AnalyticsAutomation-Core.sln -nologo`
- `dotnet build src/App.Api/App.Api.csproj -nologo -v minimal`
- `dotnet test tests/Integration/Incidents/Incidents.IntegrationTests.csproj -nologo -v minimal`
- `dotnet test tests/Integration/App.Api/App.Api.IntegrationTests.csproj -nologo -v minimal`
- `dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore`
- `git diff --check`

PR CI expected:
- restore
- build
- format
- unit-tests
- integration-tests

## Handoff docs
None in this PR.
Background design source:
- S2-35 task card already merged.

## Next step
After merge:
- deploy current main to Korobochka
- run LAN smoke for admin review:
  - anonymous assigned/me -> 401
  - assigned admin assigned/me -> 200
  - non-assigned admin route-id spoof -> 403
  - assigned admin decision -> success
  - non-assigned admin decision -> reject

## NO-GO / Deferred
- no App.Web changes
- no App.Mobile.Android changes
- no App.UI.Shared changes
- no App.Worker changes
- no shared DTO changes
- no migrations
- no deploy workflow changes
- deferred:
  - admin review UI
  - fraud suspicion admin review surface
  - deep media dedupe review
  - reports/export/read-model polish

## Security notes
- bearer auth required for admin review endpoints
- caller cannot read чужие assigned incidents by route id substitution
- caller cannot spoof another deciding admin through request payload
- no secrets/tokens/passwords added or logged
