### PR TITLE
S2-42 Formalize Manual-only Korobochka Deploy Policy

### DIFF
--- a/04_GITHUB_WORKFLOW_AND_INFRA_RULES.txt
+++ b/04_GITHUB_WORKFLOW_AND_INFRA_RULES.txt
@@ -1,5 +1,13 @@
 GITHUB WORKFLOW AND INFRA RULES
 
+Korobochka deploy policy
+
+- Korobochka deploy is manual-only through GitHub Actions `workflow_dispatch` in `.github/workflows/deploy-korobochka.yml`.
+- Merge or push to `main` does not automatically deploy to Korobochka.
+- `pull_request` must not deploy to Korobochka.
+- Push-to-main auto-deploy remains disabled until a separate approved PR explicitly restores a push trigger.
+- After a manual deploy, verify health, version, and smoke checks.
+
 PR sync-readiness metadata
 
 Each PR body must include:

--- a/docs/ops/chatgpt-project-instructions.txt
+++ b/docs/ops/chatgpt-project-instructions.txt
@@ -4,8 +4,8 @@
 
 Не просить и не публиковать секреты, пароли, GitHub runner token, private SSH keys.
 
-Учитывать, что Коробочка уже настроена: Ubuntu Server 24.04 LTS, App.Api, App.Worker, PostgreSQL, Nginx, GitHub Actions self-hosted runner, автоматический деплой из main через v1-deploy.
+Учитывать, что Коробочка уже настроена: Ubuntu Server 24.04 LTS, App.Api, App.Worker, PostgreSQL, Nginx, GitHub Actions self-hosted runner, manual-only deploy через GitHub Actions `workflow_dispatch` и v1-deploy.
 
 Не предлагать переустановку Ubuntu, пересоздание БД или ручной запуск сервера без необходимости.
 
-Для серверных изменений использовать обычный flow: ветка -> PR -> merge в main -> GitHub Actions deploy на Коробочку.
+Для серверных изменений использовать обычный flow: ветка -> PR -> merge в main -> repo CI/coordination flow. Deploy на Коробочку НЕ запускается автоматически от merge/push; оператор вручную запускает GitHub Actions `deploy-korobochka.yml` через `workflow_dispatch`, затем проверяет health/version/smoke.

--- a/docs/ops/korobochka-chatgpt-context.md
+++ b/docs/ops/korobochka-chatgpt-context.md
@@ -25,7 +25,7 @@
 - Main branch: main
 - Direct push to main запрещён.
 - Изменения идут через короткие ветки и Pull Request.
-- Текущее состояние: merge в main НЕ запускает deploy автоматически. Deploy на Коробочку сейчас выполняется вручную через GitHub Actions workflow_dispatch. Автоматический deploy на push в main требует отдельного PR и явного решения владельца проекта.
+- Текущее состояние: merge в main НЕ запускает deploy автоматически. Deploy на Коробочку сейчас выполняется вручную через GitHub Actions workflow `.github/workflows/deploy-korobochka.yml` по `workflow_dispatch`. Автоматический deploy на push в main требует отдельного PR и явного решения владельца проекта.
 
 ## Технологический baseline
 
@@ -95,13 +95,13 @@ Important paths:
   - framework: .NET 10.0.6
   - databaseProvider: PostgreSQL / EF Core / Npgsql
 - GitHub Actions runner активен и слушает jobs.
-- Текущий release после автоматического деплоя: 20260420-072726
+- Текущий release после ранее выполненного deploy: 20260420-072726
 - current-api -> /opt/v1-pyton/releases/20260420-072726/api
 - current-worker -> /opt/v1-pyton/releases/20260420-072726/worker
 
 ## Deployment flow
 
-GitHub main
+Manual GitHub Actions `workflow_dispatch` in `.github/workflows/deploy-korobochka.yml`
 -> GitHub Actions self-hosted runner on Korobochka
 -> sudo /usr/local/bin/v1-deploy
 -> backup
@@ -114,6 +114,14 @@ GitHub main
 Актуальный workflow сейчас запускается только на:
 
 - manual workflow_dispatch
+
+Merge/push в main НЕ запускает deploy на Коробочку автоматически. Merge в main фиксирует код и запускает repo CI/coordination flow. Deploy выполняется только вручную через GitHub Actions `workflow_dispatch`.
+
+После ручного deploy обязательно проверить health/version/smoke:
+
+- health ready;
+- `/api/system/version`;
+- smoke-check результата deploy.
 
 Push в main auto-deploy пока не включен. Включение push-trigger требует отдельного PR, CI и явного approval.
 
