### PR TITLE
feat(mobile): persist local report draft snapshots

### DIFF
--- a/docs/reports/coder3-canonical-mobile-import.md
+++ b/docs/reports/coder3-canonical-mobile-import.md
@@ -54,7 +54,20 @@ What changes:
 - git diff --check
 
 ## Manual steps pending
-- physical Android full-restart check for restored report draft fields, restored attachment metadata, validation, and local queue action.
+- none for REPORT-06.
+
+## Physical Android runtime check
+- Result: passed.
+- Runtime status: report06 phone ok.
+- Confirmed:
+  - local drafts survive full app restart;
+  - edited fields survive full app restart;
+  - attachment metadata survives full app restart;
+  - restored attachments are metadata-only;
+  - validation still works after restore;
+  - local report queue action still works after restore;
+  - no fake businessObjectKey is shown;
+  - production PreUploadCheck remains blocked.
 
 ## Next code step
 - REPORT-07 create-from-last, or wait for backend concrete businessObjectKey source.

--- a/docs/reports/coder3-canonical-mobile-import.md
+++ b/docs/reports/coder3-canonical-mobile-import.md
@@ -1,95 +1,60 @@
-# Coder 3 Canonical Mobile Import
+# Coder 3 canonical mobile import report
 
 ## Current step
-- MOB-CANON-REPORT-05 local validation summary and ready-to-queue gating.
+- MOB-CANON-REPORT-06 local report draft snapshot persistence.
 
 ## Main baseline
+- Base main SHA: b9fc98b
 - IMPORT-01..07 are in main.
+- BACKEND-00 readiness is in main.
 - BACKEND-01 unresolved business-object binding guard is in main.
-- REPORT-00..03 local report-first baseline is in main.
+- REPORT-00..03 local report baseline is in main.
 - REPORT-04 local field editing and selector prototype is in main.
-- Latest main SHA reviewed for this replay: `5e17f51`.
-- TEAM COORDINATION LOG #89 records the Android `businessObjectKey` decision:
+- REPORT-05 local validation and ready-to-queue gating is in main.
+- REPORT-05 Russian localization fixes are preserved.
+- TEAM COORDINATION LOG #89 records the Android businessObjectKey decision:
   https://github.com/uVormik/AnalyticsAutomation-Core/issues/89#issuecomment-4321720298
 
-## Completed Android media/outbox/report foundation
-- IMPORT-01 shell/navigation
-- IMPORT-02 media picker/cache
-- IMPORT-03 local outbox
-- IMPORT-04 selected media to outbox draft
-- IMPORT-05 local duplicate-precheck
-- IMPORT-06 restart snapshots
-- IMPORT-07 repair/rebind
-- BACKEND-01 unresolved business-object binding guard before production `PreUploadCheck`
-- REPORT-00..03 local report-first baseline
-- REPORT-04 local field editing and selector prototype
+## Current slice
+This PR slice adds Android-local JSON metadata snapshots for FPV report drafts so local draft fields and attachment metadata survive a full app restart without backend save.
 
-## Scope restored in this PR slice
-- Android-local validation models.
-- Android-local validation service.
-- Validation summary in report draft.
-- Local ready-to-queue gating.
-- Outbox protection against invalid local report drafts.
+What changes:
+- local report draft JSON metadata snapshots;
+- restored field values;
+- restored attachment metadata;
+- metadata-only note for restored attachments;
+- validation after restore;
+- local queue action after restore.
 
 ## Explicitly not included
-- production `PreUploadCheck`
-- `UploadReceipt`
-- backend create-report
-- approved backend endpoint/source for `businessObjectKey`
-- auth/session/device binding
-- direct upload runtime
-- download runtime
-- production reports engine
-- backend validation rules
-- report persistence
-- incident creation
-- App.UI.Shared changes
-- shared DTO/contracts changes
-- App.Api/backend changes
-- Modules changes
-- DB migrations
-- workflows/deploy changes
+- production PreUploadCheck;
+- UploadReceipt;
+- backend create-report;
+- approved backend endpoint/source for businessObjectKey;
+- backend validation rules;
+- media byte persistence;
+- file copy;
+- stream persistence;
+- SQLite or local database;
+- App.UI.Shared changes;
+- shared contracts changes;
+- backend/runtime integration.
 
 ## BusinessObject decision status
-- Production direction is Option 1: Android must obtain `businessObjectKey` from a backend-controlled report/business-object binding source before `PreUploadCheck`.
-- The concrete backend source/endpoint/contract remains undocumented.
-- Local report draft ids are not `businessObjectKey`.
-- Local queue action is not backend report save.
-- Production `PreUploadCheck` runtime remains blocked.
-- This slice is Android-local validation/gating only.
-- This local validation is not backend validation.
+- Production direction is Option 1: Android must obtain businessObjectKey from a backend-controlled report/business-object binding source before PreUploadCheck.
+- Concrete backend source/endpoint/contract is still not documented.
+- Local report draft ids are not businessObjectKey.
+- Local JSON snapshot ids and attachment metadata are not businessObjectKey.
+- Production PreUploadCheck runtime remains blocked.
 
 ## Validation plan
-- `dotnet test .\tests\Unit\App.Mobile.Android.Foundation.Tests\App.Mobile.Android.Foundation.Tests.csproj -c Debug`
-- `dotnet build .\src\App.Mobile.Android\App.Mobile.Android.csproj -f net10.0-android -m:1`
-- `dotnet format whitespace .\AnalyticsAutomation-Core.sln --verify-no-changes --no-restore`
-- `git diff --check`
-
-## Physical Android runtime check
-- Result: passed after runtime localization fixes.
-- Runtime localization check: passed.
-- Runtime status: report05 ru ok.
-- Confirmed:
-  - validation summary renders in report draft.
-  - missing required fields are shown in Russian.
-  - missing video attachment is shown in Russian.
-  - incomplete draft is blocked from local queue.
-  - completed draft can be placed into local queue.
-  - field editing and selector behavior still work.
-  - media attachments still work.
-  - no fake `businessObjectKey` is shown.
-  - production `PreUploadCheck` remains blocked.
-- Runtime issue found after PR #112 opened:
-  - physical Android check found Russian localization mojibake in visible UI.
-  - physical Android check found user-facing English terms in report validation/media/field text.
-- Fix scope:
-  - ReportDraft visible text and `MobileUiText` Russian localization only.
-  - User-facing backend/upload/save/validation wording replaced with Russian wording where applicable.
-  - Empty report field placeholders render current Russian localization even for existing local placeholder field state.
-  - Technical identifiers remain unchanged where needed.
+- dotnet test .\tests\Unit\App.Mobile.Android.Foundation.Tests\App.Mobile.Android.Foundation.Tests.csproj -c Debug
+- dotnet build .\src\App.Mobile.Android\App.Mobile.Android.csproj -f net10.0-android -m:1
+- dotnet format whitespace .\AnalyticsAutomation-Core.sln --verify-no-changes --no-restore
+- git diff --check
 
 ## Manual steps pending
-- none for REPORT-05-R1.
+- physical Android full-restart check for restored report draft fields, restored attachment metadata, validation, and local queue action.
 
 ## Next code step
-- REPORT-06 local report draft snapshot persistence, or wait for backend concrete `businessObjectKey` source.
+- REPORT-07 create-from-last, or wait for backend concrete businessObjectKey source.

--- a/docs/reports/coder3-mobile-foundation-reconciliation.md
+++ b/docs/reports/coder3-mobile-foundation-reconciliation.md
@@ -1,91 +1,55 @@
-# Coder 3 Mobile Foundation Reconciliation
-
-## Purpose
-Track the controlled mobile foundation replay into the canonical repository without importing broad local-only work.
+# Coder 3 mobile foundation reconciliation
 
 ## Canonical App.Mobile.Android current state
-The canonical repository contains the complete IMPORT-01..07 Android media/outbox foundation chain in `main`:
-- Shell, navigation, Russian visible baseline, and local shell-state stubs are present from MOB-CANON-IMPORT-01 / PR #67.
-- Android native video picker and native camera capture baseline are present from MOB-CANON-IMPORT-02 / PR #95.
-- Local selected-media descriptor/cache and the selected local media card are present from MOB-CANON-IMPORT-02 / PR #95.
-- Local in-memory outbox foundation, queue rendering, and retry/remove local actions are present from MOB-CANON-IMPORT-03 / PR #96.
-- Selected-media to outbox draft handoff and media-linked queue details are present from MOB-CANON-IMPORT-04 / PR #97.
-- Local duplicate-precheck and duplicate-aware handoff behavior are present from MOB-CANON-IMPORT-05 / PR #98.
-- Restart-resilience JSON metadata snapshots are present from MOB-CANON-IMPORT-06 / PR #99.
-- Local repair/rebind is present from MOB-CANON-IMPORT-07 / PR #100.
-- BACKEND-01 unresolved business-object binding guard is present from PR #108.
-- REPORT-00..03 local report-first baseline is present from PR #109.
-- REPORT-04 local field editing and selector prototype is present from PR #111.
-- `App.UI.Shared` was intentionally unchanged by IMPORT-02..07, BACKEND-01, and REPORT-00..03.
+The canonical repository contains the Android media/outbox/report foundation through REPORT-05:
+
+- IMPORT-01..07 media/outbox foundation;
+- BACKEND-00 backend readiness checkpoint;
+- BACKEND-01 unresolved business-object binding guard;
+- REPORT-00..03 local report-first baseline;
+- REPORT-04 local field editing and selector prototype;
+- REPORT-05 local validation and ready-to-queue gating;
+- REPORT-05 Russian localization fixes.
 
 ## Current local UX slice
-`MOB-CANON-REPORT-05` replays local validation summary and ready-to-queue gating as an Android-local UX slice.
+MOB-CANON-REPORT-06 is the current Android-local restart-resilience slice.
 
-Physical Android runtime check for REPORT-04 is passed with status `report04 phone ok`.
-Physical Android runtime check for REPORT-05 is passed with status `report05 phone ok`.
+REPORT-06 means:
+- local FPV report drafts are persisted as JSON metadata snapshots;
+- edited field values are restored after app restart;
+- attachment metadata is restored after app restart;
+- restored attachments are clearly metadata-only;
+- local validation and queue gating still run after restore.
 
