### PR TITLE
feat(mobile): add unresolved business object binding guard

### DIFF
--- a/docs/handoffs/MOB-CANON-BACKEND-01_ANDROID_BUSINESS_OBJECT_BINDING_BLOCKER.md
+++ b/docs/handoffs/MOB-CANON-BACKEND-01_ANDROID_BUSINESS_OBJECT_BINDING_BLOCKER.md
@@ -1,0 +1,30 @@
+# MOB-CANON-BACKEND-01 Android Business Object Binding Blocker
+
+## Blocker summary
+Android upload control-plane work still lacks an approved source for `businessObjectKey` / report draft / business object binding before `PreUploadCheck`.
+
+## Approved source search result
+No approved Android source was found in the reviewed repo docs, task cards, handoffs, ops docs, root architecture docs, or TEAM COORDINATION LOG issue #89 latest entries.
+
+Documents confirm `businessObjectKey` is required for upload metadata, and some smoke/support docs show non-secret test values, but those do not approve a production Android source.
+
+## Runtime scope
+This slice adds only an Android-local unresolved guard:
+- local intent state
+- explicit unresolved binding snapshot
+- PreUploadCheck eligibility gate that blocks production precheck while no approved key exists
+- Upload page blocker card
+
+No runtime backend integration is added.
+No `PreUploadCheck` request is constructed or sent.
+No `UploadReceipt` flow is added.
+No fake `businessObjectKey` is generated.
+
+## Coordination question
+What is the approved Android source for businessObjectKey before PreUploadCheck?
+
+Expected answer category:
+1. draft/create-select endpoint first
+2. existing catalog/entity endpoint
+3. temporary approved non-production stub
+4. another approved source

--- a/docs/reports/coder3-canonical-mobile-import.md
+++ b/docs/reports/coder3-canonical-mobile-import.md
@@ -92,15 +92,15 @@
 
 ## Physical Android runtime check
 - Result: passed.
-- Runtime status: import07 phone ok.
-- Restored queue draft can be rebound from current selected media.
-- Mismatch is blocked with Russian warning.
-- Successful repair clears current selected media.
-- Metadata-only note disappears after successful repair.
-- Retry/remove still work.
+- Runtime status: backend01 phone ok.
+- Upload page shows unresolved businessObjectKey blocker.
+- Local intent can be saved and cleared.
+- PreUploadCheck readiness check is blocked.
+- No fake businessObjectKey is shown.
+- Media/outbox foundation still works.
 
 ## Manual steps pending
-- none for IMPORT-07.
+- none for BACKEND-01.
 
 ## Waiting for coder 1
 - No immediate blocker for this import slice.
@@ -110,5 +110,5 @@
 - No App.UI.Shared changes are included in this PR slice.
 
 ## Next code step
-- Blocked pending owner/coder 1 answer for the approved Android `businessObjectKey` source.
+- Blocked pending owner/coder 1 answer for the approved Android `businessObjectKey` source or next approved local UX replay.
 - Do not start report, UX, profile, backend, or worker work in this branch.

--- a/docs/reports/coder3-canonical-mobile-import.md
+++ b/docs/reports/coder3-canonical-mobile-import.md
@@ -1,7 +1,7 @@
 # Coder 3 Canonical Mobile Import
 
 ## Current step
-- MOB-CANON-BACKEND-00 readiness checkpoint.
+- MOB-CANON-BACKEND-01 unresolved business-object binding guard.
 
 ## IMPORT-01..07 completed in main
 - Android media/outbox foundation is complete in `main` through IMPORT-07.
@@ -15,7 +15,10 @@
   - IMPORT-06 restart snapshots
   - IMPORT-07 repair/rebind
 - Current task is docs-only backend readiness planning.
-- Next code step is blocked pending readiness recommendation and coordination decision.
+- PR #106 is merged.
+- Approved source search result: no approved Android source found for `businessObjectKey` / report draft / business object binding before `PreUploadCheck`.
+- This step adds an Android-local unresolved guard only.
+- No production `PreUploadCheck` runtime is included.
 
 ## Base and coordination state
 - Base main SHA at task start: `e4dd243`
@@ -107,5 +110,5 @@
 - No App.UI.Shared changes are included in this PR slice.
 
 ## Next code step
-- Blocked pending MOB-CANON-BACKEND-00 readiness recommendation.
+- Blocked pending owner/coder 1 answer for the approved Android `businessObjectKey` source.
 - Do not start report, UX, profile, backend, or worker work in this branch.

--- a/docs/reports/coder3-mobile-foundation-reconciliation.md
+++ b/docs/reports/coder3-mobile-foundation-reconciliation.md
@@ -18,11 +18,11 @@ The canonical repository contains the complete IMPORT-01..07 Android media/outbo
 - `App.UI.Shared` was intentionally unchanged by IMPORT-02..07.
 
 ## Current readiness checkpoint
-`MOB-CANON-BACKEND-00` is a docs-only readiness checkpoint from fresh `main` at `e4dd243`.
+`MOB-CANON-BACKEND-01` is a blocker-safe Android-local guard from fresh `main` at `f08050d`.
 
 Android media/outbox foundation reconciliation is complete in main through IMPORT-07.
 Report/UX/backend work is not yet replayed from old stacked work.
-The next decision is backend adapter foundation versus local report UX replay.
+Backend integration remains blocked pending the approved Android `businessObjectKey` source.
 
 ## Explicitly deferred
 - report draft shell
@@ -66,6 +66,12 @@ Continue with small PR-ready slices from fresh `main`, but choose the next direc
 Backend adapter foundation should wait for the approved Android source of `businessObjectKey` / report draft / business object binding before any `PreUploadCheck` runtime.
 
 Local report UX replay remains possible only as local/non-production context if the owner accepts that it does not provide backend save, `businessObjectKey`, production reports engine, `PreUploadCheck`, or `UploadReceipt`.
+
+BACKEND-01 adds only:
+- Android-local unresolved business-object binding state.
+- Android-local `PreUploadCheck` eligibility guard.
+- Upload page blocker card.
+- Unit tests proving no fake `businessObjectKey` is produced.
 
 Do not start report, UX, profile, backend/S1 integration, incident creation, fraud, or worker logic in this branch.
 

