### PR TITLE
S2-45 Replace stale S2-18 Web prompt with desktop-client prompt

### DIFF
--- a/docs/handoffs/C2_S2_18_WEB_UPLOAD_CONTROL_PLANE_HANDOFF.md
+++ b/docs/handoffs/C2_S2_18_WEB_UPLOAD_CONTROL_PLANE_HANDOFF.md
@@ -1,3 +1,10 @@
+> SUPERSEDED FOR PRIMARY DESKTOP CLIENT
+>
+> This Web/PWA/App.Web handoff is stale for primary desktop-client planning after PR #101 / desktop-client form architecture update.
+> App.Web may still be used as a non-primary web/admin/diagnostic/support surface.
+> Primary desktop-client work must use the standalone desktop-client replacement prompt in `docs/handoffs/S2_18_DESKTOP_CLIENT_UPLOAD_CONTROL_PLANE_PROMPT.md`.
+> Do not use this file as the primary desktop-client implementation prompt.
+
 # C2 S2-18 Web Upload Control Plane Handoff
 
 Status: local increment ready for PR readiness.

--- a/docs/handoffs/S2_18_DESKTOP_CLIENT_UPLOAD_CONTROL_PLANE_PROMPT.md
+++ b/docs/handoffs/S2_18_DESKTOP_CLIENT_UPLOAD_CONTROL_PLANE_PROMPT.md
@@ -1,0 +1,78 @@
+# S2-18 Desktop Client Upload Control Plane Prompt
+
+Use this prompt for a future implementation chat/Codex session that builds the primary desktop upload flow.
+
+## Ready Prompt
+
+You are working in `uVormik/AnalyticsAutomation-Core`.
+
+Task:
+Implement the primary desktop upload control-plane flow as a standalone launchable desktop application.
+
+Important architecture boundary:
+- The primary desktop client must be a standalone desktop application.
+- App.Web is not the primary desktop client.
+- App.Web may remain a non-primary web/admin/diagnostic/support surface.
+- Browser/PWA/App.Web cannot be used as the primary desktop client without a new explicit architecture decision.
+- S2-18-WEB is stale for primary desktop-client implementation.
+- S2-18-ANDROID remains broadly aligned with the mobile baseline.
+
+Before coding:
+1. Verify the active repository root, current branch, and clean working tree.
+2. Search the repo docs for an approved desktop UI technology decision/task card.
+3. If no approved desktop UI technology decision exists, stop implementation work and create only a narrow desktop technology decision/task card. Do not implement UI code and do not select a concrete UI technology yourself.
+4. If an approved desktop UI technology decision exists, follow it exactly and keep changes scoped to the approved desktop-client surface.
+
+Required flow:
+Implement or reuse this upload control-plane flow:
+
+SignIn -> GroupTree -> file select -> SHA-256 -> businessObjectKey -> PreUploadCheck -> direct site upload boundary -> UploadReceipt
+
+Flow requirements:
+- Authenticate through the existing server control-plane auth surface.
+- Load the group tree through the server control plane.
+- Let the user select a local video file in the standalone desktop app.
+- Compute SHA-256 client-side before upload.
+- Produce or collect `businessObjectKey` before `PreUploadCheck`.
+- Run `PreUploadCheck` before site upload when the server is online.
+- Upload video bytes directly from the client to the site boundary.
+- Submit `UploadReceipt` only after the direct site upload boundary succeeds or a task-approved stub reports success.
+
+Hard boundaries:
+- Video bytes must not go through App.Api.
+- App.Api must remain the control plane, not a media byte proxy.
+- Do not change public API routes, DTOs, shared contracts, migrations, workflows, deploy scripts, or server runtime unless a separate explicit task approves it.
+- Do not use App.Web as the primary desktop-client implementation.
+- Do not add offline behavior beyond limited/deferred placeholders unless a specific task card approves offline scope.
+
+Site provider boundary:
+- The real site provider may be stubbed behind a desktop-client adapter seam.
+- A stub must make the direct-site boundary explicit.
+- A stub must not send bytes through App.Api.
+- Keep replacement by a real provider straightforward and local to the adapter boundary.
+
+Security:
+- Do not commit credentials.
+- Do not print passwords, access tokens, refresh tokens, authorization headers, or secret-bearing response bodies.
+- Redact token-like values in logs, UI diagnostics, tests, screenshots, and PR notes.
+
+Validation expectations:
+- Run targeted format/build/test commands for the affected desktop-client and shared projects.
+- Run `git diff --check`.
+- Verify changed files stay inside the approved desktop-client/docs/test scope.
+- Confirm no API/contracts/migrations/workflows/deploy changes unless explicitly approved.
+- Confirm App.Web remains non-primary and is not used as the desktop implementation surface.
+- Include a sanitized manual smoke path for SignIn, GroupTree, file select, SHA-256, PreUploadCheck, direct-site boundary, and UploadReceipt.
+
+PR metadata expectations:
+- State the approved desktop UI technology decision/task card used.
+- State whether the site provider is real or stubbed behind an adapter seam.
+- State that video bytes do not pass through App.Api.
+- State that server remains the control plane.
+- State contracts/migrations/workflows/deploy impact.
+- State App.Web/App.Mobile.Android impact.
+- Include validation commands and results.
+- Include any deferred offline or provider work as follow-up tasks.
+
+Stop condition:
+If the approved desktop UI technology decision is missing, do not implement desktop UI/runtime code. Create the narrow technology decision/task card and report that implementation is blocked until that decision is approved.