-REPORT-05 means:
-- validation summary renders in report draft
-- missing required local fields are shown in Russian
-- missing video attachment is shown in Russian
-- incomplete draft is blocked from local queue
-- completed draft can be placed into local queue
-- local validation is not backend validation
-- no backend save
-- no sync
-- no upload
-- no production reports engine
+REPORT-06 does not mean:
+- backend save;
+- backend validation;
+- create-report API;
+- media byte persistence;
+- file copy;
+- stream persistence;
+- SQLite/local DB;
+- production report flow.
 
 ## BusinessObject and backend boundary
-- TEAM COORDINATION LOG #89 records the Android `businessObjectKey` decision:
+- TEAM COORDINATION LOG #89 records the Android businessObjectKey decision:
   https://github.com/uVormik/AnalyticsAutomation-Core/issues/89#issuecomment-4321720298
-- Production direction is Option 1.
-- Android must obtain `businessObjectKey` from a backend-controlled report/business-object binding source before `PreUploadCheck`.
+- Android must obtain businessObjectKey from a backend-controlled report/business-object binding source before PreUploadCheck.
 - The concrete backend source/endpoint/contract remains undocumented.
-- Backend integration remains blocked pending that concrete backend source/endpoint/contract.
-- Local report draft state is not backend-recognized binding.
-- Local report draft id is not `businessObjectKey`.
-- Local queue action is not backend report save.
+- Local report draft id is not businessObjectKey.
+- JSON snapshot metadata is not businessObjectKey.
+- Production PreUploadCheck remains blocked.
 
-## Gap matrix
-| Capability | Exists in canonical main | Current slice changes | Later slice needed | Notes |
-| --- | --- | --- | --- | --- |
-| MAUI shell | yes | no | no | Present from PR #67 |
-| mobile navigation/menu | yes | no | later polish possible | Report-first entry point remains Android-local |
-| native video picker | yes | remains inside draft | no for baseline | Present from PR #95 |
-| native camera capture | yes | remains inside draft | no for baseline | Device capability still applies |
-| selected media cache | yes | feeds report attachment | later persistence possible | Temporary Android-local state |
-| local outbox foundation | yes | report draft queue action remains | later backend sync | No upload/runtime integration |
-| selected media to outbox handoff | yes | remains under report draft | later production binding | Attachment flow only |
-| local duplicate-precheck | yes | duplicate-safe draft attachment remains | later backend dedupe | Local-only warning/guard |
-| restart snapshots | yes | no new persistence claim | later policy | Existing metadata snapshots only |
-| local repair/rebind | yes | remains intact | later polish possible | Existing repair flow retained |
-| BACKEND-01 blocker guard | yes | remains intact | backend contract needed | No fake `businessObjectKey` |
-| local report draft shell | yes | field editing added | later UX slices | Local-only baseline |
-| local selector prototype | yes | remains intact | final lookup/catalog integration later | Stub options only |
-| local validation/gating | partial | yes | later persistence possible | Local-only, not backend validation |
-| production report flow | no | no | yes | Requires backend source/contract |
-| production PreUploadCheck | no | no | yes | Blocked pending backend source |
+## Scope guard
+- no App.UI.Shared changes;
+- no App.Api changes;
+- no shared DTO/contracts changes;
+- no DB migrations;
+- no backend runtime integration;
+- no invented create-report API;
+- no fake businessObjectKey;
+- no local draft id as businessObjectKey;
+- no production PreUploadCheck;
+- no UploadReceipt.
 
-## Recommended reconciliation strategy
-Continue with small PR-ready slices from fresh `main`.
-
-This slice is allowed because the source-of-truth decision permits local report/business-object UX replay and unresolved seams while production `PreUploadCheck` remains blocked.
-
-Backend adapter runtime should wait for the approved concrete Android source of `businessObjectKey` / report draft / business object binding before any production `PreUploadCheck` runtime.
-
-## Not allowed
-- no backend changes
-- no shared DTO/contracts changes
-- no App.UI.Shared changes
-- no App.Api changes
-- no Modules changes
-- no DB migrations
-- no workflows/deploy changes
-- no invented create-report API
-- no fake `businessObjectKey`
-- no local draft id as `businessObjectKey`
-- no production `PreUploadCheck`
-- no `UploadReceipt`
-- no direct upload runtime
-- no desktop runtime changes
+Backend adapter runtime should wait for the approved concrete Android source of businessObjectKey / report draft / business object binding before any production PreUploadCheck runtime.

--- a/docs/task-cards/MOB-CANON-REPORT-06.txt
+++ b/docs/task-cards/MOB-CANON-REPORT-06.txt
@@ -1,0 +1,77 @@
+Title: MOB-CANON-REPORT-06 — Local report draft snapshot persistence
+
+Coder: 3
+
+Module: App.Mobile.Android
+
+Task type: Android-local persistence / report draft restart resilience
+
+Goal:
+Persist local FPV report drafts as JSON metadata snapshots so edited fields and attachment metadata survive full app restart without backend save.
+
+Base main SHA:
+b9fc98b
+
+Coordination log entries reviewed:
+- TEAM COORDINATION LOG #89 latest entries reviewed.
+- Android businessObjectKey decision comment:
+  https://github.com/uVormik/AnalyticsAutomation-Core/issues/89#issuecomment-4321720298
+
+Handoff/task cards reviewed:
+- docs/reports/coder3-android-backend-readiness.md
+- docs/task-cards/MOB-CANON-BACKEND-00.txt
+- docs/task-cards/MOB-CANON-BACKEND-01.txt
+- docs/handoffs/MOB-CANON-BACKEND-01_ANDROID_BUSINESS_OBJECT_BINDING_BLOCKER.md
+- docs/task-cards/MOB-CANON-REPORT-00-03.txt
+- docs/task-cards/MOB-CANON-REPORT-04.txt
+- docs/task-cards/MOB-CANON-REPORT-05.txt
+- docs/task-cards/MOB-CANON-REPORT-06.txt
+
+What changes:
+- Android-local JSON metadata snapshot store for report drafts
+- restored field values
+- restored attachment metadata
+- metadata-only note for restored attachments
+- validation after restore
+- local queue action after restore
+
+Contracts:
+- shared DTO/contracts unchanged
+
+Migration:
+- none
+
+Feature flags:
+- local mobile stub flags only
+
+Offline behavior:
+- local JSON metadata snapshots only
+- no backend save
+- no sync
+- no upload
+- no media byte persistence
+
+Security:
+- no auth/session/device binding
+- no tokens/secrets
+
+BusinessObject:
+- businessObjectKey source remains unresolved
+- local report draft id is not businessObjectKey
+- production PreUploadCheck remains blocked
+
+Rollback:
+- revert this PR
+
+Definition of done:
+- build succeeds
+- unit tests pass
+- format/diff-check pass
+- local drafts survive full app restart
+- edited fields survive full app restart
+- attachment metadata survives full app restart
+- restored attachments are clearly metadata-only
+- validation still works after restore
+- local report queue action still works after restore
+- no backend integration
+- no App.UI.Shared changes

--- a/src/App.Mobile.Android/Components/Pages/ReportDraft.razor
+++ b/src/App.Mobile.Android/Components/Pages/ReportDraft.razor
@@ -1,4 +1,4 @@
-@page "/reports/{DraftId}"
+﻿@page "/reports/{DraftId}"
 @using global::App.Mobile.Android.Localization
 @inject global::App.Mobile.Android.Navigation.MobileNavigationState NavigationState
 @inject global::App.Mobile.Android.Services.Abstractions.IMobileMediaService MobileMediaService
@@ -40,7 +40,11 @@ else
         </header>
 
         <p class="report-draft-note">@MobileUiText.ReportDraftLocalOnlyNote</p>
-        <p class="report-draft-note report-draft-note-secondary">@MobileUiText.ReportDraftNoBackendSaveNote</p>
+        <p class="report-draft-note report-draft-note-secondary">@MobileUiText.GetReportDraftLocalPersistenceWarningText()</p>
+        @if (Draft.IsRestoredFromSnapshot)
+        {
+            <p class="report-draft-note report-draft-note-restored">@MobileUiText.GetReportDraftRestoredFromSnapshotText()</p>
+        }
 
         @if (!string.IsNullOrWhiteSpace(FieldResultText))
         {
@@ -307,6 +311,11 @@ else
                                     <dd>@MobileUiText.GetReportAttachmentLocalAccessText(attachment.HasLocalReadHandle)</dd>
                                 </div>
                             </dl>
+
+                            @if (!attachment.HasLocalReadHandle)
+                            {
+                                <p class="report-draft-attachment-note">@MobileUiText.GetReportDraftRestoredAttachmentMetadataOnlyText()</p>
+                            }
                         </article>
                     }
                 </div>

--- a/src/App.Mobile.Android/Components/Pages/ReportDraft.razor.css
+++ b/src/App.Mobile.Android/Components/Pages/ReportDraft.razor.css
@@ -61,6 +61,11 @@
     color: #9a3412;
 }
 
+.report-draft-note-restored {
+    background: #ecfeff;
+    color: #155e75;
+}
+
 .report-draft-section {
     display: grid;
     gap: 0.85rem;
@@ -271,6 +276,15 @@
     border: 1px solid #d7dee9;
     border-radius: 0.75rem;
     background: #f8fafc;
+}
+
+.report-draft-attachment-note {
+    margin: 0.75rem 0 0;
+    padding: 0.7rem 0.8rem;
+    border-radius: 0.75rem;
+    background: #fff7ed;
+    color: #9a3412;
+    line-height: 1.4;
 }
 
 .report-draft-attachment-meta > div {

--- a/src/App.Mobile.Android/Components/Pages/Reports.razor
+++ b/src/App.Mobile.Android/Components/Pages/Reports.razor
@@ -28,6 +28,8 @@ else
             <button type="button" class="btn btn-primary" @onclick="CreateDraftAsync">@MobileUiText.ReportsCreateFpvDraftButton</button>
         </div>
 
+        <p class="reports-local-note">@MobileUiText.GetReportDraftLocalSnapshotNoteText()</p>
+
         @if (Drafts.Count == 0)
         {
             <div class="reports-empty-state">
@@ -62,6 +64,11 @@ else
                                 <dd>@draft.Attachments.Count</dd>
                             </div>
                         </dl>
+
+                        @if (draft.IsRestoredFromSnapshot)
+                        {
+                            <p class="reports-draft-restored-note">@MobileUiText.GetReportDraftRestoredFromSnapshotText()</p>
+                        }
                     </article>
                 }
             </div>

--- a/src/App.Mobile.Android/Components/Pages/Reports.razor.css
+++ b/src/App.Mobile.Android/Components/Pages/Reports.razor.css
@@ -44,6 +44,21 @@
     justify-content: flex-start;
 }
 