--- a/docs/task-cards/MOB-CANON-BACKEND-01.txt
+++ b/docs/task-cards/MOB-CANON-BACKEND-01.txt
@@ -1,0 +1,80 @@
+Title:
+MOB-CANON-BACKEND-01 - Android unresolved business-object binding guard
+
+Coder:
+3
+
+Module:
+App.Mobile.Android / backend adapter readiness / blocker guard
+
+Task type:
+Android-local blocker-safe runtime guard / integration readiness
+
+Goal:
+Add an Android-local unresolved business-object binding seam and PreUploadCheck eligibility guard that makes the missing approved businessObjectKey source explicit in UI/state/code without implementing production backend PreUploadCheck runtime.
+
+Base main SHA:
+f08050d
+
+Coordination log entries reviewed:
+- GitHub issue #89: PR #96 local outbox foundation manual replay.
+- GitHub issue #89: PR #97 selected-media handoff manual replay.
+- GitHub issue #89: PR #98 duplicate-precheck manual replay.
+- GitHub issue #89: PR #99 restart-snapshot manual replay.
+- GitHub issue #89: PR #101 desktop client form architecture update.
+- GitHub issue #89: PR #102 stale Web prompt replaced with desktop-client prompt.
+- GitHub issue #89: PR #103 desktop UI technology decision task.
+- GitHub issue #89: PR #104 desktop UI technology owner decision.
+- GitHub issue #89: PR #105 desktop application skeleton task card.
+
+Handoff/task cards reviewed:
+- docs/reports/coder3-android-backend-readiness.md
+- docs/task-cards/MOB-CANON-BACKEND-00.txt
+- docs/handoffs/s1-11-coder3-android-integration.md
+- docs/handoffs/s1-11-backend-integration-note.md
+- docs/handoffs/s1-12-sprint1-quality-gate.md
+- docs/task-cards/MOB-CANON-IMPORT-01.txt
+- docs/task-cards/MOB-CANON-IMPORT-02.txt
+- docs/task-cards/MOB-CANON-IMPORT-03.txt
+- docs/task-cards/MOB-CANON-IMPORT-04.txt
+- docs/task-cards/MOB-CANON-IMPORT-05.txt
+- docs/task-cards/MOB-CANON-IMPORT-06.txt
+- docs/task-cards/MOB-CANON-IMPORT-07.txt
+
+What changes:
+- Android-local unresolved business-object binding state
+- Android-local PreUploadCheck eligibility guard
+- Upload page blocker card/state
+- tests for unresolved guard behavior
+
+New or changed contracts:
+- shared DTO/contracts unchanged
+
+Migration:
+- none
+
+Feature flags:
+- local mobile stub flag: mobile.business-object-binding.blocker-card
+
+Offline behavior:
+- local blocker state only
+- no new sync/upload behavior
+
+Security:
+- no tokens
+- no backend calls
+- no secrets
+- no production upload
+
+Rollback:
+- revert this PR
+
+Definition of done:
+- approved source search is documented
+- blocker remains explicit if no source found
+- Upload page shows backend business-object binding unresolved
+- PreUploadCheck production path is blocked while unresolved
+- no fake businessObjectKey
+- no backend integration
+- no App.UI.Shared changes
+- tests/build/format pass

--- a/src/App.Mobile.Android/BusinessObjectBinding/MobileBusinessObjectBindingApprovalState.cs
+++ b/src/App.Mobile.Android/BusinessObjectBinding/MobileBusinessObjectBindingApprovalState.cs
@@ -1,0 +1,8 @@
+namespace App.Mobile.Android.BusinessObjectBinding;
+
+internal enum MobileBusinessObjectBindingApprovalState
+{
+    Unresolved = 0,
+    NotApproved = 1,
+    ApprovedResolved = 2
+}

--- a/src/App.Mobile.Android/BusinessObjectBinding/MobileBusinessObjectBindingSnapshot.cs
+++ b/src/App.Mobile.Android/BusinessObjectBinding/MobileBusinessObjectBindingSnapshot.cs
@@ -1,0 +1,38 @@
+namespace App.Mobile.Android.BusinessObjectBinding;
+
+internal sealed record MobileBusinessObjectBindingSnapshot
+{
+    public MobileBusinessObjectBindingSnapshot(
+        global::App.Mobile.Android.BusinessObjectBinding.MobileBusinessObjectBindingApprovalState approvalState,
+        global::App.Mobile.Android.BusinessObjectBinding.MobileBusinessObjectDraftIntent? localIntent,
+        string? approvedBusinessObjectKey,
+        string messageText,
+        string sourceDescriptionText)
+    {
+        if (approvalState is not global::App.Mobile.Android.BusinessObjectBinding.MobileBusinessObjectBindingApprovalState.ApprovedResolved
+            && !string.IsNullOrWhiteSpace(approvedBusinessObjectKey))
+        {
+            throw new ArgumentException(
+                "Approved businessObjectKey is allowed only after approved binding is resolved.",
+                nameof(approvedBusinessObjectKey));
+        }
+
+        ApprovalState = approvalState;
+        LocalIntent = localIntent;
+        ApprovedBusinessObjectKey = string.IsNullOrWhiteSpace(approvedBusinessObjectKey)
+            ? null
+            : approvedBusinessObjectKey;
+        MessageText = messageText;
+        SourceDescriptionText = sourceDescriptionText;
+    }
+
+    public global::App.Mobile.Android.BusinessObjectBinding.MobileBusinessObjectBindingApprovalState ApprovalState { get; }
+
+    public global::App.Mobile.Android.BusinessObjectBinding.MobileBusinessObjectDraftIntent? LocalIntent { get; }
+
+    public string? ApprovedBusinessObjectKey { get; }
+
+    public string MessageText { get; }
+
+    public string SourceDescriptionText { get; }
+}

--- a/src/App.Mobile.Android/BusinessObjectBinding/MobileBusinessObjectDraftIntent.cs
+++ b/src/App.Mobile.Android/BusinessObjectBinding/MobileBusinessObjectDraftIntent.cs
@@ -1,0 +1,10 @@
+namespace App.Mobile.Android.BusinessObjectBinding;
+
+internal sealed record MobileBusinessObjectDraftIntent(
+    string LocalIntentId,
+    DateTimeOffset CreatedAtUtc,
+    DateTimeOffset UpdatedAtUtc,
+    string DisplayTitle,
+    string NoteText,
+    bool IsLocalOnly,
+    global::App.Mobile.Android.BusinessObjectBinding.MobileBusinessObjectBindingApprovalState ApprovalState);

--- a/src/App.Mobile.Android/BusinessObjectBinding/MobilePreUploadEligibilityResult.cs
+++ b/src/App.Mobile.Android/BusinessObjectBinding/MobilePreUploadEligibilityResult.cs
@@ -1,0 +1,7 @@
+namespace App.Mobile.Android.BusinessObjectBinding;
+
+internal sealed record MobilePreUploadEligibilityResult(
+    bool CanRunProductionPreUploadCheck,
+    string MessageText,
+    string RequiredActionText,
+    global::App.Mobile.Android.BusinessObjectBinding.MobileBusinessObjectBindingSnapshot BindingSnapshot);