@@ -209,14 +217,17 @@ Push в main auto-deploy пока не включен. Включение push-t
 
 ## Как продолжать работу
 
-При новых задачах учитывать, что сервер уже поднят и деплой автоматизирован.
+При новых задачах учитывать, что сервер уже поднят и deploy pipeline настроен, но push-to-main auto-deploy сейчас не включён.
 
 Для серверных изменений предпочтительно:
 
 1. изменить код/конфиг в ветке;
 2. PR в GitHub;
 3. merge в main;
-4. GitHub Actions деплоит на Коробочку.
+4. repo CI/coordination flow фиксирует состояние main;
+5. оператор вручную запускает GitHub Actions `deploy-korobochka.yml` через `workflow_dispatch`;
+6. после deploy проверяются health/version/smoke.
+
 ## S2-04 manual deploy verification
 
 На 2026-04-20 проверено:

--- a/docs/runbooks/s2-39-deploy-trigger-reconciliation.md
+++ b/docs/runbooks/s2-39-deploy-trigger-reconciliation.md
@@ -4,6 +4,20 @@
 
 This note records the confirmed mismatch between the expected Korobochka deploy trigger model and the actual current-main workflow behavior. It is docs-only and does not change workflow code or execute deploy.
 
+## S2-42 outcome
+
+S2-42 selected Option B: formalize the manual-only Korobochka deploy policy.
+
+Canonical policy after S2-42:
+
+- merge to `main` fixes code in the repository and runs the repo CI/coordination flow;
+- Korobochka deploy is not triggered automatically by merge or push to `main`;
+- Korobochka deploy is executed manually through GitHub Actions `workflow_dispatch` in `.github/workflows/deploy-korobochka.yml`;
+- after a manual deploy, operators must verify health, version, and smoke checks;
+- push-to-main auto-deploy remains disabled until a separate PR and explicit owner approval.
+
+No workflow YAML change is part of S2-42.
+
 ## Actual current state
 
 - `.github/workflows/deploy-korobochka.yml` on current `main` contains only `workflow_dispatch`.
@@ -12,11 +26,12 @@ This note records the confirmed mismatch between the expected Korobochka deploy 
 - Korobochka version afterward matched `b377e59`.
 - The deploy workflow therefore behaves as manual-only today.
 
-## Source inputs behind the mismatch
+## Source inputs behind the original S2-39 mismatch
 
 - `.github/workflows/deploy-korobochka.yml` shows a manual-only trigger model on current `main`.
-- `docs/ops/chatgpt-project-instructions.txt` still describes the server-change flow as `branch -> PR -> merge to main -> GitHub Actions deploy on Korobochka`.
-- `docs/ops/korobochka-chatgpt-context.md` explicitly says auto-deploy on `push` to `main` is not enabled, but it also contains a generic `merge -> deploy` flow description.
+- At the time of S2-39, `docs/ops/chatgpt-project-instructions.txt` still described the server-change flow as `branch -> PR -> merge to main -> GitHub Actions deploy on Korobochka`.
+- At the time of S2-39, `docs/ops/korobochka-chatgpt-context.md` explicitly said auto-deploy on `push` to `main` was not enabled, but it also contained a generic `merge -> deploy` flow description.
+- S2-42 updates the active docs/context wording to manual-only.
 
 ## Confirmed mismatch
 
@@ -36,26 +51,26 @@ Operational evidence:
 - explicit dispatch succeeded;
 - server version then became `b377e59`.
 
-## Desired decision for the next implementation step
+## Decision model
 
-The next implementation PR must choose exactly one canonical deploy trigger model.
+The reconciliation decision is now made by S2-42. Option B is canonical.
 
-### Option A: restore push-to-main deploy trigger
+### Historical Option A: restore push-to-main deploy trigger
 
 - Add `push` on `main` back to `.github/workflows/deploy-korobochka.yml`.
 - Keep manual `workflow_dispatch`.
 - Do not add deploy from `pull_request`.
 
-### Option B: formalize manual-only deploy policy
+### Selected Option B: formalize manual-only deploy policy
 
 - Keep `.github/workflows/deploy-korobochka.yml` manual-only.
 - Update all operational docs/context so merge to `main` is never described as an automatic deploy trigger.
 
 ## Recommendation
 