+.reports-local-note,
+.reports-draft-restored-note {
+    margin: 0;
+    color: #475569;
+    line-height: 1.45;
+}
+
+.reports-draft-restored-note {
+    margin-top: 0.75rem;
+    padding: 0.75rem 0.85rem;
+    border-radius: 0.75rem;
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+}
+
 .reports-empty-state {
     padding: 1rem;
     border-radius: 0.85rem;

--- a/src/App.Mobile.Android/Localization/MobileUiText.cs
+++ b/src/App.Mobile.Android/Localization/MobileUiText.cs
@@ -563,4 +563,24 @@ internal static class MobileUiText
             ? "Готов к локальной очереди"
             : "Не готов к локальной очереди";
     }
+
+    public static string GetReportDraftRestoredFromSnapshotText()
+    {
+        return "Черновик восстановлен из локального JSON-снимка после перезапуска. Это только локальные метаданные без серверного создания отчета.";
+    }
+
+    public static string GetReportDraftRestoredAttachmentMetadataOnlyText()
+    {
+        return "Вложение восстановлено только как локальные метаданные. Доступ к исходному файлу после перезапуска пока не восстанавливается в этом срезе.";
+    }
+
+    public static string GetReportDraftLocalSnapshotNoteText()
+    {
+        return "Локальные черновики и метаданные вложений восстановлены из JSON-снимка. Это не серверное сохранение и не API создания отчета.";
+    }
+
+    public static string GetReportDraftLocalPersistenceWarningText()
+    {
+        return "Черновик сохранен только локально. Серверное создание отчета пока не подключено.";
+    }
 }

--- a/src/App.Mobile.Android/MauiProgram.cs
+++ b/src/App.Mobile.Android/MauiProgram.cs
@@ -46,6 +46,10 @@ public static class MauiProgram
             global::App.Mobile.Android.Services.Abstractions.IMobileLookupCatalogProvider,
             global::App.Mobile.Android.Services.Stubs.StubMobileReportLookupProvider>();
         builder.Services.AddSingleton<
+            global::App.Mobile.Android.Services.Abstractions.IMobileReportDraftSnapshotStore>(
+            _ => new global::App.Mobile.Android.Services.Local.FileMobileReportDraftSnapshotStore(
+                global::Microsoft.Maui.Storage.FileSystem.AppDataDirectory));
+        builder.Services.AddSingleton<
             global::App.Mobile.Android.Services.Abstractions.IMobileReportDraftStore,
             global::App.Mobile.Android.Services.Local.InMemoryMobileReportDraftStore>();
         builder.Services.AddSingleton<

--- a/src/App.Mobile.Android/Reports/MobileReportDraft.cs
+++ b/src/App.Mobile.Android/Reports/MobileReportDraft.cs
@@ -7,4 +7,7 @@ internal sealed record MobileReportDraft(
     string Title,
     MobileReportDraftStatus Status,
     IReadOnlyList<MobileReportDraftFieldValue> Fields,
-    IReadOnlyList<MobileReportAttachment> Attachments);
+    IReadOnlyList<MobileReportAttachment> Attachments)
+{
+    public bool IsRestoredFromSnapshot { get; init; }
+}

--- a/src/App.Mobile.Android/Services/Abstractions/IMobileReportDraftSnapshotStore.cs
+++ b/src/App.Mobile.Android/Services/Abstractions/IMobileReportDraftSnapshotStore.cs
@@ -1,0 +1,11 @@
+namespace App.Mobile.Android.Services.Abstractions;
+
+internal interface IMobileReportDraftSnapshotStore
+{
+    Task<IReadOnlyList<global::App.Mobile.Android.Reports.MobileReportDraft>> LoadAsync(
+        CancellationToken cancellationToken = default);
+
+    Task SaveAsync(
+        IReadOnlyList<global::App.Mobile.Android.Reports.MobileReportDraft> drafts,
+        CancellationToken cancellationToken = default);
+}

--- a/src/App.Mobile.Android/Services/Local/FileMobileReportDraftSnapshotStore.cs
+++ b/src/App.Mobile.Android/Services/Local/FileMobileReportDraftSnapshotStore.cs
@@ -1,0 +1,118 @@
+namespace App.Mobile.Android.Services.Local;
+
+internal sealed class FileMobileReportDraftSnapshotStore :
+    global::App.Mobile.Android.Services.Abstractions.IMobileReportDraftSnapshotStore
+{
+    private static readonly global::System.Text.Json.JsonSerializerOptions SerializerOptions = new();
+    private readonly string _storageDirectory;
+
+    public FileMobileReportDraftSnapshotStore(string storageDirectory)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(storageDirectory);
+
+        _storageDirectory = storageDirectory;
+        Directory.CreateDirectory(_storageDirectory);
+    }
+
+    public async Task<IReadOnlyList<global::App.Mobile.Android.Reports.MobileReportDraft>> LoadAsync(
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        Directory.CreateDirectory(_storageDirectory);
+
+        var snapshotPath = GetSnapshotPath();
+        if (!File.Exists(snapshotPath))
+        {
+            return [];
+        }
+
+        await using var stream = File.OpenRead(snapshotPath);
+        var document = await global::System.Text.Json.JsonSerializer.DeserializeAsync<SnapshotDocument>(
+            stream,
+            SerializerOptions,
+            cancellationToken);
+
+        return document?.Drafts?
+            .Select(snapshot => snapshot.ToDraft())
+            .ToArray()
+            ?? [];
+    }
+
+    public async Task SaveAsync(
+        IReadOnlyList<global::App.Mobile.Android.Reports.MobileReportDraft> drafts,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentNullException.ThrowIfNull(drafts);
+        Directory.CreateDirectory(_storageDirectory);
+
+        var snapshotPath = GetSnapshotPath();
+        if (drafts.Count == 0)
+        {
+            if (File.Exists(snapshotPath))
+            {
+                File.Delete(snapshotPath);
+            }
+
+            return;
+        }
+
+        var document = new SnapshotDocument(
+            drafts.Select(ReportDraftSnapshot.FromDraft).ToArray());
+
+        await using var stream = File.Create(snapshotPath);
+        await global::System.Text.Json.JsonSerializer.SerializeAsync(
+            stream,
+            document,
+            SerializerOptions,
+            cancellationToken);
+        await stream.FlushAsync(cancellationToken);
+    }
+
+    private string GetSnapshotPath()
+    {
+        return Path.Combine(_storageDirectory, "mobile-report-drafts-snapshot.json");
+    }
+
+    private sealed record SnapshotDocument(ReportDraftSnapshot[] Drafts);
+
+    private sealed record ReportDraftSnapshot(
+        string DraftId,
+        DateTimeOffset CreatedAtUtc,
+        DateTimeOffset UpdatedAtUtc,
+        string Title,
+        global::App.Mobile.Android.Reports.MobileReportDraftStatus Status,
+        global::App.Mobile.Android.Reports.MobileReportDraftFieldValue[] Fields,
+        global::App.Mobile.Android.Reports.MobileReportAttachment[] Attachments,
+        bool IsRestoredFromSnapshot)
+    {
+        public global::App.Mobile.Android.Reports.MobileReportDraft ToDraft()
+        {
+            return new global::App.Mobile.Android.Reports.MobileReportDraft(
+                DraftId,
+                CreatedAtUtc,
+                UpdatedAtUtc,
+                Title,
+                Status,
+                Fields ?? [],
+                Attachments ?? [])
+            {
+                IsRestoredFromSnapshot = IsRestoredFromSnapshot
+            };
+        }
+
+        public static ReportDraftSnapshot FromDraft(
+            global::App.Mobile.Android.Reports.MobileReportDraft draft)
+        {
+            return new ReportDraftSnapshot(
+                draft.DraftId,
+                draft.CreatedAtUtc,
+                draft.UpdatedAtUtc,
+                draft.Title,
+                draft.Status,
+                draft.Fields.ToArray(),
+                draft.Attachments.ToArray(),
+                draft.IsRestoredFromSnapshot);
+        }
+    }
+}

--- a/src/App.Mobile.Android/Services/Local/InMemoryMobileReportDraftStore.cs
+++ b/src/App.Mobile.Android/Services/Local/InMemoryMobileReportDraftStore.cs
@@ -1,7 +1,8 @@
 namespace App.Mobile.Android.Services.Local;
 
 internal sealed class InMemoryMobileReportDraftStore :
-    global::App.Mobile.Android.Services.Abstractions.IMobileReportDraftStore
+    global::App.Mobile.Android.Services.Abstractions.IMobileReportDraftStore,
+    IDisposable
 {
     private static readonly HashSet<string> RequiredFieldKeys = new(StringComparer.Ordinal)
     {
@@ -15,42 +16,47 @@ internal sealed class InMemoryMobileReportDraftStore :
     };
 
     private readonly object _gate = new();
+    private readonly SemaphoreSlim _loadGate = new(1, 1);
     private readonly global::App.Mobile.Android.Services.Abstractions.IMobileLookupCatalogProvider _lookupCatalogProvider;
+    private readonly global::App.Mobile.Android.Services.Abstractions.IMobileReportDraftSnapshotStore _snapshotStore;
     private readonly List<global::App.Mobile.Android.Reports.MobileReportDraft> _drafts = [];
+    private bool _snapshotLoaded;
     private int _sequence;
 
     public InMemoryMobileReportDraftStore(
-        global::App.Mobile.Android.Services.Abstractions.IMobileLookupCatalogProvider lookupCatalogProvider)
+        global::App.Mobile.Android.Services.Abstractions.IMobileLookupCatalogProvider lookupCatalogProvider,
+        global::App.Mobile.Android.Services.Abstractions.IMobileReportDraftSnapshotStore snapshotStore)
     {
         _lookupCatalogProvider = lookupCatalogProvider;
+        _snapshotStore = snapshotStore;
     }
 
