### PR TITLE
S2-40 Coordination Readiness and ChatGPT Sync Readiness

### DIFF
--- a/00_START_HERE_README.txt
+++ b/00_START_HERE_README.txt
@@ -1,0 +1,17 @@
+START HERE - Coordination Readiness
+
+Before any new work step, any new chat, any resumed work after a pause, or any continuation after someone else merged into main:
+
+1. If the working tree is dirty, commit or stash first.
+2. Run git fetch origin --prune.
+3. Run git switch main.
+4. Run git pull --ff-only origin main.
+5. Read the latest TEAM COORDINATION LOG entries.
+6. Open every referenced handoff doc and task card.
+7. Only then return to the feature/docs branch and continue.
+
+Remember:
+- GitHub main + TEAM COORDINATION LOG are the source of truth.
+- Telegram is notification only.
+- Do not continue from stale local main.
+- Do not continue from Telegram retellings, screenshots, or oral summaries alone.

--- a/02_SHARED_RULES_AND_PROTOCOLS.txt
+++ b/02_SHARED_RULES_AND_PROTOCOLS.txt
@@ -1,0 +1,31 @@
+SHARED RULES AND PROTOCOLS
+
+MANDATORY START-OF-STEP SYNC
+
+Hard rule:
+Before any new work step, before any new chat, when resuming after a pause, and after any other merge to main, the coder must first make local state current and re-read the coordination context.
+
+Required sequence:
+1. If the working tree is dirty, commit or stash first.
+2. Run git fetch origin --prune.
+3. Run git switch main.
+4. Run git pull --ff-only origin main.
+5. Read the latest TEAM COORDINATION LOG entries.
+6. Open and review every referenced handoff doc and task card.
+7. Only then return to the working feature/docs branch and continue.
+
+This sync is mandatory:
+- before each new work step;
+- before each new chat;
+- when resuming after a pause;
+- after any merge by someone else into main.
+
+Hard constraints:
+- GitHub main + TEAM COORDINATION LOG are the source of truth for current project coordination state.
+- Telegram is notification only and never replaces GitHub main, the coordination log, or referenced handoff/task-card docs.
+- Telegram retellings, screenshots, and oral summaries are not enough to continue work.
+- Work must not continue from stale local main; fetch and pull --ff-only are mandatory before relying on local state.
+- Returning to a feature/docs branch is allowed only after the sync sequence above is completed.
+- Reviewer or maintainer may reject sync-readiness claims that do not identify what coordination log entries and handoff/task-card sources were actually reviewed.
+- Nobody should claim automatic sync completed when repo-side updates exist but ChatGPT-side prerequisites were not actually checked.
+- This rule protects the current coordination point and prevents silent drift between local state, GitHub state, and ChatGPT/project context.

--- a/03_TASK_CARD_TEMPLATE.txt
+++ b/03_TASK_CARD_TEMPLATE.txt
@@ -1,0 +1,26 @@
+Title:
+
+Owner:
+
+Module:
+
+Type:
+
+Goal:
+
+Context:
+
+Upstream context / reviewed sources:
+- Base main SHA at task start:
+- Coordination log entries reviewed:
+- Handoff/task cards reviewed:
+
+Scope:
+
+What changes:
+
+Validation:
+
+Rollback:
+
+Definition of done:

--- a/04_GITHUB_WORKFLOW_AND_INFRA_RULES.txt
+++ b/04_GITHUB_WORKFLOW_AND_INFRA_RULES.txt
@@ -1,0 +1,16 @@
+GITHUB WORKFLOW AND INFRA RULES
+
+PR sync-readiness metadata
+
+Each PR body must include:
+- Base main SHA
+- Coordination log entries reviewed
+- Handoff/task cards reviewed
+
+Review hardening
+
+- Reviewer may return a PR without review if sync readiness is not confirmed.
+- Reviewer may return a PR without review if the branch is clearly stale relative to main.
+- Reviewer may return a PR without review if the coder did not state which coordination log entries, handoff docs, or task cards were reviewed.
+- Reviewer is not required to reconstruct current context from Telegram messages, screenshots, or oral retellings.
+- Protected main discipline is not weakened by docs/process-only scope; sync readiness still must be shown explicitly.

