### PR TITLE
S2-39 Deploy Trigger Reconciliation

### DIFF
--- a/docs/runbooks/s2-39-deploy-trigger-reconciliation.md
+++ b/docs/runbooks/s2-39-deploy-trigger-reconciliation.md
@@ -1,0 +1,86 @@
+# S2-39 Deploy Trigger Reconciliation
+
+## Purpose
+
+This note records the confirmed mismatch between the expected Korobochka deploy trigger model and the actual current-main workflow behavior. It is docs-only and does not change workflow code or execute deploy.
+
+## Actual current state
+
+- `.github/workflows/deploy-korobochka.yml` on current `main` contains only `workflow_dispatch`.
+- `b377e59` did not receive a deploy run immediately after merge to `main`.
+- An explicit manual dispatch was then executed successfully.
+- Korobochka version afterward matched `b377e59`.
+- The deploy workflow therefore behaves as manual-only today.
+
+## Source inputs behind the mismatch
+
+- `.github/workflows/deploy-korobochka.yml` shows a manual-only trigger model on current `main`.
+- `docs/ops/chatgpt-project-instructions.txt` still describes the server-change flow as `branch -> PR -> merge to main -> GitHub Actions deploy on Korobochka`.
+- `docs/ops/korobochka-chatgpt-context.md` explicitly says auto-deploy on `push` to `main` is not enabled, but it also contains a generic `merge -> deploy` flow description.
+
+## Confirmed mismatch
+
+Expected trigger model:
+
+- deploy on `push` to `main`;
+- deploy on manual `workflow_dispatch`.
+
+Actual trigger model:
+
+- deploy on manual `workflow_dispatch` only;
+- merge to `main` alone does not create a deploy run.
+
+Operational evidence:
+
+- no deploy run was found for `b377e59` until explicit dispatch;
+- explicit dispatch succeeded;
+- server version then became `b377e59`.
+
+## Desired decision for the next implementation step
+
+The next implementation PR must choose exactly one canonical deploy trigger model.
+
+### Option A: restore push-to-main deploy trigger
+
+- Add `push` on `main` back to `.github/workflows/deploy-korobochka.yml`.
+- Keep manual `workflow_dispatch`.
+- Do not add deploy from `pull_request`.
+
+### Option B: formalize manual-only deploy policy
+
+- Keep `.github/workflows/deploy-korobochka.yml` manual-only.
+- Update all operational docs/context so merge to `main` is never described as an automatic deploy trigger.
+
+## Recommendation
+
+- Prefer one canonical deploy trigger model and document it consistently in both workflow YAML and operational docs.
+- Do not leave a split state where operators expect post-merge deploy but the workflow is manual-only.
+- Until the decision is implemented, assume manual dispatch is required after merge.
+
+## Decision criteria
+
+- Release safety.
+- Operational predictability.
+- Not deploying untrusted pull requests.
+- Consistency with docs/context.
+- Minimal ambiguity for maintainers and future task execution.
+
+## Security guardrail
+
+- Do not run the Korobochka self-hosted runner on untrusted pull requests.
+- Do not enable deploy from `pull_request` as part of the reconciliation fix.
+
+## Exact next implementation step
+
+Open one narrow infra PR that does exactly one of the following:
+
+- Option A: change only `.github/workflows/deploy-korobochka.yml` and directly related operational docs to restore `push` to `main` while keeping `workflow_dispatch`.
+- Option B: keep the workflow YAML unchanged and update only the operational docs/context so the canonical policy is manual-only.
+
+No runtime API, contracts, migrations, or deploy execution should be part of that step.
+
+## Non-goals of this note
+
+- No workflow behavior change in this PR.
+- No deploy execution in this PR.
+- No runtime code, contracts, migrations, or secrets handling changes.