-    public Task<IReadOnlyList<global::App.Mobile.Android.Reports.MobileReportDraft>> GetDraftsAsync(
+    public async Task<IReadOnlyList<global::App.Mobile.Android.Reports.MobileReportDraft>> GetDraftsAsync(
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
+        await EnsureSnapshotLoadedAsync(cancellationToken);
 
         lock (_gate)
         {
-            return Task.FromResult<IReadOnlyList<global::App.Mobile.Android.Reports.MobileReportDraft>>(
-                _drafts
-                    .OrderByDescending(draft => draft.UpdatedAtUtc)
-                    .ToArray());
+            return _drafts
+                .OrderByDescending(draft => draft.UpdatedAtUtc)
+                .ToArray();
         }
     }
 
-    public Task<global::App.Mobile.Android.Reports.MobileReportDraft?> GetDraftAsync(
+    public async Task<global::App.Mobile.Android.Reports.MobileReportDraft?> GetDraftAsync(
         string draftId,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         ArgumentException.ThrowIfNullOrWhiteSpace(draftId);
+        await EnsureSnapshotLoadedAsync(cancellationToken);
 
         lock (_gate)
         {
-            return Task.FromResult(
-                _drafts.FirstOrDefault(draft =>
-                    string.Equals(draft.DraftId, draftId, StringComparison.Ordinal)));
+            return _drafts.FirstOrDefault(draft =>
+                string.Equals(draft.DraftId, draftId, StringComparison.Ordinal));
         }
     }
 
@@ -58,6 +64,7 @@ internal sealed class InMemoryMobileReportDraftStore :
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
+        await EnsureSnapshotLoadedAsync(cancellationToken);
 
         var snapshot = await _lookupCatalogProvider.GetReportDraftFieldsAsync(cancellationToken);
         var now = DateTimeOffset.UtcNow;
@@ -86,31 +93,37 @@ internal sealed class InMemoryMobileReportDraftStore :
             Fields: fields,
             Attachments: Array.Empty<global::App.Mobile.Android.Reports.MobileReportAttachment>());
 
+        global::App.Mobile.Android.Reports.MobileReportDraft[] persistedDrafts;
         lock (_gate)
         {
             _drafts.Insert(0, draft);
+            persistedDrafts = _drafts.ToArray();
         }
 
+        await _snapshotStore.SaveAsync(persistedDrafts, cancellationToken);
         return draft;
     }
 
-    public Task<global::App.Mobile.Android.Reports.MobileReportDraftOperationResult> AttachSelectedVideoAsync(
+    public async Task<global::App.Mobile.Android.Reports.MobileReportDraftOperationResult> AttachSelectedVideoAsync(
         string draftId,
         global::App.Mobile.Android.Media.LocalSelectedMediaDescriptor descriptor,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         ArgumentException.ThrowIfNullOrWhiteSpace(draftId);
+        await EnsureSnapshotLoadedAsync(cancellationToken);
 
         if (descriptor is null || !IsValidDescriptor(descriptor))
         {
-            return Task.FromResult(
-                new global::App.Mobile.Android.Reports.MobileReportDraftOperationResult(
-                    Applied: false,
-                    Message: global::App.Mobile.Android.Localization.MobileUiText.ReportDraftInvalidVideoSelectionText,
-                    Draft: null,
-                    Attachment: null));
+            return new global::App.Mobile.Android.Reports.MobileReportDraftOperationResult(
+                Applied: false,
+                Message: global::App.Mobile.Android.Localization.MobileUiText.ReportDraftInvalidVideoSelectionText,
+                Draft: null,
+                Attachment: null);
         }
+
+        global::App.Mobile.Android.Reports.MobileReportDraftOperationResult operationResult;
+        global::App.Mobile.Android.Reports.MobileReportDraft[]? persistedDrafts = null;
 
         lock (_gate)
         {
@@ -119,23 +132,21 @@ internal sealed class InMemoryMobileReportDraftStore :
 
             if (index < 0)
             {
-                return Task.FromResult(
-                    new global::App.Mobile.Android.Reports.MobileReportDraftOperationResult(
-                        Applied: false,
-                        Message: global::App.Mobile.Android.Localization.MobileUiText.ReportDraftNotFoundMessage,
-                        Draft: null,
-                        Attachment: null));
+                return new global::App.Mobile.Android.Reports.MobileReportDraftOperationResult(
+                    Applied: false,
+                    Message: global::App.Mobile.Android.Localization.MobileUiText.ReportDraftNotFoundMessage,
+                    Draft: null,
+                    Attachment: null);
             }
 
             var currentDraft = _drafts[index];
             if (HasDuplicateVideoAttachment(currentDraft, descriptor))
             {
-                return Task.FromResult(
-                    new global::App.Mobile.Android.Reports.MobileReportDraftOperationResult(
-                        Applied: false,
-                        Message: global::App.Mobile.Android.Localization.MobileUiText.ReportDraftDuplicateAttachmentWarningText,
-                        Draft: currentDraft,
-                        Attachment: null));
+                return new global::App.Mobile.Android.Reports.MobileReportDraftOperationResult(
+                    Applied: false,
+                    Message: global::App.Mobile.Android.Localization.MobileUiText.ReportDraftDuplicateAttachmentWarningText,
+                    Draft: currentDraft,
+                    Attachment: null);
             }
 
             var now = DateTimeOffset.UtcNow;
@@ -162,18 +173,20 @@ internal sealed class InMemoryMobileReportDraftStore :
             };
 
             _drafts[index] = updatedDraft;
-
-            return Task.FromResult(
-                new global::App.Mobile.Android.Reports.MobileReportDraftOperationResult(
-                    Applied: true,
-                    Message: global::App.Mobile.Android.Localization.MobileUiText.GetReportDraftAttachVideoSuccessText(
-                        descriptor.FileName),
-                    Draft: updatedDraft,
-                    Attachment: attachment));
+            persistedDrafts = _drafts.ToArray();
+            operationResult = new global::App.Mobile.Android.Reports.MobileReportDraftOperationResult(
+                Applied: true,
+                Message: global::App.Mobile.Android.Localization.MobileUiText.GetReportDraftAttachVideoSuccessText(
+                    descriptor.FileName),
+                Draft: updatedDraft,
+                Attachment: attachment);
         }
+
+        await _snapshotStore.SaveAsync(persistedDrafts, cancellationToken);
+        return operationResult;
     }
 
-    public Task<global::App.Mobile.Android.Reports.MobileReportDraftOperationResult> UpdateFieldValueAsync(
+    public async Task<global::App.Mobile.Android.Reports.MobileReportDraftOperationResult> UpdateFieldValueAsync(
         string draftId,
         string fieldKey,
         string? valueText,
@@ -182,6 +195,10 @@ internal sealed class InMemoryMobileReportDraftStore :
         cancellationToken.ThrowIfCancellationRequested();
         ArgumentException.ThrowIfNullOrWhiteSpace(draftId);
         ArgumentException.ThrowIfNullOrWhiteSpace(fieldKey);
+        await EnsureSnapshotLoadedAsync(cancellationToken);
+
+        global::App.Mobile.Android.Reports.MobileReportDraftOperationResult operationResult;
+        global::App.Mobile.Android.Reports.MobileReportDraft[]? persistedDrafts = null;
 
         lock (_gate)
         {
@@ -190,15 +207,14 @@ internal sealed class InMemoryMobileReportDraftStore :
 
             if (draftIndex < 0)
             {
-                return Task.FromResult(
-                    new global::App.Mobile.Android.Reports.MobileReportDraftOperationResult(
-                        Applied: false,
-                        Message: global::App.Mobile.Android.Localization.MobileUiText.ReportDraftNotFoundMessage,
-                        Draft: null,
-                        Attachment: null)
-                    {
-                        FieldKey = fieldKey
-                    });
+                return new global::App.Mobile.Android.Reports.MobileReportDraftOperationResult(
+                    Applied: false,
+                    Message: global::App.Mobile.Android.Localization.MobileUiText.ReportDraftNotFoundMessage,
+                    Draft: null,
+                    Attachment: null)
+                {
+                    FieldKey = fieldKey
+                };
             }
 
             var currentDraft = _drafts[draftIndex];
@@ -210,15 +226,14 @@ internal sealed class InMemoryMobileReportDraftStore :
 
             if (fieldIndex < 0)
             {
-                return Task.FromResult(
-                    new global::App.Mobile.Android.Reports.MobileReportDraftOperationResult(
-                        Applied: false,
-                        Message: global::App.Mobile.Android.Localization.MobileUiText.ReportDraftFieldNotFoundMessage,
-                        Draft: currentDraft,
-                        Attachment: null)
-                    {
-                        FieldKey = fieldKey
-                    });
+                return new global::App.Mobile.Android.Reports.MobileReportDraftOperationResult(
+                    Applied: false,
+                    Message: global::App.Mobile.Android.Localization.MobileUiText.ReportDraftFieldNotFoundMessage,
+                    Draft: currentDraft,
+                    Attachment: null)
+                {
+                    FieldKey = fieldKey
+                };
             }
 
             var now = DateTimeOffset.UtcNow;
@@ -241,27 +256,33 @@ internal sealed class InMemoryMobileReportDraftStore :
             };
 
             _drafts[draftIndex] = updatedDraft;
-
-            return Task.FromResult(
-                new global::App.Mobile.Android.Reports.MobileReportDraftOperationResult(
-                    Applied: true,
-                    Message: global::App.Mobile.Android.Localization.MobileUiText.GetReportDraftFieldUpdatedText(
-                        updatedField.Label,
-                        normalizedValue),
-                    Draft: updatedDraft,
-                    Attachment: null)
-                {
-                    FieldKey = updatedField.FieldKey
-                });
+            persistedDrafts = _drafts.ToArray();
+            operationResult = new global::App.Mobile.Android.Reports.MobileReportDraftOperationResult(
+                Applied: true,
+                Message: global::App.Mobile.Android.Localization.MobileUiText.GetReportDraftFieldUpdatedText(
+                    updatedField.Label,
+                    normalizedValue),
+                Draft: updatedDraft,
+                Attachment: null)
+            {
+                FieldKey = updatedField.FieldKey
+            };
         }
+
+        await _snapshotStore.SaveAsync(persistedDrafts, cancellationToken);
+        return operationResult;
     }
 