--- a/docs/operations/C2_CODEX_AUTOMATION_PROMPTS.md
+++ b/docs/operations/C2_CODEX_AUTOMATION_PROMPTS.md
@@ -79,6 +79,11 @@ Required gates:
 
 Use for bounded code changes.
 
+Desktop client prompt replacement:
+- For primary desktop-client upload control-plane work, use `docs/handoffs/S2_18_DESKTOP_CLIENT_UPLOAD_CONTROL_PLANE_PROMPT.md`.
+- `docs/task-cards/C2-S2-18_web-upload-control-plane-integration.txt` and `docs/handoffs/C2_S2_18_WEB_UPLOAD_CONTROL_PLANE_HANDOFF.md` are stale for primary desktop-client implementation after PR #101.
+- App.Web remains available only as a non-primary web/admin/diagnostic/support surface unless a new explicit architecture decision says otherwise.
+
 Required behavior:
 - verify current feature branch
 - verify clean working tree

--- a/docs/task-cards/C2-S2-18_desktop-client-upload-control-plane-integration.txt
+++ b/docs/task-cards/C2-S2-18_desktop-client-upload-control-plane-integration.txt
@@ -1,0 +1,80 @@
+TASK CARD: C2-S2-18 Desktop Client Upload Control Plane Integration
+
+Owner:
+Coder 1 acting as Coder 2 / Desktop Client
+
+Module:
+Desktop client / upload control-plane integration
+
+Client form:
+desktop standalone
+
+Type:
+implementation planning prompt / task card
+
+Status:
+Replacement prompt for stale S2-18-WEB primary desktop-client planning.
+
+Goal:
+Build the primary desktop upload flow as a standalone launchable desktop application.
+
+Context:
+PR #101 / desktop-client form architecture update replaced browser/PWA as the primary desktop-client form with a standalone desktop application. Earlier S2-18 Web/PWA planning remains useful as App.Web support history, but it must not be used as the primary desktop-client implementation prompt.
+
+Primary desktop-client rule:
+- The primary desktop client is a standalone desktop application.
+- App.Web is not the primary desktop client.
+- App.Web may remain a non-primary web/admin/diagnostic/support surface.
+- Browser, PWA, and App.Web cannot be used as the primary desktop client without a new explicit architecture decision.
+
+Technology decision guard:
+- Do NOT choose WPF, WinUI, MAUI Desktop, Avalonia, Electron, Tauri, Blazor Hybrid, or any other concrete desktop UI technology in this task unless an approved architecture decision already exists.
+- If no approved desktop UI technology decision exists, the next implementation task must first create a narrow desktop technology decision/task card.
+- Do not implement desktop UI runtime code until that technology decision exists and explicitly approves the UI technology.
+
+Upload control-plane baseline to preserve:
+- Server remains the control plane.
+- Video bytes remain direct client <-> site.
+- App.Api must not become a media byte proxy.
+- Run PreUploadCheck before site upload when the server is online.
+- Run UploadReceipt after the direct site upload boundary.
+- Keep direct-site upload/download behind a client-side adapter boundary when the real provider is not ready.
+
+Expected primary flow:
+1. SignIn.
+2. GroupTree.
+3. File select.
+4. SHA-256.
+5. businessObjectKey.
+6. PreUploadCheck.
+7. Direct site upload boundary.
+8. UploadReceipt.
+
+Related prompts / history:
+- Stale for primary desktop: `docs/task-cards/C2-S2-18_web-upload-control-plane-integration.txt`.
+- Historical Web/App.Web support handoff: `docs/handoffs/C2_S2_18_WEB_UPLOAD_CONTROL_PLANE_HANDOFF.md`.
+- New desktop implementation prompt: `docs/handoffs/S2_18_DESKTOP_CLIENT_UPLOAD_CONTROL_PLANE_PROMPT.md`.
+- S2-18-ANDROID remains broadly aligned with the mobile baseline.
+
+Out of scope for this docs-only task:
+- Runtime code changes.
+- API changes.
+- Shared contract changes.
+- Database migrations.
+- Deploy scripts or deploy workflow changes.
+- GitHub Actions workflow changes.
+- App.Api, App.Worker, App.Web, App.Mobile.Android, App.UI.Shared, BuildingBlocks.Contracts, Modules, or migration edits.
+
+Validation for this docs-only replacement:
+- git diff --name-only
+- git diff --check
+- dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore
+- Confirm no runtime/API/contracts/migrations/workflows/deploy changes.
+- Confirm App.Web and App.Mobile.Android are unchanged.
+
+Definition of done:
+- Old S2-18 Web/PWA task card is explicitly marked stale/superseded for primary desktop-client planning.
+- New standalone desktop-client task card exists.
+- New desktop-client handoff prompt exists for future implementation work.
+- Existing Web/App.Web support history remains available and is not deleted.
+- The next implementation path cannot select a desktop UI technology without an approved architecture decision.