-- Prefer one canonical deploy trigger model and document it consistently in both workflow YAML and operational docs.
+- Keep one canonical deploy trigger model and document it consistently in operational docs.
 - Do not leave a split state where operators expect post-merge deploy but the workflow is manual-only.
-- Until the decision is implemented, assume manual dispatch is required after merge.
+- Manual dispatch is required after merge when a Korobochka deploy is needed.
 
 ## Decision criteria
 
@@ -70,12 +85,9 @@ The next implementation PR must choose exactly one canonical deploy trigger mode
 - Do not run the Korobochka self-hosted runner on untrusted pull requests.
 - Do not enable deploy from `pull_request` as part of the reconciliation fix.
 
-## Exact next implementation step
+## S2-42 implementation step
 
-Open one narrow infra PR that does exactly one of the following:
-
-- Option A: change only `.github/workflows/deploy-korobochka.yml` and directly related operational docs to restore `push` to `main` while keeping `workflow_dispatch`.
-- Option B: keep the workflow YAML unchanged and update only the operational docs/context so the canonical policy is manual-only.
+Open one narrow docs/process PR that keeps the workflow YAML unchanged and updates only the operational docs/context so the canonical policy is manual-only.
 
 No runtime API, contracts, migrations, or deploy execution should be part of that step.
 

--- a/docs/task-cards/S2-39_deploy-trigger-reconciliation.txt
+++ b/docs/task-cards/S2-39_deploy-trigger-reconciliation.txt
@@ -21,6 +21,12 @@ Context:
 - S2-38E admin review LAN smoke passed on version `b377e59`.
 - The backend vertical slice is closed; the remaining gap is deploy trigger reconciliation in infra/process/docs.
 
+Post-S2-42 outcome:
+- S2-42 selected Option B.
+- The canonical deploy policy is manual-only `workflow_dispatch` through `.github/workflows/deploy-korobochka.yml`.
+- Merge/push to `main` does not automatically deploy to Korobochka.
+- The expected deploy assumption below is retained as historical S2-39 mismatch input, not current policy.
+
 Observed mismatch:
 - Expected deploy assumption after merge to `main`:
   - GitHub Actions deploy should be available on `push` to `main`.

--- a/docs/task-cards/S2-42_formalize-manual-only-deploy-policy.txt
+++ b/docs/task-cards/S2-42_formalize-manual-only-deploy-policy.txt
@@ -1,0 +1,103 @@
+Title:
+S2-42 Formalize Manual-only Korobochka Deploy Policy
+
+Owner:
+Coder 1 / Platform Owner
+
+Module:
+GitHub Actions / Korobochka deploy process / docs
+
+Type:
+docs / process / context hardening
+
+Goal:
+Formalize Option B from S2-39: Korobochka deploy remains manual-only, and operational docs/context must not describe merge to main as an automatic deploy trigger.
+
+Context:
+- Canonical repo: `uVormik/AnalyticsAutomation-Core`.
+- Current branch: `docs/s2-42-formalize-manual-only-deploy-policy`.
+- S2-39 documented the mismatch between workflow behavior and older docs/context wording.
+- S2-41 preflight audit baseline was OK.
+- `.github/workflows/deploy-korobochka.yml` currently uses manual `workflow_dispatch`.
+
+Canonical policy:
+- Merge to `main` fixes code in the repository and runs repo CI/coordination flow.
+- Korobochka deploy does not start automatically from merge or push to `main`.
+- Korobochka deploy is executed manually through GitHub Actions `workflow_dispatch` in `.github/workflows/deploy-korobochka.yml`.
+- After manual deploy, operators must verify health, version, and smoke checks.
+- Push-to-main auto-deploy remains disabled until a separate PR and explicit owner approval.
+
+Scope:
+- `docs/ops/`
+- `docs/runbooks/`
+- `docs/task-cards/`
+- `04_GITHUB_WORKFLOW_AND_INFRA_RULES.txt`
+- Docs-only files that explicitly contain conflicting deploy wording.
+
+Out of scope:
+- `.github/workflows/deploy-korobochka.yml`
+- `.github/workflows/*`
+- Runtime API code
+- Contracts
+- DB migrations
+- Deploy scripts
+- Production/server runtime behavior
+- Deploy execution
+
+What changes:
+- Runtime API: no.
+- Contracts: no changes.
+- Migrations: no.
+- Feature flags: no.
+- Workflow code: no changes.
+- Deploy execution: no.
+- Docs/process: formalize manual-only deploy policy.
+
+Contracts:
+- No shared DTO changes.
+- No public API route changes.
+- No runtime API contract changes.
+
+Migration:
+- No migration.
+
+Runtime API impact:
+- None.
+
+Feature flags:
+- None.
+
+Workflow code:
+- No changes.
+
+Deploy execution:
+- No deploy is executed by this task.
+
+Security:
+- Do not enable deploy from `pull_request`.
+- Do not enable push-to-main deploy in this task.
+- Do not expose runner token, SSH keys, secrets, or server-only files in repo/docs/PRs.
+
+Future option:
+- A push trigger can be restored only by a separate PR and explicit owner approval.
+
+Rollback:
+- Revert the docs PR.
+
+Verification:
+- `git diff --check`
+- `dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore`
+- `git diff --name-only`
+- Confirm `.github/workflows/deploy-korobochka.yml` was not changed.
+- Confirm runtime/API/contracts/migrations/deploy scripts were not changed.
+
+Build/tests:
+- Not required for docs-only scope.
+- CI will still verify the PR.
+
+Definition of done:
+- Conflicting docs/context wording no longer describes merge to main as automatic Korobochka deploy.
+- S2-39 runbook records that Option B was selected in S2-42.
+- Infra rules include a small Korobochka deploy policy block.
+- New S2-42 task card exists.
+- No workflow code, runtime API, contracts, migrations, deploy scripts, or deploy execution are included.