--- a/docs/ops/korobochka-chatgpt-context.md
+++ b/docs/ops/korobochka-chatgpt-context.md
@@ -190,6 +190,23 @@ Push в main auto-deploy пока не включен. Включение push-t
 - Module data ownership mandatory.
 - New work starts as a task card.
 
+## Source of truth and sync readiness
+
+- Source of truth for current project coordination state = GitHub main + TEAM COORDINATION LOG.
+- Telegram = notification only.
+- Telegram retellings, screenshots, and oral summaries do not replace GitHub main, TEAM COORDINATION LOG, or linked handoff/task-card docs.
+- Before any new task, any new chat, any resumed work after a pause, or any continuation after another merge to main, first:
+  1. if the working tree is dirty, commit or stash;
+  2. run git fetch origin --prune;
+  3. run git switch main;
+  4. run git pull --ff-only origin main;
+  5. review the latest TEAM COORDINATION LOG entries;
+  6. review every referenced handoff doc and task card;
+  7. only then return to the working branch and continue.
+- If sync readiness is not confirmed, ChatGPT must not behave as if project context is guaranteed current.
+- Do not claim automatic sync completed unless repo-side sync and ChatGPT-side prerequisites were both actually verified.
+- Project context must support repo rules and must never weaken or conflict with them.
+
 ## Как продолжать работу
 
 При новых задачах учитывать, что сервер уже поднят и деплой автоматизирован.


### PR DESCRIPTION
## Coder
Coder 1 / Platform Owner

## Task ID
S2-40

## Module
Docs / process / ChatGPT project context

## Scope
Docs/process/context hardening only.

## Changed areas
- 00_START_HERE_README.txt
- 02_SHARED_RULES_AND_PROTOCOLS.txt
- 03_TASK_CARD_TEMPLATE.txt
- 04_GITHUB_WORKFLOW_AND_INFRA_RULES.txt
- docs/ops/korobochka-chatgpt-context.md

## Base main SHA
bf46a3e

## Coordination log entries reviewed
S2-39 merge context and latest TEAM COORDINATION LOG status were reviewed before this branch work.
GitHub main remains the source of truth.

## Handoff/task cards reviewed
- S2-36 Team Coordination Automation MVP context
- S2-39 Deploy Trigger Reconciliation context
- S2-40 coordination readiness request from owner

## Contracts
No shared DTO/contracts changes.

## Migrations
No.

## Feature flags
No.

## API impact
No runtime API changes.

## Web impact
No App.Web changes.

## Android impact
No App.Mobile.Android changes.

## Offline behavior
No offline behavior change.

## Rollback
Revert this docs PR.

## Validation
Repo-side validation:
- git diff --check
- git diff --name-only
- dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore
- checked that 01_MASTER_PLAN_AND_ARCHITECTURE.txt was not changed
- checked runtime/API/contracts/migrations/deploy workflow scope was not changed
- checked S2-40 files for BOM / hidden Unicode / unsafe Unicode categories

Build/tests:
- not required for this docs/context-only change set
- CI still required on PR

## Handoff docs
This PR updates process/context docs and docs/ops/korobochka-chatgpt-context.md.

## Next step
After merge:
- refresh or re-upload updated docs/ops/korobochka-chatgpt-context.md into ChatGPT Project Sources;
- verify ChatGPT project/workspace uses current sources/instructions;
- verify GitHub app / repo access and TEAM COORDINATION LOG accessibility from the ChatGPT-side workflow if available.

## NO-GO / Deferred
- no runtime code changes
- no API/contracts changes
- no migrations
- no deploy workflow changes
- no deploy execution
- no claim that ChatGPT-side automatic sync is fully verified

## Security notes
- GitHub main + TEAM COORDINATION LOG remain source of truth.
- Telegram remains notification-only.
- Do not rely on Telegram screenshots or oral retelling as source of truth.
- Do not claim automatic sync completed unless ChatGPT Project Sources / GitHub app / coordination log access are actually verified.