--- a/docs/task-cards/C2-S2-18_web-upload-control-plane-integration.txt
+++ b/docs/task-cards/C2-S2-18_web-upload-control-plane-integration.txt
@@ -1,3 +1,9 @@
+SUPERSEDED FOR PRIMARY DESKTOP CLIENT
+- This Web/PWA/App.Web prompt is stale for primary desktop-client planning after PR #101 / desktop-client form architecture update.
+- App.Web may still be used as a non-primary web/admin/diagnostic/support surface.
+- Primary desktop-client work must use the standalone desktop-client replacement prompt.
+- Do not use this file as the primary desktop-client implementation prompt.
+
 TASK CARD: C2-S2-18 Web/PWA Upload Control Plane Integration Increment 1
 
 Owner:


### PR DESCRIPTION
## Coder
Coder 1 acting as Coder 2 / Desktop Client

## Task ID
S2-45

## Module
Docs / task cards / desktop-client prompt replacement

## Scope
Docs-only prompt replacement.

## Changed areas
- docs/task-cards
- docs/handoffs
- docs/operations

## Base main SHA
9c623fbfc5b9add357a20fe1939e15fbea1bdb64

## Coordination log entries reviewed
TEAM COORDINATION LOG issue #89 reviewed through PR #101 desktop-client form architecture update and prior manual replay entries.

## Handoff/task cards reviewed
- desktop-client-form-architecture-update.txt
- C2-S2-18_web-upload-control-plane-integration.txt
- S2-44 Web Upload UI Site Upload MVP handoff, as non-primary App.Web/support context

## Contracts
No shared DTO/contracts changes.

## Migrations
No.

## Feature flags
No.

## API impact
No runtime API changes.

## Web impact
No App.Web code changes.
Old Web/PWA prompt is marked stale for primary desktop only.
App.Web may remain non-primary web/admin/diagnostic/support surface.

## Android impact
No App.Mobile.Android changes.
S2-18-ANDROID remains broadly aligned with mobile baseline.

## Offline behavior
No runtime offline behavior change.

## Desktop client form
Primary desktop client must be a standalone launchable desktop application.
Concrete desktop UI technology is not selected in this PR.
Future implementation must verify an approved desktop technology decision exists before coding UI.

## Rollback
Revert this docs PR.

## Validation
- git diff --check
- dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore
- runtime scope guard
- PR file BOM / hidden Unicode scan

Build/tests:
- not required for docs-only prompt/task-card changes
- CI still required on PR

## Handoff docs
New desktop-client implementation prompt/handoff created in docs/handoffs.

## Next step
After merge:
- refresh affected ChatGPT Project Sources;
- use the new desktop-client prompt instead of stale S2-18-WEB;
- if no desktop UI technology decision exists, create/approve that decision before runtime implementation.

## NO-GO / Deferred
- no runtime code changes
- no App.Api/App.Worker/App.Web/App.Mobile.Android changes
- no shared contracts changes
- no migrations
- no deploy workflow changes
- no deploy execution
- no concrete desktop UI technology selected

## Security notes
- no secrets/tokens/passwords added
- GitHub main + TEAM COORDINATION LOG remain source of truth
- Telegram remains notification only