--- a/src/App.Mobile.Android/Components/Pages/Upload.razor
+++ b/src/App.Mobile.Android/Components/Pages/Upload.razor
@@ -6,6 +6,8 @@
 @inject global::App.Mobile.Android.Services.Abstractions.IMobileSelectedMediaStore SelectedMediaStore
 @inject global::App.Mobile.Android.Services.Abstractions.IMobileOutboxService MobileOutboxService
 @inject global::App.Mobile.Android.Services.Abstractions.ILocalDuplicatePrecheckService DuplicatePrecheckService
+@inject global::App.Mobile.Android.Services.Abstractions.IMobileBusinessObjectBindingService BusinessObjectBindingService
+@inject global::App.Mobile.Android.Services.Abstractions.IMobilePreUploadEligibilityGate PreUploadEligibilityGate
 
 <h1>@MobileUiText.UploadTitle</h1>
 <p>@MobileUiText.UploadIntro</p>
@@ -100,6 +102,62 @@
     </section>
 }
 
+@if (ShowBusinessObjectBindingBlockerCard)
+{
+    <section class="business-object-card">
+        <h3>@MobileUiText.BusinessObjectBindingCardTitle</h3>
+
+        <dl class="business-object-grid">
+            <div>
+                <dt>@MobileUiText.BusinessObjectBindingStateLabel</dt>
+                <dd>@GetBusinessObjectBindingStateText(BusinessObjectSnapshot)</dd>
+            </div>
+            @if (BusinessObjectSnapshot?.LocalIntent is not null)
+            {
+                <div>
+                    <dt>@MobileUiText.BusinessObjectBindingLocalIntentTitleLabel</dt>
+                    <dd>@BusinessObjectSnapshot.LocalIntent.DisplayTitle</dd>
+                </div>
+            }
+        </dl>
+
+        <p class="business-object-warning">@BusinessObjectSnapshot?.MessageText</p>
+        <p class="business-object-note">@MobileUiText.BusinessObjectBindingLocalOnlyNote</p>
+        <p class="business-object-note">@MobileUiText.BusinessObjectBindingNoFakeKeyNote</p>
+
+        <div class="business-object-fields">
+            <label>
+                @MobileUiText.BusinessObjectBindingLocalIntentTitleLabel
+                <input class="form-control" @bind="BusinessObjectLocalIntentTitle" />
+            </label>
+            <label>
+                @MobileUiText.BusinessObjectBindingLocalIntentNoteLabel
+                <textarea class="form-control" rows="2" @bind="BusinessObjectLocalIntentNote"></textarea>
+            </label>
+        </div>
+
+        <div class="business-object-actions">
+            <button type="button" class="btn btn-outline-primary" @onclick="SaveBusinessObjectLocalIntentAsync">@MobileUiText.BusinessObjectBindingSaveLocalIntentButton</button>
+            <button type="button" class="btn btn-outline-secondary" @onclick="ClearBusinessObjectLocalIntentAsync">@MobileUiText.BusinessObjectBindingClearLocalIntentButton</button>
+            <button type="button" class="btn btn-outline-danger" @onclick="CheckPreUploadEligibilityAsync">@MobileUiText.BusinessObjectBindingCheckReadinessButton</button>
+        </div>
+
+        @if (!string.IsNullOrWhiteSpace(BusinessObjectResultText))
+        {
+            <p class="business-object-result">@BusinessObjectResultText</p>
+        }
+
+        @if (PreUploadEligibilityResult is not null)
+        {
+            <div class="business-object-blocked">
+                <strong>@MobileUiText.BusinessObjectBindingPreUploadBlockedTitle</strong>
+                <p>@PreUploadEligibilityResult.MessageText</p>
+                <p>@PreUploadEligibilityResult.RequiredActionText</p>
+            </div>
+        }
+    </section>
+}
+
 @if (ShowQueueFoundationAction)
 {
     <section class="outbox-foundation-block">
@@ -120,14 +178,27 @@
 
     private global::App.Mobile.Android.DuplicatePrecheck.LocalDuplicatePrecheckResult? CurrentPrecheckResult { get; set; }
 
+    private global::App.Mobile.Android.BusinessObjectBinding.MobileBusinessObjectBindingSnapshot? BusinessObjectSnapshot { get; set; }
+
+    private global::App.Mobile.Android.BusinessObjectBinding.MobilePreUploadEligibilityResult? PreUploadEligibilityResult { get; set; }
+
     private string MediaResultText { get; set; } = string.Empty;
 
     private string OutboxResultText { get; set; } = string.Empty;
+
+    private string BusinessObjectLocalIntentTitle { get; set; } = string.Empty;
+
+    private string BusinessObjectLocalIntentNote { get; set; } = string.Empty;
+
+    private string BusinessObjectResultText { get; set; } = string.Empty;
 
     private bool OutboxResultIsWarning { get; set; }
 
     private bool ShowQueueFoundationAction =>
         FeatureFlagReader.IsEnabled(global::App.Mobile.Android.Services.Stubs.StubFeatureFlagReader.QueueFoundationCardFlag);
+
+    private bool ShowBusinessObjectBindingBlockerCard =>
+        FeatureFlagReader.IsEnabled(global::App.Mobile.Android.Services.Stubs.StubFeatureFlagReader.BusinessObjectBindingBlockerCardFlag);
 
     private string CapabilitySummaryText =>
         CapabilitySnapshot?.SummaryText
@@ -137,6 +208,7 @@
     {
         NavigationState.SetCurrentView(global::App.Mobile.Android.Navigation.MobileViewId.Upload);
         CapabilitySnapshot = await MobileMediaService.GetCapabilitySnapshotAsync();
+        await RefreshBusinessObjectBindingAsync();
         await RefreshCurrentSelectionAndPrecheckAsync();
     }
 
@@ -176,6 +248,38 @@
         await RefreshCurrentSelectionAndPrecheckAsync();
     }
 