--- a/docs/task-cards/S2-39_deploy-trigger-reconciliation.txt
+++ b/docs/task-cards/S2-39_deploy-trigger-reconciliation.txt
@@ -1,0 +1,120 @@
+Title:
+S2-39 Deploy Trigger Reconciliation
+
+Owner:
+Coder 1 / Platform Owner
+
+Module:
+GitHub Actions / Korobochka deploy process / operational docs
+
+Type:
+docs / infra decision / deploy trigger reconciliation
+
+Goal:
+Document the confirmed mismatch between the expected deploy trigger model and the actual current-main workflow behavior, so the next narrow implementation PR can choose one canonical model without changing runtime code or executing deploy in this PR.
+
+Context:
+- Canonical repo: `uVormik/AnalyticsAutomation-Core`.
+- Current main / branch base: `b377e59 S2-37 Admin Review API AuthZ Scope`.
+- S2-37 is merged.
+- S2-38D explicit dispatch deploy audit proved that only an explicit dispatch brought Korobochka to version `b377e59`.
+- S2-38E admin review LAN smoke passed on version `b377e59`.
+- The backend vertical slice is closed; the remaining gap is deploy trigger reconciliation in infra/process/docs.
+
+Observed mismatch:
+- Expected deploy assumption after merge to `main`:
+  - GitHub Actions deploy should be available on `push` to `main`.
+  - GitHub Actions deploy should also remain available through manual `workflow_dispatch`.
+- Actual current-main behavior:
+  - `.github/workflows/deploy-korobochka.yml` currently contains only `workflow_dispatch`.
+  - Merge to `main` did not produce a deploy run for `b377e59`.
+  - An explicit manual dispatch was required.
+
+Evidence:
+- No deploy run was found for `b377e59` until explicit dispatch.
+- Explicit dispatch succeeded.
+- Server version then became `b377e59`.
+- `.github/workflows/deploy-korobochka.yml` on current main is manual-only.
+- Repo operational docs/context still contain wording that can be read as `merge to main -> GitHub Actions deploy`, so the trigger model is ambiguous.
+
+Scope:
+- Add `docs/task-cards/S2-39_deploy-trigger-reconciliation.txt`.
+- Add `docs/runbooks/s2-39-deploy-trigger-reconciliation.md`.
+- Document the mismatch, evidence, decision boundary, and next implementation step.
+- Do not change `.github/workflows/deploy-korobochka.yml` in this PR.
+- Do not execute deploy in this PR.
+
+What changes:
+- Runtime API: no change.
+- Contracts: no change.
+- Migrations: no.
+- Feature flags: no.
+- Workflow behavior: unchanged in this PR.
+- Docs/process: reconciliation package only.
+
+Contracts:
+- No shared DTO changes.
+- No public API route changes.
+- No runtime API contract changes.
+
+Migration:
+- No migration.
+
+Runtime API impact:
+- None.
+
+Feature flag:
+- None.
+
+Events:
+- No product/runtime event changes.
+- This task card is docs/process only.
+
+Security:
+- Do not run the Korobochka self-hosted runner on untrusted pull requests.
+- Future workflow changes must not enable deploy from `pull_request`.
+- Preserve trusted-branch and authorized-maintainer deploy boundaries.
+- Do not expose runner token, SSH keys, secrets, or server-only files in repo/docs/PRs.
+
+Future fix options:
+Option A:
+- Restore `push` to `main` in `.github/workflows/deploy-korobochka.yml`.
+- Keep manual `workflow_dispatch`.
+
+Option B:
+- Formally redefine deploy policy as manual-only.
+- Update all docs/context so merge to `main` is never described as an automatic deploy trigger.
+
+Decision criteria:
+- Release safety.
+- Operational predictability.
+- Not deploying untrusted PRs.
+- Consistency with workflow YAML and docs/context.
+- One canonical deploy trigger model, with no ambiguity.
+
+PR body requirements for this docs PR:
+- Purpose: docs-only deploy trigger reconciliation.
+- Scope: docs-only deploy trigger reconciliation.
+- Contracts: no changes.
+- Migrations: no.
+- Runtime API impact: none.
+- Deploy workflow changed: no, this PR documents mismatch only.
+- Manual verification:
+  - `git diff --check`
+  - `dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore`
+- Rollback: revert docs PR.
+
+Rollback:
+- Task-card PR rollback: revert docs PR.
+- Future implementation rollback:
+  - revert the workflow PR; or
+  - remove the `push` trigger if it proves unsafe.
+- No DB rollback.
+- No runtime rollback introduced by this docs PR.
+
+Definition of done:
+- `docs/task-cards/S2-39_deploy-trigger-reconciliation.txt` is added.
+- `docs/runbooks/s2-39-deploy-trigger-reconciliation.md` is added.
+- The exact mismatch and evidence are recorded.
+- The next implementation step is narrow and isolated.
+- No workflow code, runtime API, contracts, migrations, or deploy execution are included in this PR.


### PR DESCRIPTION
﻿## Goal

Document deploy trigger mismatch and define the next reconciliation step.

## Module / Scope

GitHub Actions / Korobochka deploy process / operational docs.

## Changes

- Adds S2-39 task card.
- Adds S2-39 runbook note.
- Documents observed mismatch:
  - operational expectation says deploy should work from `push main` and `workflow_dispatch`;
  - current deploy workflow behavior observed in practice required explicit dispatch for `b377e59`.
- Documents decision fork for the next isolated implementation step:
  - Option A: restore push-to-main trigger;
  - Option B: formally declare deploy manual-only and align docs/context.

## Contracts

No shared DTO changes.
No public API route changes.
No runtime contract changes.

## Migrations

No.

## Feature flags

No.

## Runtime API impact

None.

## Deploy workflow changed in this PR

No.
This PR documents the mismatch only.

## Manual verification

- `git diff --check`
- `dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore`

## Rollback

Revert this docs PR.

## Security notes

- do not run self-hosted runner on untrusted PRs
- no secrets in repo or logs
- no runtime deploy execution in this PR