-    public Task<global::App.Mobile.Android.Reports.MobileReportDraftOperationResult> MarkDraftQueuedLocalAsync(
+    public async Task<global::App.Mobile.Android.Reports.MobileReportDraftOperationResult> MarkDraftQueuedLocalAsync(
         string draftId,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         ArgumentException.ThrowIfNullOrWhiteSpace(draftId);
+        await EnsureSnapshotLoadedAsync(cancellationToken);
+
+        global::App.Mobile.Android.Reports.MobileReportDraftOperationResult operationResult;
+        global::App.Mobile.Android.Reports.MobileReportDraft[]? persistedDrafts = null;
 
         lock (_gate)
         {
@@ -270,12 +291,11 @@ internal sealed class InMemoryMobileReportDraftStore :
 
             if (index < 0)
             {
-                return Task.FromResult(
-                    new global::App.Mobile.Android.Reports.MobileReportDraftOperationResult(
-                        Applied: false,
-                        Message: global::App.Mobile.Android.Localization.MobileUiText.ReportDraftNotFoundMessage,
-                        Draft: null,
-                        Attachment: null));
+                return new global::App.Mobile.Android.Reports.MobileReportDraftOperationResult(
+                    Applied: false,
+                    Message: global::App.Mobile.Android.Localization.MobileUiText.ReportDraftNotFoundMessage,
+                    Draft: null,
+                    Attachment: null);
             }
 
             var updatedDraft = _drafts[index] with
@@ -285,15 +305,64 @@ internal sealed class InMemoryMobileReportDraftStore :
             };
 
             _drafts[index] = updatedDraft;
-
-            return Task.FromResult(
-                new global::App.Mobile.Android.Reports.MobileReportDraftOperationResult(
-                    Applied: true,
-                    Message: global::App.Mobile.Android.Localization.MobileUiText.GetReportDraftQueuedLocalText(
-                        updatedDraft.Title),
-                    Draft: updatedDraft,
-                    Attachment: null));
+            persistedDrafts = _drafts.ToArray();
+            operationResult = new global::App.Mobile.Android.Reports.MobileReportDraftOperationResult(
+                Applied: true,
+                Message: global::App.Mobile.Android.Localization.MobileUiText.GetReportDraftQueuedLocalText(
+                    updatedDraft.Title),
+                Draft: updatedDraft,
+                Attachment: null);
         }
+
+        await _snapshotStore.SaveAsync(persistedDrafts, cancellationToken);
+        return operationResult;
+    }
+
+    private async Task EnsureSnapshotLoadedAsync(CancellationToken cancellationToken)
+    {
+        if (_snapshotLoaded)
+        {
+            return;
+        }
+
+        await _loadGate.WaitAsync(cancellationToken);
+        try
+        {
+            if (_snapshotLoaded)
+            {
+                return;
+            }
+
+            var restoredDrafts = await _snapshotStore.LoadAsync(cancellationToken);
+            var normalizedDrafts = restoredDrafts
+                .Select(NormalizeRestoredDraft)
+                .ToArray();
+
+            lock (_gate)
+            {
+                _drafts.Clear();
+                _drafts.AddRange(normalizedDrafts);
+                _sequence = Math.Max(_sequence, _drafts.Count);
+                _snapshotLoaded = true;
+            }
+        }
+        finally
+        {
+            _loadGate.Release();
+        }
+    }
+
+    private static global::App.Mobile.Android.Reports.MobileReportDraft NormalizeRestoredDraft(
+        global::App.Mobile.Android.Reports.MobileReportDraft draft)
+    {
+        return draft with
+        {
+            IsRestoredFromSnapshot = true,
+            Fields = draft.Fields.ToArray(),
+            Attachments = draft.Attachments
+                .Select(attachment => attachment with { HasLocalReadHandle = false })
+                .ToArray()
+        };
     }
 
     private static bool IsValidDescriptor(global::App.Mobile.Android.Media.LocalSelectedMediaDescriptor descriptor)
@@ -331,5 +400,9 @@ internal sealed class InMemoryMobileReportDraftStore :
         return string.IsNullOrWhiteSpace(valueText)
             ? string.Empty
             : valueText.Trim();
+    }
+    public void Dispose()
+    {
+        _loadGate.Dispose();
     }
 }

--- a/tests/Unit/App.Mobile.Android.Foundation.Tests/App.Mobile.Android.Foundation.Tests.csproj
+++ b/tests/Unit/App.Mobile.Android.Foundation.Tests/App.Mobile.Android.Foundation.Tests.csproj
@@ -63,6 +63,7 @@
     <Compile Include="..\..\..\src\App.Mobile.Android\Services\Abstractions\IMobileLookupCatalogProvider.cs" Link="LinkedProduction\Services\Abstractions\IMobileLookupCatalogProvider.cs" />
     <Compile Include="..\..\..\src\App.Mobile.Android\Services\Abstractions\IMobileOutboxService.cs" Link="LinkedProduction\Services\Abstractions\IMobileOutboxService.cs" />
     <Compile Include="..\..\..\src\App.Mobile.Android\Services\Abstractions\IMobileReportDraftStore.cs" Link="LinkedProduction\Services\Abstractions\IMobileReportDraftStore.cs" />
+    <Compile Include="..\..\..\src\App.Mobile.Android\Services\Abstractions\IMobileReportDraftSnapshotStore.cs" Link="LinkedProduction\Services\Abstractions\IMobileReportDraftSnapshotStore.cs" />
     <Compile Include="..\..\..\src\App.Mobile.Android\Services\Abstractions\IMobileReportDraftValidationService.cs" Link="LinkedProduction\Services\Abstractions\IMobileReportDraftValidationService.cs" />
     <Compile Include="..\..\..\src\App.Mobile.Android\Services\Abstractions\IMobileOutboxSnapshotStore.cs" Link="LinkedProduction\Services\Abstractions\IMobileOutboxSnapshotStore.cs" />
     <Compile Include="..\..\..\src\App.Mobile.Android\Services\Abstractions\IMobileSelectedMediaStore.cs" Link="LinkedProduction\Services\Abstractions\IMobileSelectedMediaStore.cs" />
@@ -73,6 +74,7 @@
     <Compile Include="..\..\..\src\App.Mobile.Android\Outbox\PendingSyncItemLocalReportDraft.cs" Link="LinkedProduction\Outbox\PendingSyncItemLocalReportDraft.cs" />
     <Compile Include="..\..\..\src\App.Mobile.Android\Outbox\PendingSyncOperationResult.cs" Link="LinkedProduction\Outbox\PendingSyncOperationResult.cs" />
     <Compile Include="..\..\..\src\App.Mobile.Android\Services\Local\FileMobileOutboxSnapshotStore.cs" Link="LinkedProduction\Services\Local\FileMobileOutboxSnapshotStore.cs" />
+    <Compile Include="..\..\..\src\App.Mobile.Android\Services\Local\FileMobileReportDraftSnapshotStore.cs" Link="LinkedProduction\Services\Local\FileMobileReportDraftSnapshotStore.cs" />
     <Compile Include="..\..\..\src\App.Mobile.Android\Services\Local\InMemoryMobileReportDraftStore.cs" Link="LinkedProduction\Services\Local\InMemoryMobileReportDraftStore.cs" />
     <Compile Include="..\..\..\src\App.Mobile.Android\Services\Local\FileMobileSelectedMediaSnapshotStore.cs" Link="LinkedProduction\Services\Local\FileMobileSelectedMediaSnapshotStore.cs" />
     <Compile Include="..\..\..\src\App.Mobile.Android\Services\Local\InMemoryMobileSelectedMediaStore.cs" Link="LinkedProduction\Services\Local\InMemoryMobileSelectedMediaStore.cs" />