### PR DESCRIPTION
﻿## Coder
Coder 1 / Platform Owner

## Task ID
S2-42

## Module
GitHub Actions / Korobochka deploy process / docs

## Scope
Docs/process/context hardening only.

## Changed areas
- 04_GITHUB_WORKFLOW_AND_INFRA_RULES.txt
- docs/ops/chatgpt-project-instructions.txt
- docs/ops/korobochka-chatgpt-context.md
- docs/runbooks/s2-39-deploy-trigger-reconciliation.md
- docs/task-cards/S2-39_deploy-trigger-reconciliation.txt
- docs/task-cards/S2-42_formalize-manual-only-deploy-policy.txt

## Base main SHA
cb0b960b9b4bc4ea8f11528ea8a0ad05f56644b5

## Coordination log entries reviewed
S2-40 merge status and S2-41 preflight context reviewed before this work.

## Handoff/task cards reviewed
- S2-39 Deploy Trigger Reconciliation
- S2-40 Coordination Readiness and ChatGPT Sync Readiness
- S2-41 Preflight Tail Audit
- S2-42 owner decision: Option B, formalize manual-only deploy policy

## Contracts
No shared DTO/contracts changes.

## Migrations
No.

## Feature flags
No.

## API impact
No runtime API changes.

## Web impact
No App.Web changes.

## Android impact
No App.Mobile.Android changes.

## Offline behavior
No offline behavior change.

## Deploy workflow changed
No.
.github/workflows/deploy-korobochka.yml is not changed in this PR.

## Canonical deploy policy
- Merge to main fixes code in the repository and runs repo CI/coordination flow.
- Korobochka deploy is not triggered automatically by merge or push to main.
- Korobochka deploy is executed manually through GitHub Actions workflow_dispatch in .github/workflows/deploy-korobochka.yml.
- pull_request must not deploy to Korobochka.
- After manual deploy, operators must verify health, version, and smoke checks.
- Push-to-main auto-deploy remains disabled until a separate PR and explicit owner approval.

## Validation
Repo-side validation:
- git diff --check
- dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore
- deploy workflow unchanged guard
- all GitHub workflows unchanged guard
- runtime scope guard
- deploy scripts guard

Build/tests:
- not required for this docs/context-only change set
- CI still required on PR

## Handoff docs
S2-39 runbook updated with S2-42 outcome.

## Next step
After merge:
- refresh/re-upload docs/ops/korobochka-chatgpt-context.md into ChatGPT Project Sources because this PR changes deploy-policy context;
- do not run deploy workflow for this docs-only PR.

## NO-GO / Deferred
- no runtime code changes
- no API/contracts changes
- no migrations
- no deploy workflow changes
- no deploy scripts changes
- no deploy execution
- push-to-main auto-deploy remains deferred and requires separate approved PR

## Security notes
- self-hosted runner must not run untrusted pull_request deploys
- no secrets/tokens/passwords added or logged