+    private async Task SaveBusinessObjectLocalIntentAsync()
+    {
+        BusinessObjectSnapshot = await BusinessObjectBindingService.CreateOrUpdateLocalIntentAsync(
+            BusinessObjectLocalIntentTitle,
+            BusinessObjectLocalIntentNote);
+        BusinessObjectResultText = MobileUiText.BusinessObjectBindingLocalIntentSavedResult;
+        PreUploadEligibilityResult = null;
+        SyncLocalIntentFields(BusinessObjectSnapshot);
+    }
+
+    private async Task ClearBusinessObjectLocalIntentAsync()
+    {
+        BusinessObjectSnapshot = await BusinessObjectBindingService.ClearLocalIntentAsync();
+        BusinessObjectResultText = MobileUiText.BusinessObjectBindingLocalIntentClearedResult;
+        PreUploadEligibilityResult = null;
+        SyncLocalIntentFields(BusinessObjectSnapshot);
+    }
+
+    private async Task CheckPreUploadEligibilityAsync()
+    {
+        PreUploadEligibilityResult = await PreUploadEligibilityGate.EvaluateAsync();
+        BusinessObjectSnapshot = PreUploadEligibilityResult.BindingSnapshot;
+        BusinessObjectResultText = PreUploadEligibilityResult.MessageText;
+        SyncLocalIntentFields(BusinessObjectSnapshot);
+    }
+
+    private async Task RefreshBusinessObjectBindingAsync()
+    {
+        BusinessObjectSnapshot = await BusinessObjectBindingService.GetCurrentAsync();
+        SyncLocalIntentFields(BusinessObjectSnapshot);
+    }
+
     private async Task RefreshCurrentSelectionAndPrecheckAsync()
     {
         CurrentSelectedMedia = await SelectedMediaStore.GetCurrentAsync();
@@ -188,6 +292,21 @@
 
         var items = await MobileOutboxService.GetItemsAsync();
         CurrentPrecheckResult = DuplicatePrecheckService.CheckAgainstOutbox(CurrentSelectedMedia, items);
+    }
+
+    private static string GetBusinessObjectBindingStateText(
+        global::App.Mobile.Android.BusinessObjectBinding.MobileBusinessObjectBindingSnapshot? snapshot)
+    {
+        return snapshot?.ApprovalState is global::App.Mobile.Android.BusinessObjectBinding.MobileBusinessObjectBindingApprovalState.ApprovedResolved
+            ? MobileUiText.BusinessObjectBindingEligibleMessage
+            : MobileUiText.BusinessObjectBindingUnresolvedStateText;
+    }
+
+    private void SyncLocalIntentFields(
+        global::App.Mobile.Android.BusinessObjectBinding.MobileBusinessObjectBindingSnapshot? snapshot)
+    {
+        BusinessObjectLocalIntentTitle = snapshot?.LocalIntent?.DisplayTitle ?? string.Empty;
+        BusinessObjectLocalIntentNote = snapshot?.LocalIntent?.NoteText ?? string.Empty;
     }
 
     private static string GetCapabilityStateText(global::App.Mobile.Android.Media.MobileMediaCapabilityState? state)

--- a/src/App.Mobile.Android/Components/Pages/Upload.razor.css
+++ b/src/App.Mobile.Android/Components/Pages/Upload.razor.css
@@ -153,6 +153,85 @@
     color: #8a5a16;
 }
 