--- a/tests/Unit/App.Mobile.Android.Foundation.Tests/FileMobileReportDraftSnapshotStoreTests.cs
+++ b/tests/Unit/App.Mobile.Android.Foundation.Tests/FileMobileReportDraftSnapshotStoreTests.cs
@@ -1,0 +1,173 @@
+namespace App.Mobile.Android.Foundation.Tests;
+
+public sealed class FileMobileReportDraftSnapshotStoreTests
+{
+    [Fact]
+    public async Task LoadAsyncReturnsEmptyListWhenFileIsAbsent()
+    {
+        var storageDirectory = CreateTempDirectory();
+
+        try
+        {
+            var store = new global::App.Mobile.Android.Services.Local.FileMobileReportDraftSnapshotStore(storageDirectory);
+
+            var loaded = await store.LoadAsync();
+
+            Assert.Empty(loaded);
+        }
+        finally
+        {
+            DeleteTempDirectory(storageDirectory);
+        }
+    }
+
+    [Fact]
+    public async Task SaveAsyncThenLoadAsyncReturnsDraftWithFields()
+    {
+        var storageDirectory = CreateTempDirectory();
+
+        try
+        {
+            var store = new global::App.Mobile.Android.Services.Local.FileMobileReportDraftSnapshotStore(storageDirectory);
+            var drafts = CreateDrafts(includeAttachment: false);
+
+            await store.SaveAsync(drafts);
+            var loaded = await store.LoadAsync();
+
+            var draft = Assert.Single(loaded);
+            Assert.Equal("draft-1", draft.DraftId);
+            Assert.Equal("Черновик FPV #1", draft.Title);
+            Assert.Equal(2, draft.Fields.Count);
+            Assert.Contains(draft.Fields, field => field.FieldKey == "device_type" && field.ValueText == "Локальное значение 1");
+            Assert.Contains(draft.Fields, field => field.FieldKey == "serial_number" && field.ValueText == "SN-001");
+        }
+        finally
+        {
+            DeleteTempDirectory(storageDirectory);
+        }
+    }
+
+    [Fact]
+    public async Task SaveAsyncThenLoadAsyncReturnsDraftWithAttachmentMetadata()
+    {
+        var storageDirectory = CreateTempDirectory();
+
+        try
+        {
+            var store = new global::App.Mobile.Android.Services.Local.FileMobileReportDraftSnapshotStore(storageDirectory);
+            var drafts = CreateDrafts(includeAttachment: true);
+
+            await store.SaveAsync(drafts);
+            var loaded = await store.LoadAsync();
+
+            var draft = Assert.Single(loaded);
+            var attachment = Assert.Single(draft.Attachments);
+            Assert.Equal(global::App.Mobile.Android.Reports.MobileReportAttachmentKind.Video, attachment.Kind);
+            Assert.Equal("video-1.mp4", attachment.FileName);
+            Assert.Equal("video/mp4", attachment.ContentType);
+            Assert.Equal("cache-1", attachment.SelectedMediaCacheKey);
+            Assert.True(attachment.HasLocalReadHandle);
+        }
+        finally
+        {
+            DeleteTempDirectory(storageDirectory);
+        }
+    }
+
+    [Fact]
+    public async Task SaveAsyncEmptyListThenLoadAsyncReturnsEmptyList()
+    {
+        var storageDirectory = CreateTempDirectory();
+
+        try
+        {
+            var store = new global::App.Mobile.Android.Services.Local.FileMobileReportDraftSnapshotStore(storageDirectory);
+            await store.SaveAsync(CreateDrafts(includeAttachment: true));
+
+            await store.SaveAsync([]);
+            var loaded = await store.LoadAsync();
+
+            Assert.Empty(loaded);
+        }
+        finally
+        {
+            DeleteTempDirectory(storageDirectory);
+        }
+    }
+
+    private static IReadOnlyList<global::App.Mobile.Android.Reports.MobileReportDraft> CreateDrafts(bool includeAttachment)
+    {
+        var now = new DateTimeOffset(2026, 4, 22, 9, 0, 0, TimeSpan.Zero);
+        var attachments = includeAttachment
+            ? new[]
+            {
+                new global::App.Mobile.Android.Reports.MobileReportAttachment(
+                    AttachmentId: "attachment-1",
+                    DraftId: "draft-1",
+                    Kind: global::App.Mobile.Android.Reports.MobileReportAttachmentKind.Video,
+                    FileName: "video-1.mp4",
+                    ContentType: "video/mp4",
+                    SourceText: "Галерея",
+                    AddedAtUtc: now,
+                    SelectedMediaCacheKey: "cache-1",
+                    HasLocalReadHandle: true)
+            }
+            : Array.Empty<global::App.Mobile.Android.Reports.MobileReportAttachment>();
+
+        return
+        [
+            new global::App.Mobile.Android.Reports.MobileReportDraft(
+                DraftId: "draft-1",
+                CreatedAtUtc: now,
+                UpdatedAtUtc: now.AddMinutes(7),
+                Title: "Черновик FPV #1",
+                Status: global::App.Mobile.Android.Reports.MobileReportDraftStatus.ReadyForAttachmentReview,
+                Fields:
+                [
+                    new global::App.Mobile.Android.Reports.MobileReportDraftFieldValue(
+                        FieldKey: "device_type",
+                        Label: global::App.Mobile.Android.Localization.MobileUiText.ReportFieldDeviceTypeLabel,
+                        ValueText: "Локальное значение 1",
+                        IsRequired: true,
+                        IsPlaceholder: false)
+                    {
+                        SectionKey = "basic-data",
+                        FieldKind = global::App.Mobile.Android.Lookup.MobileLookupFieldKind.SearchableSingleSelect,
+                        SelectorMode = global::App.Mobile.Android.Lookup.MobileLookupSelectorMode.ImmediatePick,
+                        LastUpdatedAtUtc = now.AddMinutes(1)
+                    },
+                    new global::App.Mobile.Android.Reports.MobileReportDraftFieldValue(
+                        FieldKey: "serial_number",
+                        Label: global::App.Mobile.Android.Localization.MobileUiText.ReportFieldSerialNumberLabel,
+                        ValueText: "SN-001",
+                        IsRequired: true,
+                        IsPlaceholder: false)
+                    {
+                        SectionKey = "basic-data",
+                        FieldKind = global::App.Mobile.Android.Lookup.MobileLookupFieldKind.Text,
+                        SelectorMode = global::App.Mobile.Android.Lookup.MobileLookupSelectorMode.None,
+                        LastUpdatedAtUtc = now.AddMinutes(2)
+                    }
+                ],
+                Attachments: attachments)
+            {
+                IsRestoredFromSnapshot = false
+            }
+        ];
+    }
+
+    private static string CreateTempDirectory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"androida-mobile-report-drafts-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static void DeleteTempDirectory(string path)
+    {
+        if (Directory.Exists(path))
+        {
+            Directory.Delete(path, recursive: true);
+        }
+    }
+}

--- a/tests/Unit/App.Mobile.Android.Foundation.Tests/InMemoryMobileReportDraftStoreTests.cs
+++ b/tests/Unit/App.Mobile.Android.Foundation.Tests/InMemoryMobileReportDraftStoreTests.cs
@@ -1,22 +1,25 @@
-namespace App.Mobile.Android.Foundation.Tests;
+﻿namespace App.Mobile.Android.Foundation.Tests;
 
 public sealed class InMemoryMobileReportDraftStoreTests
 {
     [Fact]
     public async Task CreateFpvDraftAsync_CreatesOneDraftWithDraftStatus()
     {
-        var store = CreateStore();
+        using var scope = CreateScope();
+        var store = scope.CreateStore();
 
         var draft = await store.CreateFpvDraftAsync();
 
         Assert.Equal(global::App.Mobile.Android.Reports.MobileReportDraftStatus.Draft, draft.Status);
         Assert.NotEmpty(draft.DraftId);
+        Assert.False(draft.IsRestoredFromSnapshot);
     }
 
     [Fact]
     public async Task CreatedDraft_ContainsObservedPlaceholderFieldLabels()
     {
-        var store = CreateStore();
+        using var scope = CreateScope();
+        var store = scope.CreateStore();
 
         var draft = await store.CreateFpvDraftAsync();
         var labels = draft.Fields.Select(field => field.Label).ToArray();
@@ -42,7 +45,8 @@ public sealed class InMemoryMobileReportDraftStoreTests
     [Fact]
     public async Task CreateFpvDraftAsync_CreatesExpectedFieldKeys()
     {
-        var store = CreateStore();
+        using var scope = CreateScope();
+        var store = scope.CreateStore();
 
         var draft = await store.CreateFpvDraftAsync();
         var keys = draft.Fields.Select(field => field.FieldKey).ToArray();
@@ -68,7 +72,8 @@ public sealed class InMemoryMobileReportDraftStoreTests
     [Fact]
     public async Task CreateFpvDraftAsync_MarksExpectedLocalRequiredFieldsAsRequired()
     {
-        var store = CreateStore();
+        using var scope = CreateScope();
+        var store = scope.CreateStore();
 
         var draft = await store.CreateFpvDraftAsync();
         var requiredKeys = draft.Fields
@@ -93,7 +98,8 @@ public sealed class InMemoryMobileReportDraftStoreTests
     [Fact]
     public async Task GetDraftsAsync_ReturnsCreatedDraft()
     {
-        var store = CreateStore();
+        using var scope = CreateScope();
+        var store = scope.CreateStore();
         var createdDraft = await store.CreateFpvDraftAsync();
 
         var drafts = await store.GetDraftsAsync();
@@ -105,7 +111,8 @@ public sealed class InMemoryMobileReportDraftStoreTests
     [Fact]
     public async Task GetDraftAsync_ReturnsCreatedDraft()
     {
-        var store = CreateStore();
+        using var scope = CreateScope();
+        var store = scope.CreateStore();
         var createdDraft = await store.CreateFpvDraftAsync();
 
         var draft = await store.GetDraftAsync(createdDraft.DraftId);
@@ -115,9 +122,62 @@ public sealed class InMemoryMobileReportDraftStoreTests
     }
 
     [Fact]
+    public async Task CreatedDraft_PersistsAndLoadsInNewStoreInstance()
+    {
+        using var scope = CreateScope();
+
+        var firstStore = scope.CreateStore();
+        var createdDraft = await firstStore.CreateFpvDraftAsync();
+
+        var secondStore = scope.CreateStore();
+        var drafts = await secondStore.GetDraftsAsync();
+
+        var restoredDraft = Assert.Single(drafts);
+        Assert.Equal(createdDraft.DraftId, restoredDraft.DraftId);
+        Assert.True(restoredDraft.IsRestoredFromSnapshot);
+    }
+
+    [Fact]
+    public async Task UpdateFieldValueAsync_UpdatesExistingField()
+    {
+        using var scope = CreateScope();
+        var store = scope.CreateStore();
+        var draft = await store.CreateFpvDraftAsync();
+
+        var result = await store.UpdateFieldValueAsync(draft.DraftId, "serial_number", "SN-001");
+
+        Assert.True(result.Applied);
+        Assert.NotNull(result.Draft);
+        var field = Assert.Single(result.Draft!.Fields, item => item.FieldKey == "serial_number");
+        Assert.Equal("SN-001", field.ValueText);
+        Assert.False(field.IsPlaceholder);
+        Assert.NotNull(field.LastUpdatedAtUtc);
+    }
+
+    [Fact]
+    public async Task UpdatedFieldValue_PersistsAndLoadsInNewStoreInstance()
+    {
+        using var scope = CreateScope();
+
+        var firstStore = scope.CreateStore();
+        var draft = await firstStore.CreateFpvDraftAsync();
+        await firstStore.UpdateFieldValueAsync(draft.DraftId, "serial_number", "SN-RESTORED");
+
+        var secondStore = scope.CreateStore();
+        var restoredDraft = await secondStore.GetDraftAsync(draft.DraftId);
+
+        Assert.NotNull(restoredDraft);
+        var field = Assert.Single(restoredDraft!.Fields, item => item.FieldKey == "serial_number");
+        Assert.Equal("SN-RESTORED", field.ValueText);
+        Assert.False(field.IsPlaceholder);
+        Assert.True(restoredDraft.IsRestoredFromSnapshot);
+    }
+
+    [Fact]
     public async Task AttachSelectedVideoAsync_AddsOneVideoAttachment()
     {
-        var store = CreateStore();
+        using var scope = CreateScope();
+        var store = scope.CreateStore();
         var draft = await store.CreateFpvDraftAsync();
 
         var result = await store.AttachSelectedVideoAsync(draft.DraftId, CreateDescriptor());
@@ -131,9 +191,46 @@ public sealed class InMemoryMobileReportDraftStoreTests
     }
 
     [Fact]
+    public async Task AttachedVideoMetadata_PersistsAndLoadsInNewStoreInstance()
+    {
+        using var scope = CreateScope();
+
+        var firstStore = scope.CreateStore();
+        var draft = await firstStore.CreateFpvDraftAsync();
+        await firstStore.AttachSelectedVideoAsync(draft.DraftId, CreateDescriptor(cacheKey: "cache-persist-1", fileName: "persisted.mp4"));
+
+        var secondStore = scope.CreateStore();
+        var restoredDraft = await secondStore.GetDraftAsync(draft.DraftId);
+
+        Assert.NotNull(restoredDraft);
+        var attachment = Assert.Single(restoredDraft!.Attachments);
+        Assert.Equal("persisted.mp4", attachment.FileName);
+        Assert.Equal("cache-persist-1", attachment.SelectedMediaCacheKey);
+        Assert.False(attachment.HasLocalReadHandle);
+    }
+
+    [Fact]
+    public async Task RestoredAttachment_HasLocalReadHandleFalse()
+    {
+        using var scope = CreateScope();
+
+        var firstStore = scope.CreateStore();
+        var draft = await firstStore.CreateFpvDraftAsync();
+        await firstStore.AttachSelectedVideoAsync(draft.DraftId, CreateDescriptor(cacheKey: "cache-restored-handle"));
+
+        var secondStore = scope.CreateStore();
+        var restoredDraft = await secondStore.GetDraftAsync(draft.DraftId);
+
+        Assert.NotNull(restoredDraft);
+        var attachment = Assert.Single(restoredDraft!.Attachments);
+        Assert.False(attachment.HasLocalReadHandle);
+    }
+
+    [Fact]
     public async Task AttachSelectedVideoAsync_SameCacheKeyTwice_ReturnsAppliedFalseAndKeepsOneAttachment()
     {
-        var store = CreateStore();
+        using var scope = CreateScope();
+        var store = scope.CreateStore();
         var draft = await store.CreateFpvDraftAsync();
         var descriptor = CreateDescriptor(cacheKey: "duplicate-cache-key");
 
@@ -149,7 +246,8 @@ public sealed class InMemoryMobileReportDraftStoreTests
     [Fact]
     public async Task AttachSelectedVideoAsync_SameFileNameAndContentTypeTwice_ReturnsAppliedFalseAndKeepsOneAttachment()
     {
-        var store = CreateStore();
+        using var scope = CreateScope();
+        var store = scope.CreateStore();
         var draft = await store.CreateFpvDraftAsync();
 
         var firstResult = await store.AttachSelectedVideoAsync(
@@ -166,9 +264,29 @@ public sealed class InMemoryMobileReportDraftStoreTests
     }
 
     [Fact]
+    public async Task DuplicateAttachmentGuard_StillWorksAfterRestore()
+    {
+        using var scope = CreateScope();
+
+        var firstStore = scope.CreateStore();
+        var draft = await firstStore.CreateFpvDraftAsync();
+        await firstStore.AttachSelectedVideoAsync(draft.DraftId, CreateDescriptor(cacheKey: "cache-guard", fileName: "guard.mp4"));
+
+        var secondStore = scope.CreateStore();
+        var result = await secondStore.AttachSelectedVideoAsync(
+            draft.DraftId,
+            CreateDescriptor(cacheKey: "cache-guard", fileName: "guard.mp4"));
+
+        Assert.False(result.Applied);
+        Assert.NotNull(result.Draft);
+        Assert.Single(result.Draft!.Attachments);
+    }
+
+    [Fact]
     public async Task AttachSelectedVideoAsync_DifferentVideo_Succeeds()
     {
-        var store = CreateStore();
+        using var scope = CreateScope();
+        var store = scope.CreateStore();
         var draft = await store.CreateFpvDraftAsync();
 
         var firstResult = await store.AttachSelectedVideoAsync(
@@ -187,7 +305,8 @@ public sealed class InMemoryMobileReportDraftStoreTests
     [Fact]
     public async Task MarkDraftQueuedLocalAsync_SetsStatusQueuedLocal()
     {
-        var store = CreateStore();
+        using var scope = CreateScope();
+        var store = scope.CreateStore();
         var draft = await store.CreateFpvDraftAsync();
 
         var result = await store.MarkDraftQueuedLocalAsync(draft.DraftId);
@@ -198,9 +317,27 @@ public sealed class InMemoryMobileReportDraftStoreTests
     }
 
     [Fact]
+    public async Task MarkDraftQueuedLocalAsync_StatusPersistsAndLoadsInNewStoreInstance()
+    {
+        using var scope = CreateScope();
+
+        var firstStore = scope.CreateStore();
+        var draft = await firstStore.CreateFpvDraftAsync();
+        await firstStore.MarkDraftQueuedLocalAsync(draft.DraftId);
+
+        var secondStore = scope.CreateStore();
+        var restoredDraft = await secondStore.GetDraftAsync(draft.DraftId);
+
+        Assert.NotNull(restoredDraft);
+        Assert.Equal(global::App.Mobile.Android.Reports.MobileReportDraftStatus.QueuedLocal, restoredDraft!.Status);
+        Assert.True(restoredDraft.IsRestoredFromSnapshot);
+    }
+
+    [Fact]
     public async Task AttachSelectedVideoAsync_DoesNotRequireBackendFieldsOrBusinessObjectKey()
     {
-        var store = CreateStore();
+        using var scope = CreateScope();
+        var store = scope.CreateStore();
         var draft = await store.CreateFpvDraftAsync();
 
         var result = await store.AttachSelectedVideoAsync(draft.DraftId, CreateDescriptor());
@@ -212,40 +349,26 @@ public sealed class InMemoryMobileReportDraftStoreTests
     }
 
     [Fact]
-    public async Task UpdateFieldValueAsync_UpdatesExistingField()
-    {
-        var store = CreateStore();
-        var draft = await store.CreateFpvDraftAsync();
-
-        var result = await store.UpdateFieldValueAsync(draft.DraftId, "serial_number", "SN-001");
-
-        Assert.True(result.Applied);
-        Assert.NotNull(result.Draft);
-        var field = Assert.Single(result.Draft!.Fields, item => item.FieldKey == "serial_number");
-        Assert.Equal("SN-001", field.ValueText);
-        Assert.False(field.IsPlaceholder);
-        Assert.NotNull(field.LastUpdatedAtUtc);
-    }
-
-    [Fact]
     public async Task UpdateFieldValueAsync_CanFillRequiredFields()
     {
-        var store = CreateStore();
+        using var scope = CreateScope();
+        var store = scope.CreateStore();
         var draft = await store.CreateFpvDraftAsync();
 
-        var result = await store.UpdateFieldValueAsync(draft.DraftId, "device_type", "Заглушка — значение 1");
+        var result = await store.UpdateFieldValueAsync(draft.DraftId, "device_type", "Stub value 1");
 
         Assert.True(result.Applied);
         Assert.NotNull(result.Draft);
         var field = Assert.Single(result.Draft!.Fields, item => item.FieldKey == "device_type");
         Assert.False(field.IsPlaceholder);
-        Assert.Equal("Заглушка — значение 1", field.ValueText);
+        Assert.Equal("Stub value 1", field.ValueText);
     }
 
     [Fact]
     public async Task UpdateFieldValueAsync_MissingDraft_ReturnsAppliedFalse()
     {
-        var store = CreateStore();
+        using var scope = CreateScope();
+        var store = scope.CreateStore();
 
         var result = await store.UpdateFieldValueAsync("missing-draft", "serial_number", "SN-001");
 
@@ -257,7 +380,8 @@ public sealed class InMemoryMobileReportDraftStoreTests
     [Fact]
     public async Task UpdateFieldValueAsync_MissingField_ReturnsAppliedFalse()
     {
-        var store = CreateStore();
+        using var scope = CreateScope();
+        var store = scope.CreateStore();
         var draft = await store.CreateFpvDraftAsync();
 
         var result = await store.UpdateFieldValueAsync(draft.DraftId, "missing-field", "value");
@@ -270,11 +394,12 @@ public sealed class InMemoryMobileReportDraftStoreTests
     [Fact]
     public async Task UpdatingRequiredFields_DoesNotRemoveAttachments()
     {
-        var store = CreateStore();
+        using var scope = CreateScope();
+        var store = scope.CreateStore();
         var draft = await store.CreateFpvDraftAsync();
         var attachResult = await store.AttachSelectedVideoAsync(draft.DraftId, CreateDescriptor());
 
-        var updateResult = await store.UpdateFieldValueAsync(draft.DraftId, "device_type", "Заглушка — значение 1");
+        var updateResult = await store.UpdateFieldValueAsync(draft.DraftId, "device_type", "Stub value 1");
 
         Assert.True(attachResult.Applied);
         Assert.True(updateResult.Applied);
@@ -283,24 +408,43 @@ public sealed class InMemoryMobileReportDraftStoreTests
     }
 
     [Fact]
-    public async Task MarkDraftQueuedLocal_StillWorksAfterValidationStyleFieldUpdate()
+    public async Task QueueValidationWorkflow_StillWorksAfterRestore()
     {
-        var store = CreateStore();
-        var draft = await store.CreateFpvDraftAsync();
+        using var scope = CreateScope();
+        var validationService = new global::App.Mobile.Android.Services.Local.LocalMobileReportDraftValidationService();
 
-        var updateResult = await store.UpdateFieldValueAsync(draft.DraftId, "reason", "Заглушка — значение 2");
-        var queueResult = await store.MarkDraftQueuedLocalAsync(draft.DraftId);
+        var firstStore = scope.CreateStore();
+        var draft = await firstStore.CreateFpvDraftAsync();
+        await FillRequiredFieldsAsync(firstStore, draft.DraftId);
+        await firstStore.AttachSelectedVideoAsync(draft.DraftId, CreateDescriptor(cacheKey: "cache-workflow", fileName: "workflow.mp4"));
 
-        Assert.True(updateResult.Applied);
+        var secondStore = scope.CreateStore();
+        var restoredDraft = await secondStore.GetDraftAsync(draft.DraftId);
+        var validationResult = validationService.ValidateForLocalQueue(restoredDraft);
+        var queueResult = await secondStore.MarkDraftQueuedLocalAsync(draft.DraftId);
+
+        Assert.NotNull(restoredDraft);
+        Assert.True(validationResult.IsValidForLocalQueue);
         Assert.True(queueResult.Applied);
-        Assert.NotNull(queueResult.Draft);
         Assert.Equal(global::App.Mobile.Android.Reports.MobileReportDraftStatus.QueuedLocal, queueResult.Draft!.Status);
     }
 
-    private static global::App.Mobile.Android.Services.Local.InMemoryMobileReportDraftStore CreateStore()
+    private static async Task FillRequiredFieldsAsync(
+        global::App.Mobile.Android.Services.Local.InMemoryMobileReportDraftStore store,
+        string draftId)
     {
-        return new global::App.Mobile.Android.Services.Local.InMemoryMobileReportDraftStore(
-            new global::App.Mobile.Android.Services.Stubs.StubMobileReportLookupProvider());
+        await store.UpdateFieldValueAsync(draftId, "device_type", "Stub value 1");
+        await store.UpdateFieldValueAsync(draftId, "serial_number", "SN-001");
+        await store.UpdateFieldValueAsync(draftId, "delivery_start", "22.04.2026 10:00");
+        await store.UpdateFieldValueAsync(draftId, "delivery_time", "15");
+        await store.UpdateFieldValueAsync(draftId, "distance", "1200");
+        await store.UpdateFieldValueAsync(draftId, "target_type", "Stub value 2");
+        await store.UpdateFieldValueAsync(draftId, "reason", "Stub value 3");
+    }
+
+    private static TestScope CreateScope()
+    {
+        return new TestScope();
     }
 
     private static global::App.Mobile.Android.Media.LocalSelectedMediaDescriptor CreateDescriptor(
@@ -315,5 +459,31 @@ public sealed class InMemoryMobileReportDraftStoreTests
             ContentType: contentType,
             SelectedAtUtc: DateTimeOffset.UtcNow,
             HasLocalReadHandle: true);
+    }
+    private sealed class TestScope : IDisposable
+    {
+        private readonly string _storageDirectory = Path.Combine(
+            Path.GetTempPath(),
+            $"androida-mobile-report-store-{Guid.NewGuid():N}");
+
+        public TestScope()
+        {
+            Directory.CreateDirectory(_storageDirectory);
+        }
+
+        public global::App.Mobile.Android.Services.Local.InMemoryMobileReportDraftStore CreateStore()
+        {
+            return new global::App.Mobile.Android.Services.Local.InMemoryMobileReportDraftStore(
+                new global::App.Mobile.Android.Services.Stubs.StubMobileReportLookupProvider(),
+                new global::App.Mobile.Android.Services.Local.FileMobileReportDraftSnapshotStore(_storageDirectory));
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(_storageDirectory))
+            {
+                Directory.Delete(_storageDirectory, recursive: true);
+            }
+        }
     }
 }

--- a/tests/Unit/App.Mobile.Android.Foundation.Tests/LocalMobileReportDraftValidationServiceTests.cs
+++ b/tests/Unit/App.Mobile.Android.Foundation.Tests/LocalMobileReportDraftValidationServiceTests.cs
@@ -56,6 +56,33 @@ public sealed class LocalMobileReportDraftValidationServiceTests
     }
 
     [Fact]
+    public void ValidateForLocalQueue_RestoredDraftWithRequiredFieldsAndVideoAttachmentMetadata_IsValidForLocalQueue()
+    {
+        var service = new global::App.Mobile.Android.Services.Local.LocalMobileReportDraftValidationService();
+
+        var result = service.ValidateForLocalQueue(
+            CreateDraft(fillRequiredFields: true, includeVideoAttachment: true, restoredAttachmentMetadataOnly: true));
+
+        Assert.True(result.IsValidForLocalQueue);
+        Assert.Empty(result.Issues);
+        Assert.Contains("локаль", result.SummaryText, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ValidateForLocalQueue_RestoredDraftWithoutVideoAttachment_RemainsInvalid()
+    {
+        var service = new global::App.Mobile.Android.Services.Local.LocalMobileReportDraftValidationService();
+
+        var result = service.ValidateForLocalQueue(
+            CreateDraft(fillRequiredFields: true, includeVideoAttachment: false, restoredAttachmentMetadataOnly: true));
+
+        Assert.False(result.IsValidForLocalQueue);
+        Assert.Contains(
+            result.Issues,
+            issue => issue.Message.Contains("видео", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
     public void ValidateForLocalQueue_OptionalFieldsMissing_DoNotBlockLocalQueue()
     {
         var service = new global::App.Mobile.Android.Services.Local.LocalMobileReportDraftValidationService();
@@ -98,7 +125,8 @@ public sealed class LocalMobileReportDraftValidationServiceTests
 
     private static global::App.Mobile.Android.Reports.MobileReportDraft CreateDraft(
         bool fillRequiredFields,
-        bool includeVideoAttachment)
+        bool includeVideoAttachment,
+        bool restoredAttachmentMetadataOnly = false)
     {
         var now = new DateTimeOffset(2026, 4, 22, 8, 0, 0, TimeSpan.Zero);
         var fields = CreateFields(fillRequiredFields);
@@ -114,7 +142,7 @@ public sealed class LocalMobileReportDraftValidationServiceTests
                     SourceText: "Галерея",
                     AddedAtUtc: now,
                     SelectedMediaCacheKey: "cache-1",
-                    HasLocalReadHandle: true)
+                    HasLocalReadHandle: !restoredAttachmentMetadataOnly)
             }
             : Array.Empty<global::App.Mobile.Android.Reports.MobileReportAttachment>();
 
@@ -125,7 +153,10 @@ public sealed class LocalMobileReportDraftValidationServiceTests
             Title: "FPV-отчет #1",
             Status: global::App.Mobile.Android.Reports.MobileReportDraftStatus.ReadyForAttachmentReview,
             Fields: fields,
-            Attachments: attachments);
+            Attachments: attachments)
+        {
+            IsRestoredFromSnapshot = restoredAttachmentMetadataOnly
+        };
     }
 
     private static global::App.Mobile.Android.Reports.MobileReportDraftFieldValue[] CreateFields(bool fillRequiredFields)


### PR DESCRIPTION
﻿Base main SHA:
b9fc98b

Coordination log entries reviewed:
- TEAM COORDINATION LOG #89 latest entries reviewed through 2026-04-26, including desktop merge entries and Android coordination context.
- Android businessObjectKey decision comment: https://github.com/uVormik/AnalyticsAutomation-Core/issues/89#issuecomment-4321720298

Handoff/task cards reviewed:
- docs/reports/coder3-android-backend-readiness.md
- docs/task-cards/MOB-CANON-BACKEND-00.txt
- docs/task-cards/MOB-CANON-BACKEND-01.txt
- docs/handoffs/MOB-CANON-BACKEND-01_ANDROID_BUSINESS_OBJECT_BINDING_BLOCKER.md
- docs/task-cards/MOB-CANON-REPORT-00-03.txt
- docs/task-cards/MOB-CANON-REPORT-04.txt
- docs/task-cards/MOB-CANON-REPORT-05.txt
- docs/task-cards/MOB-CANON-REPORT-06.txt

Purpose:
Persist local FPV report drafts as Android JSON metadata snapshots after local validation/gating is in main.

Module:
App.Mobile.Android / mobile unit tests / mobile docs.

Contracts:
Shared DTO/contracts unchanged.

Migration:
None.

Feature flags:
Local mobile stub flags only.

Offline behavior:
Local JSON metadata snapshots only. No backend save, no sync, no upload. No media byte persistence.

Manual check:
Physical Android runtime check passed:
- local drafts survive full app restart
- edited fields survive full app restart
- attachment metadata survives full app restart
- restored attachments are metadata-only
- validation still works after restore
- local report queue action still works after restore
- no fake businessObjectKey is shown
- production PreUploadCheck remains blocked

Tests:
dotnet test .\tests\Unit\App.Mobile.Android.Foundation.Tests\App.Mobile.Android.Foundation.Tests.csproj -c Debug
Result: passed, 109/109.

Build:
dotnet build .\src\App.Mobile.Android\App.Mobile.Android.csproj -f net10.0-android -m:1
Result: success, warnings only.

Format:
dotnet format whitespace .\AnalyticsAutomation-Core.sln --verify-no-changes --no-restore
Result: success.

git diff --check:
Result: passed.

Rollback:
Revert this PR / remove local report draft snapshot persistence.

Out of scope:
- no backend integration
- no App.Api changes
- no Modules changes
- no BuildingBlocks.Contracts changes
- no shared DTO/contracts changes
- no App.UI.Shared changes
- no auth/session/device binding
- no create-report API
- no businessObjectKey invention
- no backend validation rules
- no PreUploadCheck runtime
- no UploadReceipt runtime
- no direct upload runtime
- no production reports engine
- no desktop implementation
- no media byte persistence
- no file copy