+.business-object-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border: 1px solid #f0c0c0;
+    border-radius: 0.9rem;
+    background: #fff7f7;
+    color: #5f1820;
+}
+
+.business-object-card h3 {
+    margin: 0 0 0.85rem;
+    font-size: 1rem;
+}
+
+.business-object-grid {
+    margin: 0 0 1rem;
+}
+
+.business-object-grid div {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.45rem 0;
+    border-top: 1px solid #f0c0c0;
+}
+
+.business-object-grid div:first-child {
+    border-top: 0;
+    padding-top: 0;
+}
+
+.business-object-grid dt,
+.business-object-grid dd {
+    margin: 0;
+}
+
+.business-object-grid dd {
+    font-weight: 600;
+    text-align: right;
+}
+
+.business-object-warning,
+.business-object-note {
+    margin: 0 0 0.65rem;
+    line-height: 1.45;
+}
+
+.business-object-fields {
+    display: grid;
+    gap: 0.75rem;
+    margin: 0.85rem 0;
+}
+
+.business-object-fields label {
+    display: grid;
+    gap: 0.35rem;
+    font-weight: 600;
+}
+
+.business-object-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.business-object-result,
+.business-object-blocked {
+    margin: 0.9rem 0 0;
+    padding: 0.75rem 0.85rem;
+    border-radius: 0.75rem;
+    background: #fff0f0;
+    color: #7f1d1d;
+    line-height: 1.45;
+}
+
+.business-object-blocked p {
+    margin: 0.35rem 0 0;
+}
+
 .outbox-foundation-block {
     margin-top: 1rem;
     padding: 1rem;
@@ -184,14 +263,16 @@
 @media (max-width: 640px) {
     .media-capability-list div,
     .selected-media-grid div,
-    .precheck-grid div {
+    .precheck-grid div,
+    .business-object-grid div {
         flex-direction: column;
         align-items: flex-start;
     }
 
     .media-capability-list dd,
     .selected-media-grid dd,
-    .precheck-grid dd {
+    .precheck-grid dd,
+    .business-object-grid dd {
         text-align: left;
     }
 }

--- a/src/App.Mobile.Android/Localization/MobileUiText.cs
+++ b/src/App.Mobile.Android/Localization/MobileUiText.cs
@@ -72,6 +72,32 @@ internal static class MobileUiText
         "Похоже, выбранное видео уже есть в локальной очереди. Повторная передача заблокирована только локальной предварительной проверкой, это не финальная backend-проверка.";
     public const string LocalDuplicatePrecheckLocalOnlyNote =
         "Сравнение выполняется только по текущему локальному выбору и draft-элементам очереди в памяти устройства.";
+    public const string BusinessObjectBindingCardTitle = "Привязка бизнес-объекта для backend precheck";
+    public const string BusinessObjectBindingStateLabel = "Статус";
+    public const string BusinessObjectBindingUnresolvedStateText = "Не разрешено: approved businessObjectKey отсутствует";
+    public const string BusinessObjectBindingUnresolvedWarning =
+        "approved businessObjectKey source is not documented yet; backend precheck cannot continue as production flow";
+    public const string BusinessObjectBindingSourceDescription =
+        "Android хранит только локальный intent. Он не является businessObjectKey и не отправляется в backend.";
+    public const string BusinessObjectBindingLocalIntentTitleLabel = "Локальный intent";
+    public const string BusinessObjectBindingLocalIntentNoteLabel = "Локальная заметка";
+    public const string BusinessObjectBindingDefaultLocalIntentTitle = "Локальный черновик без approved businessObjectKey";
+    public const string BusinessObjectBindingSaveLocalIntentButton = "Сохранить локальный intent";
+    public const string BusinessObjectBindingClearLocalIntentButton = "Очистить локальный intent";
+    public const string BusinessObjectBindingCheckReadinessButton = "Проверить готовность backend precheck";
+    public const string BusinessObjectBindingLocalIntentSavedResult = "Локальный intent сохранен. Approved businessObjectKey не создан.";
+    public const string BusinessObjectBindingLocalIntentClearedResult = "Локальный intent очищен. Approved businessObjectKey по-прежнему отсутствует.";
+    public const string BusinessObjectBindingPreUploadBlockedTitle = "Backend PreUploadCheck заблокирован";
+    public const string PreUploadCheckBlockedMessage =
+        "approved businessObjectKey source is not documented yet; backend precheck cannot continue as production flow";
+    public const string BusinessObjectBindingRequiredActionText =
+        "Нужен утвержденный источник businessObjectKey / report draft / business object binding до production PreUploadCheck.";
+    public const string BusinessObjectBindingLocalOnlyNote =
+        "Это локальная blocker-карточка Android. Она не вызывает backend, не создает create-report и не запускает upload.";
+    public const string BusinessObjectBindingNoFakeKeyNote =
+        "LocalIntentId не является businessObjectKey. Фейковый ключ, hash файла или group id не используются.";
+    public const string BusinessObjectBindingEligibleMessage =
+        "Approved businessObjectKey найден. Production PreUploadCheck может быть разрешен отдельной approved integration task.";
     public const string UploadEnqueueStubButton = "Передать выбранное видео в локальную очередь";
     public const string UploadOutboxActionHint =
         "Локальный handoff переносит только текущее выбранное видео в черновик очереди на устройстве. " +

--- a/src/App.Mobile.Android/MauiProgram.cs
+++ b/src/App.Mobile.Android/MauiProgram.cs
@@ -49,6 +49,12 @@ public static class MauiProgram
             global::App.Mobile.Android.Services.Abstractions.ILocalMediaDraftRepairService,
             global::App.Mobile.Android.Services.Local.LocalCurrentSelectionDraftRepairService>();
         builder.Services.AddSingleton<
+            global::App.Mobile.Android.Services.Abstractions.IMobileBusinessObjectBindingService,
+            global::App.Mobile.Android.Services.Local.UnresolvedMobileBusinessObjectBindingService>();
+        builder.Services.AddSingleton<
+            global::App.Mobile.Android.Services.Abstractions.IMobilePreUploadEligibilityGate,
+            global::App.Mobile.Android.Services.Local.LocalMobilePreUploadEligibilityGate>();
+        builder.Services.AddSingleton<
             global::App.Mobile.Android.Services.Abstractions.IMobileOutboxSnapshotStore>(
             _ => new global::App.Mobile.Android.Services.Local.FileMobileOutboxSnapshotStore(
                 global::Microsoft.Maui.Storage.FileSystem.AppDataDirectory));

--- a/src/App.Mobile.Android/Services/Abstractions/IMobileBusinessObjectBindingService.cs
+++ b/src/App.Mobile.Android/Services/Abstractions/IMobileBusinessObjectBindingService.cs
@@ -1,0 +1,15 @@
+namespace App.Mobile.Android.Services.Abstractions;
+
+internal interface IMobileBusinessObjectBindingService
+{
+    Task<global::App.Mobile.Android.BusinessObjectBinding.MobileBusinessObjectBindingSnapshot> GetCurrentAsync(
+        CancellationToken cancellationToken = default);
+
+    Task<global::App.Mobile.Android.BusinessObjectBinding.MobileBusinessObjectBindingSnapshot> CreateOrUpdateLocalIntentAsync(
+        string? displayTitle,
+        string? noteText,
+        CancellationToken cancellationToken = default);
+
+    Task<global::App.Mobile.Android.BusinessObjectBinding.MobileBusinessObjectBindingSnapshot> ClearLocalIntentAsync(
+        CancellationToken cancellationToken = default);
+}

--- a/src/App.Mobile.Android/Services/Abstractions/IMobilePreUploadEligibilityGate.cs
+++ b/src/App.Mobile.Android/Services/Abstractions/IMobilePreUploadEligibilityGate.cs
@@ -1,0 +1,7 @@
+namespace App.Mobile.Android.Services.Abstractions;
+
+internal interface IMobilePreUploadEligibilityGate
+{
+    Task<global::App.Mobile.Android.BusinessObjectBinding.MobilePreUploadEligibilityResult> EvaluateAsync(
+        CancellationToken cancellationToken = default);
+}

--- a/src/App.Mobile.Android/Services/Local/LocalMobilePreUploadEligibilityGate.cs
+++ b/src/App.Mobile.Android/Services/Local/LocalMobilePreUploadEligibilityGate.cs
@@ -1,0 +1,37 @@
+namespace App.Mobile.Android.Services.Local;
+
+internal sealed class LocalMobilePreUploadEligibilityGate :
+    global::App.Mobile.Android.Services.Abstractions.IMobilePreUploadEligibilityGate
+{
+    private readonly global::App.Mobile.Android.Services.Abstractions.IMobileBusinessObjectBindingService _bindingService;
+
+    public LocalMobilePreUploadEligibilityGate(
+        global::App.Mobile.Android.Services.Abstractions.IMobileBusinessObjectBindingService bindingService)
+    {
+        _bindingService = bindingService;
+    }
+
+    public async Task<global::App.Mobile.Android.BusinessObjectBinding.MobilePreUploadEligibilityResult> EvaluateAsync(
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var snapshot = await _bindingService.GetCurrentAsync(cancellationToken);
+        var canRun = snapshot.ApprovalState is global::App.Mobile.Android.BusinessObjectBinding.MobileBusinessObjectBindingApprovalState.ApprovedResolved
+            && !string.IsNullOrWhiteSpace(snapshot.ApprovedBusinessObjectKey);
+
+        if (canRun)
+        {
+            return new global::App.Mobile.Android.BusinessObjectBinding.MobilePreUploadEligibilityResult(
+                CanRunProductionPreUploadCheck: true,
+                MessageText: global::App.Mobile.Android.Localization.MobileUiText.BusinessObjectBindingEligibleMessage,
+                RequiredActionText: string.Empty,
+                BindingSnapshot: snapshot);
+        }
+
+        return new global::App.Mobile.Android.BusinessObjectBinding.MobilePreUploadEligibilityResult(
+            CanRunProductionPreUploadCheck: false,
+            MessageText: global::App.Mobile.Android.Localization.MobileUiText.PreUploadCheckBlockedMessage,
+            RequiredActionText: global::App.Mobile.Android.Localization.MobileUiText.BusinessObjectBindingRequiredActionText,
+            BindingSnapshot: snapshot);
+    }
+}

--- a/src/App.Mobile.Android/Services/Local/UnresolvedMobileBusinessObjectBindingService.cs
+++ b/src/App.Mobile.Android/Services/Local/UnresolvedMobileBusinessObjectBindingService.cs
@@ -1,0 +1,80 @@
+namespace App.Mobile.Android.Services.Local;
+
+internal sealed class UnresolvedMobileBusinessObjectBindingService :
+    global::App.Mobile.Android.Services.Abstractions.IMobileBusinessObjectBindingService
+{
+    private readonly object _gate = new();
+    private global::App.Mobile.Android.BusinessObjectBinding.MobileBusinessObjectDraftIntent? _localIntent;
+
+    public Task<global::App.Mobile.Android.BusinessObjectBinding.MobileBusinessObjectBindingSnapshot> GetCurrentAsync(
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        lock (_gate)
+        {
+            return Task.FromResult(CreateSnapshot(_localIntent));
+        }
+    }
+
+    public Task<global::App.Mobile.Android.BusinessObjectBinding.MobileBusinessObjectBindingSnapshot> CreateOrUpdateLocalIntentAsync(
+        string? displayTitle,
+        string? noteText,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var now = DateTimeOffset.UtcNow;
+        var normalizedTitle = string.IsNullOrWhiteSpace(displayTitle)
+            ? global::App.Mobile.Android.Localization.MobileUiText.BusinessObjectBindingDefaultLocalIntentTitle
+            : displayTitle.Trim();
+        var normalizedNote = string.IsNullOrWhiteSpace(noteText)
+            ? string.Empty
+            : noteText.Trim();
+
+        lock (_gate)
+        {
+            _localIntent = _localIntent is null
+                ? new global::App.Mobile.Android.BusinessObjectBinding.MobileBusinessObjectDraftIntent(
+                    LocalIntentId: $"local-intent-{Guid.NewGuid():N}",
+                    CreatedAtUtc: now,
+                    UpdatedAtUtc: now,
+                    DisplayTitle: normalizedTitle,
+                    NoteText: normalizedNote,
+                    IsLocalOnly: true,
+                    ApprovalState: global::App.Mobile.Android.BusinessObjectBinding.MobileBusinessObjectBindingApprovalState.Unresolved)
+                : _localIntent with
+                {
+                    UpdatedAtUtc = now,
+                    DisplayTitle = normalizedTitle,
+                    NoteText = normalizedNote,
+                    IsLocalOnly = true,
+                    ApprovalState = global::App.Mobile.Android.BusinessObjectBinding.MobileBusinessObjectBindingApprovalState.Unresolved
+                };
+
+            return Task.FromResult(CreateSnapshot(_localIntent));
+        }
+    }
+
+    public Task<global::App.Mobile.Android.BusinessObjectBinding.MobileBusinessObjectBindingSnapshot> ClearLocalIntentAsync(
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        lock (_gate)
+        {
+            _localIntent = null;
+            return Task.FromResult(CreateSnapshot(_localIntent));
+        }
+    }
+
+    private static global::App.Mobile.Android.BusinessObjectBinding.MobileBusinessObjectBindingSnapshot CreateSnapshot(
+        global::App.Mobile.Android.BusinessObjectBinding.MobileBusinessObjectDraftIntent? localIntent)
+    {
+        return new global::App.Mobile.Android.BusinessObjectBinding.MobileBusinessObjectBindingSnapshot(
+            approvalState: global::App.Mobile.Android.BusinessObjectBinding.MobileBusinessObjectBindingApprovalState.Unresolved,
+            localIntent: localIntent,
+            approvedBusinessObjectKey: null,
+            messageText: global::App.Mobile.Android.Localization.MobileUiText.BusinessObjectBindingUnresolvedWarning,
+            sourceDescriptionText: global::App.Mobile.Android.Localization.MobileUiText.BusinessObjectBindingSourceDescription);
+    }
+}

--- a/src/App.Mobile.Android/Services/Stubs/StubFeatureFlagReader.cs
+++ b/src/App.Mobile.Android/Services/Stubs/StubFeatureFlagReader.cs
@@ -5,10 +5,12 @@ internal sealed class StubFeatureFlagReader :
 {
     public const string ShellBannerFlag = "mobile.shell.banner";
     public const string QueueFoundationCardFlag = "mobile.queue.foundation-card";
+    public const string BusinessObjectBindingBlockerCardFlag = "mobile.business-object-binding.blocker-card";
 
     public bool IsEnabled(string flagName)
     {
         return string.Equals(flagName, ShellBannerFlag, global::System.StringComparison.Ordinal)
-            || string.Equals(flagName, QueueFoundationCardFlag, global::System.StringComparison.Ordinal);
+            || string.Equals(flagName, QueueFoundationCardFlag, global::System.StringComparison.Ordinal)
+            || string.Equals(flagName, BusinessObjectBindingBlockerCardFlag, global::System.StringComparison.Ordinal);
     }
 }

--- a/tests/Unit/App.Mobile.Android.Foundation.Tests/App.Mobile.Android.Foundation.Tests.csproj
+++ b/tests/Unit/App.Mobile.Android.Foundation.Tests/App.Mobile.Android.Foundation.Tests.csproj
@@ -26,6 +26,10 @@
     <Compile Include="..\..\..\src\App.Mobile.Android\Media\LocalSelectedMediaStoreEntry.cs" Link="LinkedProduction\Media\LocalSelectedMediaStoreEntry.cs" />
     <Compile Include="..\..\..\src\App.Mobile.Android\DraftRepair\LocalMediaDraftRepairStatus.cs" Link="LinkedProduction\DraftRepair\LocalMediaDraftRepairStatus.cs" />
     <Compile Include="..\..\..\src\App.Mobile.Android\DraftRepair\LocalMediaDraftRepairResult.cs" Link="LinkedProduction\DraftRepair\LocalMediaDraftRepairResult.cs" />
+    <Compile Include="..\..\..\src\App.Mobile.Android\BusinessObjectBinding\MobileBusinessObjectBindingApprovalState.cs" Link="LinkedProduction\BusinessObjectBinding\MobileBusinessObjectBindingApprovalState.cs" />
+    <Compile Include="..\..\..\src\App.Mobile.Android\BusinessObjectBinding\MobileBusinessObjectDraftIntent.cs" Link="LinkedProduction\BusinessObjectBinding\MobileBusinessObjectDraftIntent.cs" />
+    <Compile Include="..\..\..\src\App.Mobile.Android\BusinessObjectBinding\MobileBusinessObjectBindingSnapshot.cs" Link="LinkedProduction\BusinessObjectBinding\MobileBusinessObjectBindingSnapshot.cs" />
+    <Compile Include="..\..\..\src\App.Mobile.Android\BusinessObjectBinding\MobilePreUploadEligibilityResult.cs" Link="LinkedProduction\BusinessObjectBinding\MobilePreUploadEligibilityResult.cs" />
     <Compile Include="..\..\..\src\App.Mobile.Android\DuplicatePrecheck\LocalDuplicatePrecheckStatus.cs" Link="LinkedProduction\DuplicatePrecheck\LocalDuplicatePrecheckStatus.cs" />
     <Compile Include="..\..\..\src\App.Mobile.Android\DuplicatePrecheck\LocalDuplicatePrecheckResult.cs" Link="LinkedProduction\DuplicatePrecheck\LocalDuplicatePrecheckResult.cs" />
     <Compile Include="..\..\..\src\App.Mobile.Android\State\MobileShellMode.cs" Link="LinkedProduction\State\MobileShellMode.cs" />
@@ -38,6 +42,8 @@
     <Compile Include="..\..\..\src\App.Mobile.Android\Services\Abstractions\IFeatureFlagReader.cs" Link="LinkedProduction\Services\Abstractions\IFeatureFlagReader.cs" />
     <Compile Include="..\..\..\src\App.Mobile.Android\Services\Abstractions\ILocalDuplicatePrecheckService.cs" Link="LinkedProduction\Services\Abstractions\ILocalDuplicatePrecheckService.cs" />
     <Compile Include="..\..\..\src\App.Mobile.Android\Services\Abstractions\ILocalMediaDraftRepairService.cs" Link="LinkedProduction\Services\Abstractions\ILocalMediaDraftRepairService.cs" />
+    <Compile Include="..\..\..\src\App.Mobile.Android\Services\Abstractions\IMobileBusinessObjectBindingService.cs" Link="LinkedProduction\Services\Abstractions\IMobileBusinessObjectBindingService.cs" />
+    <Compile Include="..\..\..\src\App.Mobile.Android\Services\Abstractions\IMobilePreUploadEligibilityGate.cs" Link="LinkedProduction\Services\Abstractions\IMobilePreUploadEligibilityGate.cs" />
     <Compile Include="..\..\..\src\App.Mobile.Android\Services\Abstractions\IMobileAccessContext.cs" Link="LinkedProduction\Services\Abstractions\IMobileAccessContext.cs" />
     <Compile Include="..\..\..\src\App.Mobile.Android\Services\Abstractions\IMobileOutboxService.cs" Link="LinkedProduction\Services\Abstractions\IMobileOutboxService.cs" />
     <Compile Include="..\..\..\src\App.Mobile.Android\Services\Abstractions\IMobileOutboxSnapshotStore.cs" Link="LinkedProduction\Services\Abstractions\IMobileOutboxSnapshotStore.cs" />
@@ -50,8 +56,10 @@
     <Compile Include="..\..\..\src\App.Mobile.Android\Services\Local\FileMobileOutboxSnapshotStore.cs" Link="LinkedProduction\Services\Local\FileMobileOutboxSnapshotStore.cs" />
     <Compile Include="..\..\..\src\App.Mobile.Android\Services\Local\FileMobileSelectedMediaSnapshotStore.cs" Link="LinkedProduction\Services\Local\FileMobileSelectedMediaSnapshotStore.cs" />
     <Compile Include="..\..\..\src\App.Mobile.Android\Services\Local\InMemoryMobileSelectedMediaStore.cs" Link="LinkedProduction\Services\Local\InMemoryMobileSelectedMediaStore.cs" />
+    <Compile Include="..\..\..\src\App.Mobile.Android\Services\Local\LocalMobilePreUploadEligibilityGate.cs" Link="LinkedProduction\Services\Local\LocalMobilePreUploadEligibilityGate.cs" />
     <Compile Include="..\..\..\src\App.Mobile.Android\Services\Local\LocalCurrentSelectionDraftRepairService.cs" Link="LinkedProduction\Services\Local\LocalCurrentSelectionDraftRepairService.cs" />
     <Compile Include="..\..\..\src\App.Mobile.Android\Services\Local\LocalOutboxDuplicatePrecheckService.cs" Link="LinkedProduction\Services\Local\LocalOutboxDuplicatePrecheckService.cs" />
+    <Compile Include="..\..\..\src\App.Mobile.Android\Services\Local\UnresolvedMobileBusinessObjectBindingService.cs" Link="LinkedProduction\Services\Local\UnresolvedMobileBusinessObjectBindingService.cs" />
     <Compile Include="..\..\..\src\App.Mobile.Android\Services\Stubs\StubFeatureFlagReader.cs" Link="LinkedProduction\Services\Stubs\StubFeatureFlagReader.cs" />
     <Compile Include="..\..\..\src\App.Mobile.Android\Services\Stubs\StubMobileAccessContext.cs" Link="LinkedProduction\Services\Stubs\StubMobileAccessContext.cs" />
     <Compile Include="..\..\..\src\App.Mobile.Android\Services\Stubs\StubMobileOutboxService.cs" Link="LinkedProduction\Services\Stubs\StubMobileOutboxService.cs" />

--- a/tests/Unit/App.Mobile.Android.Foundation.Tests/LocalMobilePreUploadEligibilityGateTests.cs
+++ b/tests/Unit/App.Mobile.Android.Foundation.Tests/LocalMobilePreUploadEligibilityGateTests.cs
@@ -1,0 +1,42 @@
+namespace App.Mobile.Android.Foundation.Tests;
+
+public sealed class LocalMobilePreUploadEligibilityGateTests
+{
+    [Fact]
+    public async Task EligibilityGateBlocksPreUploadCheckWhenUnresolved()
+    {
+        var bindingService = new global::App.Mobile.Android.Services.Local.UnresolvedMobileBusinessObjectBindingService();
+        var gate = new global::App.Mobile.Android.Services.Local.LocalMobilePreUploadEligibilityGate(bindingService);
+
+        var result = await gate.EvaluateAsync();
+
+        Assert.False(result.CanRunProductionPreUploadCheck);
+        Assert.Null(result.BindingSnapshot.ApprovedBusinessObjectKey);
+    }
+
+    [Fact]
+    public async Task EligibilityGateMessageMentionsApprovedSourceIsNotDocumented()
+    {
+        var bindingService = new global::App.Mobile.Android.Services.Local.UnresolvedMobileBusinessObjectBindingService();
+        var gate = new global::App.Mobile.Android.Services.Local.LocalMobilePreUploadEligibilityGate(bindingService);
+
+        var result = await gate.EvaluateAsync();
+
+        Assert.Contains("approved businessObjectKey source is not documented", result.MessageText);
+        Assert.Contains("businessObjectKey", result.RequiredActionText);
+    }
+
+    [Fact]
+    public async Task EligibilityGateDoesNotProduceFakeBusinessObjectKeyAfterLocalIntent()
+    {
+        var bindingService = new global::App.Mobile.Android.Services.Local.UnresolvedMobileBusinessObjectBindingService();
+        await bindingService.CreateOrUpdateLocalIntentAsync("Inspection draft", "local note");
+        var gate = new global::App.Mobile.Android.Services.Local.LocalMobilePreUploadEligibilityGate(bindingService);
+
+        var result = await gate.EvaluateAsync();
+
+        Assert.False(result.CanRunProductionPreUploadCheck);
+        Assert.NotNull(result.BindingSnapshot.LocalIntent);
+        Assert.Null(result.BindingSnapshot.ApprovedBusinessObjectKey);
+    }
+}

--- a/tests/Unit/App.Mobile.Android.Foundation.Tests/StubFeatureFlagReaderTests.cs
+++ b/tests/Unit/App.Mobile.Android.Foundation.Tests/StubFeatureFlagReaderTests.cs
@@ -11,6 +11,12 @@ public sealed class StubFeatureFlagReaderTests
     }
 
     [Fact]
+    public void BusinessObjectBindingBlockerCardFlagIsEnabled()
+    {
+        Assert.True(Reader.IsEnabled(global::App.Mobile.Android.Services.Stubs.StubFeatureFlagReader.BusinessObjectBindingBlockerCardFlag));
+    }
+
+    [Fact]
     public void UnknownFlagIsDisabled()
     {
         Assert.False(Reader.IsEnabled("mobile.unknown.flag"));

--- a/tests/Unit/App.Mobile.Android.Foundation.Tests/UnresolvedMobileBusinessObjectBindingServiceTests.cs
+++ b/tests/Unit/App.Mobile.Android.Foundation.Tests/UnresolvedMobileBusinessObjectBindingServiceTests.cs
@@ -1,0 +1,62 @@
+namespace App.Mobile.Android.Foundation.Tests;
+
+public sealed class UnresolvedMobileBusinessObjectBindingServiceTests
+{
+    private readonly global::App.Mobile.Android.Services.Local.UnresolvedMobileBusinessObjectBindingService _service = new();
+
+    [Fact]
+    public async Task DefaultBindingStateIsUnresolved()
+    {
+        var snapshot = await _service.GetCurrentAsync();
+
+        Assert.Equal(
+            global::App.Mobile.Android.BusinessObjectBinding.MobileBusinessObjectBindingApprovalState.Unresolved,
+            snapshot.ApprovalState);
+        Assert.Null(snapshot.LocalIntent);
+    }
+
+    [Fact]
+    public async Task DefaultSnapshotHasNoApprovedBusinessObjectKey()
+    {
+        var snapshot = await _service.GetCurrentAsync();
+
+        Assert.Null(snapshot.ApprovedBusinessObjectKey);
+    }
+
+    [Fact]
+    public async Task LocalIntentCanBeCreatedWithoutBusinessObjectKey()
+    {
+        var snapshot = await _service.CreateOrUpdateLocalIntentAsync("Inspection draft", "local note");
+
+        Assert.NotNull(snapshot.LocalIntent);
+        Assert.Equal("Inspection draft", snapshot.LocalIntent.DisplayTitle);
+        Assert.Equal("local note", snapshot.LocalIntent.NoteText);
+        Assert.True(snapshot.LocalIntent.IsLocalOnly);
+        Assert.Null(snapshot.ApprovedBusinessObjectKey);
+    }
+
+    [Fact]
+    public async Task LocalIntentIdIsNotExposedAsBusinessObjectKey()
+    {
+        var snapshot = await _service.CreateOrUpdateLocalIntentAsync("Inspection draft", null);
+
+        Assert.NotNull(snapshot.LocalIntent);
+        Assert.False(string.IsNullOrWhiteSpace(snapshot.LocalIntent.LocalIntentId));
+        Assert.NotEqual(snapshot.LocalIntent.LocalIntentId, snapshot.ApprovedBusinessObjectKey);
+        Assert.Null(snapshot.ApprovedBusinessObjectKey);
+    }
+
+    [Fact]
+    public async Task ClearIntentReturnsUnresolvedWithoutApprovedKey()
+    {
+        await _service.CreateOrUpdateLocalIntentAsync("Inspection draft", "local note");
+
+        var snapshot = await _service.ClearLocalIntentAsync();
+
+        Assert.Equal(
+            global::App.Mobile.Android.BusinessObjectBinding.MobileBusinessObjectBindingApprovalState.Unresolved,
+            snapshot.ApprovalState);
+        Assert.Null(snapshot.LocalIntent);
+        Assert.Null(snapshot.ApprovedBusinessObjectKey);
+    }
+}


### PR DESCRIPTION
﻿Base main SHA:
f08050d

Coordination log entries reviewed:
- GitHub issue #89: PR #95 Android media picker/cache manual replay.
- GitHub issue #89: PR #96 local outbox foundation manual replay.
- GitHub issue #89: PR #97 selected-media handoff manual replay.
- GitHub issue #89: PR #98 duplicate-precheck manual replay.
- GitHub issue #89: PR #99 restart-snapshot manual replay.
- GitHub issue #89: PR #101 desktop client form architecture update.
- GitHub issue #89: PR #102 stale Web prompt replaced with desktop-client prompt.
- GitHub issue #89: PR #103 desktop UI technology decision task.
- GitHub issue #89: PR #104 desktop UI technology owner decision.
- GitHub issue #89: PR #105 desktop application skeleton task card.

Handoff/task cards reviewed:
- docs/reports/coder3-android-backend-readiness.md
- docs/task-cards/MOB-CANON-BACKEND-00.txt
- docs/handoffs/s1-11-coder3-android-integration.md
- docs/handoffs/s1-11-backend-integration-note.md
- docs/handoffs/s1-12-sprint1-quality-gate.md
- docs/task-cards/MOB-CANON-IMPORT-01.txt
- docs/task-cards/MOB-CANON-IMPORT-02.txt
- docs/task-cards/MOB-CANON-IMPORT-03.txt
- docs/task-cards/MOB-CANON-IMPORT-04.txt
- docs/task-cards/MOB-CANON-IMPORT-05.txt
- docs/task-cards/MOB-CANON-IMPORT-06.txt
- docs/task-cards/MOB-CANON-IMPORT-07.txt
- docs/task-cards/MOB-CANON-BACKEND-01.txt

Purpose:
Add Android-local unresolved business-object binding guard so production PreUploadCheck path remains explicitly blocked until approved businessObjectKey source is documented.

Module:
App.Mobile.Android / mobile unit tests / mobile docs.

Contracts:
Shared DTO/contracts unchanged.

Migration:
None.

Feature flags:
Local mobile stub flag only: mobile.business-object-binding.blocker-card.

Offline behavior:
Local unresolved blocker state only. No backend save, no sync, no upload.

Manual check:
Physical Android runtime check passed:
- Upload page shows unresolved businessObjectKey blocker
- local intent can be saved/cleared
- PreUploadCheck readiness check is blocked
- no fake businessObjectKey is shown
- media/outbox foundation still works

Tests:
dotnet test .\tests\Unit\App.Mobile.Android.Foundation.Tests\App.Mobile.Android.Foundation.Tests.csproj -c Debug
Result: passed 56/56

Build:
dotnet build .\src\App.Mobile.Android\App.Mobile.Android.csproj -f net10.0-android -m:1
Result: success

Format:
dotnet format whitespace .\AnalyticsAutomation-Core.sln --verify-no-changes --no-restore
Result: success

git diff --check:
Result: success

Rollback:
Revert this PR / remove Android-local unresolved business-object binding guard.

Out of scope:
- no backend integration
- no App.Api changes
- no Modules changes
- no BuildingBlocks.Contracts changes
- no shared DTO/contracts changes
- no App.UI.Shared changes
- no auth/session/device binding
- no create-report API
- no businessObjectKey invention
- no PreUploadCheck runtime
- no UploadReceipt runtime
- no direct upload runtime
- no report/UX production flow
- no desktop implementation
