### PR TITLE
S2-50 desktop auth session boundary runtime

### DIFF
--- a/src/App.Desktop/Boundaries/DesktopAuthClientBoundary.cs
+++ b/src/App.Desktop/Boundaries/DesktopAuthClientBoundary.cs
@@ -1,0 +1,104 @@
+namespace App.Desktop.Boundaries;
+
+public interface IDesktopAuthClient
+{
+    ValueTask<DesktopAuthResult> SignInAsync(
+        DesktopSignInRequest request,
+        CancellationToken cancellationToken);
+}
+
+public sealed class DesktopSignInRequest
+{
+    public DesktopSignInRequest(
+        string login,
+        string password,
+        Guid? deviceId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(login);
+        ArgumentException.ThrowIfNullOrWhiteSpace(password);
+
+        Login = login.Trim();
+        Password = password;
+        DeviceId = deviceId;
+    }
+
+    public string Login { get; }
+
+    public string Password { get; }
+
+    public Guid? DeviceId { get; }
+
+    public override string ToString()
+    {
+        return $"{nameof(DesktopSignInRequest)} {{ HasLogin = True, HasPassword = True, DeviceId = {DeviceId} }}";
+    }
+}
+
+public sealed class DesktopAuthResult
+{
+    private DesktopAuthResult(
+        DesktopAuthStatus status,
+        DesktopAuthenticatedSession? session,
+        DesktopAuthError? error)
+    {
+        Status = status;
+        Session = session;
+        Error = error;
+    }
+
+    public DesktopAuthStatus Status { get; }
+
+    public DesktopAuthenticatedSession? Session { get; }
+
+    public DesktopAuthError? Error { get; }
+
+    public bool IsSuccess => Status == DesktopAuthStatus.Succeeded;
+
+    public static DesktopAuthResult Succeeded(DesktopAuthenticatedSession session)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+
+        return new DesktopAuthResult(DesktopAuthStatus.Succeeded, session, error: null);
+    }
+
+    public static DesktopAuthResult Rejected(string code, string message)
+    {
+        return new DesktopAuthResult(
+            DesktopAuthStatus.Rejected,
+            session: null,
+            new DesktopAuthError(code, message));
+    }
+
+    public static DesktopAuthResult Failed(string code, string message)
+    {
+        return new DesktopAuthResult(
+            DesktopAuthStatus.Failed,
+            session: null,
+            new DesktopAuthError(code, message));
+    }
+
+    public static DesktopAuthResult Unavailable(string code, string message)
+    {
+        return new DesktopAuthResult(
+            DesktopAuthStatus.Unavailable,
+            session: null,
+            new DesktopAuthError(code, message));
+    }
+
+    public override string ToString()
+    {
+        return $"{nameof(DesktopAuthResult)} {{ Status = {Status}, HasSession = {Session is not null}, Error = {Error} }}";
+    }
+}
+
+public sealed record DesktopAuthError(
+    string Code,
+    string Message);
+
+public enum DesktopAuthStatus
+{
+    Succeeded,
+    Rejected,
+    Failed,
+    Unavailable
+}

--- a/src/App.Desktop/Boundaries/DesktopAuthClientBoundary.cs
+++ b/src/App.Desktop/Boundaries/DesktopAuthClientBoundary.cs
@@ -30,7 +30,8 @@ public sealed class DesktopSignInRequest
 
     public override string ToString()
     {
-        return $"{nameof(DesktopSignInRequest)} {{ HasLogin = True, HasPassword = True, DeviceId = {DeviceId} }}";
+        return $"{nameof(DesktopSignInRequest)} {{ HasLogin = True, HasPassword = True, "
+            + $"DeviceId = {DeviceId} }}";
     }
 }
 

--- a/src/App.Desktop/Boundaries/DesktopSessionBoundary.cs
+++ b/src/App.Desktop/Boundaries/DesktopSessionBoundary.cs
@@ -57,7 +57,9 @@ public sealed record DesktopSessionSnapshot(
 
     public override string ToString()
     {
-        return $"{nameof(DesktopSessionSnapshot)} {{ Status = {Status}, UserId = {UserId}, DisplayName = {DisplayName}, HasAccessToken = {HasAccessToken}, HasRefreshToken = {HasRefreshToken}, ExpiresAtUtc = {ExpiresAtUtc:O} }}";
+        return $"{nameof(DesktopSessionSnapshot)} {{ Status = {Status}, UserId = {UserId}, "
+            + $"DisplayName = {DisplayName}, HasAccessToken = {HasAccessToken}, "
+            + $"HasRefreshToken = {HasRefreshToken}, ExpiresAtUtc = {ExpiresAtUtc:O} }}";
     }
 }
 

--- a/src/App.Desktop/Boundaries/DesktopSessionBoundary.cs
+++ b/src/App.Desktop/Boundaries/DesktopSessionBoundary.cs
@@ -1,0 +1,273 @@
+namespace App.Desktop.Boundaries;
+
+public interface IDesktopSessionState
+{
+    DesktopSessionSnapshot Current { get; }
+
+    ValueTask<DesktopSessionSnapshot> LoadAsync(CancellationToken cancellationToken);
+
+    ValueTask<DesktopSessionSnapshot> SetSignedInAsync(
+        DesktopAuthenticatedSession session,
+        CancellationToken cancellationToken);
+
+    ValueTask<DesktopSessionSnapshot> SignOutAsync(CancellationToken cancellationToken);
+}
+
+public interface IDesktopSessionStore
+{
+    ValueTask<DesktopStoredSession?> LoadAsync(CancellationToken cancellationToken);
+
+    ValueTask<DesktopSessionStoreResult> SaveAsync(
+        DesktopStoredSession session,
+        CancellationToken cancellationToken);
+
+    ValueTask<DesktopSessionStoreResult> ClearAsync(CancellationToken cancellationToken);
+}
+
+public sealed record DesktopSessionSnapshot(
+    DesktopSessionStatus Status,
+    Guid? UserId,
+    string? DisplayName,
+    bool HasAccessToken,
+    bool HasRefreshToken,
+    DateTimeOffset? ExpiresAtUtc)
+{
+    public static DesktopSessionSnapshot SignedOut { get; } = new(
+        DesktopSessionStatus.SignedOut,
+        UserId: null,
+        DisplayName: null,
+        HasAccessToken: false,
+        HasRefreshToken: false,
+        ExpiresAtUtc: null);
+
+    public bool IsSignedIn => Status == DesktopSessionStatus.SignedIn;
+
+    public static DesktopSessionSnapshot FromSession(DesktopAuthenticatedSession session)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+
+        return new DesktopSessionSnapshot(
+            DesktopSessionStatus.SignedIn,
+            session.UserId,
+            session.DisplayName,
+            HasAccessToken: true,
+            HasRefreshToken: !string.IsNullOrWhiteSpace(session.RefreshToken),
+            session.ExpiresAtUtc);
+    }
+
+    public override string ToString()
+    {
+        return $"{nameof(DesktopSessionSnapshot)} {{ Status = {Status}, UserId = {UserId}, DisplayName = {DisplayName}, HasAccessToken = {HasAccessToken}, HasRefreshToken = {HasRefreshToken}, ExpiresAtUtc = {ExpiresAtUtc:O} }}";
+    }
+}
+
+public enum DesktopSessionStatus
+{
+    SignedOut,
+    SignedIn
+}
+
+public sealed class DesktopAuthenticatedSession
+{
+    private DesktopAuthenticatedSession(
+        Guid sessionId,
+        Guid userId,
+        Guid? deviceId,
+        string? displayName,
+        string accessToken,
+        string? refreshToken,
+        DateTimeOffset issuedAtUtc,
+        DateTimeOffset expiresAtUtc,
+        bool isOfflineRestricted)
+    {
+        SessionId = sessionId;
+        UserId = userId;
+        DeviceId = deviceId;
+        DisplayName = displayName;
+        AccessToken = accessToken;
+        RefreshToken = refreshToken;
+        IssuedAtUtc = issuedAtUtc;
+        ExpiresAtUtc = expiresAtUtc;
+        IsOfflineRestricted = isOfflineRestricted;
+    }
+
+    public Guid SessionId { get; }
+
+    public Guid UserId { get; }
+
+    public Guid? DeviceId { get; }
+
+    public string? DisplayName { get; }
+
+    public string AccessToken { get; }
+
+    public string? RefreshToken { get; }
+
+    public DateTimeOffset IssuedAtUtc { get; }
+
+    public DateTimeOffset ExpiresAtUtc { get; }
+
+    public bool IsOfflineRestricted { get; }
+
+    public static DesktopAuthenticatedSession Create(
+        Guid sessionId,
+        Guid userId,
+        Guid? deviceId,
+        string? displayName,
+        string accessToken,
+        string? refreshToken,
+        DateTimeOffset issuedAtUtc,
+        DateTimeOffset expiresAtUtc,
+        bool isOfflineRestricted)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(accessToken);
+
+        return new DesktopAuthenticatedSession(
+            sessionId,
+            userId,
+            deviceId,
+            string.IsNullOrWhiteSpace(displayName) ? null : displayName.Trim(),
+            accessToken,
+            string.IsNullOrWhiteSpace(refreshToken) ? null : refreshToken,
+            issuedAtUtc,
+            expiresAtUtc,
+            isOfflineRestricted);
+    }
+
+    public static DesktopAuthenticatedSession FromStoredSession(DesktopStoredSession storedSession)
+    {
+        ArgumentNullException.ThrowIfNull(storedSession);
+
+        return Create(
+            storedSession.SessionId,
+            storedSession.UserId,
+            storedSession.DeviceId,
+            storedSession.DisplayName,
+            storedSession.AccessToken,
+            storedSession.RefreshToken,
+            storedSession.IssuedAtUtc,
+            storedSession.ExpiresAtUtc,
+            storedSession.IsOfflineRestricted);
+    }
+
+    public override string ToString()
+    {
+        return $"{nameof(DesktopAuthenticatedSession)} {{ SessionId = {SessionId}, UserId = {UserId}, DeviceId = {DeviceId}, DisplayName = {DisplayName}, HasAccessToken = True, HasRefreshToken = {!string.IsNullOrWhiteSpace(RefreshToken)}, ExpiresAtUtc = {ExpiresAtUtc:O}, IsOfflineRestricted = {IsOfflineRestricted} }}";
+    }
+}
+
+public sealed class DesktopStoredSession
+{
+    private DesktopStoredSession(
+        Guid sessionId,
+        Guid userId,
+        Guid? deviceId,
+        string? displayName,
+        string accessToken,
+        string? refreshToken,
+        DateTimeOffset issuedAtUtc,
+        DateTimeOffset expiresAtUtc,
+        bool isOfflineRestricted)
+    {
+        SessionId = sessionId;
+        UserId = userId;
+        DeviceId = deviceId;
+        DisplayName = displayName;
+        AccessToken = accessToken;
+        RefreshToken = refreshToken;
+        IssuedAtUtc = issuedAtUtc;
+        ExpiresAtUtc = expiresAtUtc;
+        IsOfflineRestricted = isOfflineRestricted;
+    }
+
+    public Guid SessionId { get; }
+
+    public Guid UserId { get; }
+
+    public Guid? DeviceId { get; }
+
+    public string? DisplayName { get; }
+
+    public string AccessToken { get; }
+
+    public string? RefreshToken { get; }
+
+    public DateTimeOffset IssuedAtUtc { get; }
+
+    public DateTimeOffset ExpiresAtUtc { get; }
+
+    public bool IsOfflineRestricted { get; }
+
+    public static DesktopStoredSession Create(
+        Guid sessionId,
+        Guid userId,
+        Guid? deviceId,
+        string? displayName,
+        string accessToken,
+        string? refreshToken,
+        DateTimeOffset issuedAtUtc,
+        DateTimeOffset expiresAtUtc,
+        bool isOfflineRestricted)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(accessToken);
+
+        return new DesktopStoredSession(
+            sessionId,
+            userId,
+            deviceId,
+            string.IsNullOrWhiteSpace(displayName) ? null : displayName.Trim(),
+            accessToken,
+            string.IsNullOrWhiteSpace(refreshToken) ? null : refreshToken,
+            issuedAtUtc,
+            expiresAtUtc,
+            isOfflineRestricted);
+    }
+
+    public static DesktopStoredSession FromAuthenticatedSession(DesktopAuthenticatedSession session)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+
+        return Create(
+            session.SessionId,
+            session.UserId,
+            session.DeviceId,
+            session.DisplayName,
+            session.AccessToken,
+            session.RefreshToken,
+            session.IssuedAtUtc,
+            session.ExpiresAtUtc,
+            session.IsOfflineRestricted);
+    }
+
+    public override string ToString()
+    {
+        return $"{nameof(DesktopStoredSession)} {{ SessionId = {SessionId}, UserId = {UserId}, DeviceId = {DeviceId}, DisplayName = {DisplayName}, HasAccessToken = True, HasRefreshToken = {!string.IsNullOrWhiteSpace(RefreshToken)}, ExpiresAtUtc = {ExpiresAtUtc:O}, IsOfflineRestricted = {IsOfflineRestricted} }}";
+    }
+}
+
+public sealed record DesktopSessionStoreResult(
+    DesktopSessionStoreStatus Status,
+    string Reason)
+{
+    public static DesktopSessionStoreResult Saved(string reason)
+    {
+        return new DesktopSessionStoreResult(DesktopSessionStoreStatus.Saved, reason);
+    }
+
+    public static DesktopSessionStoreResult Cleared(string reason)
+    {
+        return new DesktopSessionStoreResult(DesktopSessionStoreStatus.Cleared, reason);
+    }
+
+    public static DesktopSessionStoreResult Disabled(string reason)
+    {
+        return new DesktopSessionStoreResult(DesktopSessionStoreStatus.Disabled, reason);
+    }
+}
+
+public enum DesktopSessionStoreStatus
+{
+    Saved,
+    Cleared,
+    Disabled
+}

--- a/src/App.Desktop/Composition/DesktopCompositionRoot.cs
+++ b/src/App.Desktop/Composition/DesktopCompositionRoot.cs
@@ -1,4 +1,5 @@
 using App.Desktop.Boundaries;
+using App.Desktop.Services.Auth;
 using App.Desktop.Services.Placeholders;
 
 using Microsoft.Extensions.DependencyInjection;
@@ -17,7 +18,13 @@ public static class DesktopCompositionRoot
 #endif
 
         services.AddSingleton<IDesktopShellLifecycle, PlaceholderDesktopShellLifecycle>();
-        services.AddSingleton<IDesktopAuthSessionBoundary, PlaceholderDesktopAuthSessionBoundary>();
+        services.AddSingleton<IDesktopSessionStore, DisabledDesktopSessionStore>();
+        services.AddSingleton<DesktopSessionState>();
+        services.AddSingleton<IDesktopSessionState>(
+            serviceProvider => serviceProvider.GetRequiredService<DesktopSessionState>());
+        services.AddSingleton<IDesktopAuthSessionBoundary>(
+            serviceProvider => serviceProvider.GetRequiredService<DesktopSessionState>());
+        services.AddSingleton<IDesktopAuthClient, UnavailableDesktopAuthClient>();
         services.AddSingleton<ISecureSessionStorage, PlaceholderSecureSessionStorage>();
         services.AddSingleton<IDesktopFilePicker, PlaceholderDesktopFilePicker>();
         services.AddSingleton<ILocalFileMetadataService, PlaceholderLocalFileMetadataService>();

--- a/src/App.Desktop/Services/Auth/DesktopSessionState.cs
+++ b/src/App.Desktop/Services/Auth/DesktopSessionState.cs
@@ -35,14 +35,18 @@ public sealed class DesktopSessionState(IDesktopSessionStore sessionStore) :
         ArgumentNullException.ThrowIfNull(session);
         cancellationToken.ThrowIfCancellationRequested();
 
-        _session = session;
-        _current = DesktopSessionSnapshot.FromSession(session);
-
         await sessionStore.SaveAsync(
             DesktopStoredSession.FromAuthenticatedSession(session),
             cancellationToken);
 
-        return _current;
+        cancellationToken.ThrowIfCancellationRequested();
+
+        DesktopSessionSnapshot snapshot = DesktopSessionSnapshot.FromSession(session);
+
+        _session = session;
+        _current = snapshot;
+
+        return snapshot;
     }
 
     public async ValueTask<DesktopSessionSnapshot> SignOutAsync(CancellationToken cancellationToken)

--- a/src/App.Desktop/Services/Auth/DesktopSessionState.cs
+++ b/src/App.Desktop/Services/Auth/DesktopSessionState.cs
@@ -1,0 +1,74 @@
+using App.Desktop.Boundaries;
+
+namespace App.Desktop.Services.Auth;
+
+public sealed class DesktopSessionState(IDesktopSessionStore sessionStore) :
+    IDesktopSessionState,
+    IDesktopAuthSessionBoundary
+{
+    private DesktopSessionSnapshot _current = DesktopSessionSnapshot.SignedOut;
+    private DesktopAuthenticatedSession? _session;
+
+    public DesktopSessionSnapshot Current => _current;
+
+    public async ValueTask<DesktopSessionSnapshot> LoadAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var storedSession = await sessionStore.LoadAsync(cancellationToken);
+        if (storedSession is null)
+        {
+            _session = null;
+            _current = DesktopSessionSnapshot.SignedOut;
+            return _current;
+        }
+
+        _session = DesktopAuthenticatedSession.FromStoredSession(storedSession);
+        _current = DesktopSessionSnapshot.FromSession(_session);
+        return _current;
+    }
+
+    public async ValueTask<DesktopSessionSnapshot> SetSignedInAsync(
+        DesktopAuthenticatedSession session,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        _session = session;
+        _current = DesktopSessionSnapshot.FromSession(session);
+
+        await sessionStore.SaveAsync(
+            DesktopStoredSession.FromAuthenticatedSession(session),
+            cancellationToken);
+
+        return _current;
+    }
+
+    public async ValueTask<DesktopSessionSnapshot> SignOutAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        _session = null;
+        _current = DesktopSessionSnapshot.SignedOut;
+
+        await sessionStore.ClearAsync(cancellationToken);
+
+        return _current;
+    }
+
+    ValueTask<DesktopAuthSessionSnapshot> IDesktopAuthSessionBoundary.GetCurrentSessionAsync(
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return ValueTask.FromResult(new DesktopAuthSessionSnapshot(
+            _current.IsSignedIn,
+            _current.DisplayName));
+    }
+
+    async ValueTask IDesktopAuthSessionBoundary.SignOutAsync(CancellationToken cancellationToken)
+    {
+        await SignOutAsync(cancellationToken);
+    }
+}

--- a/src/App.Desktop/Services/Auth/DisabledDesktopSessionStore.cs
+++ b/src/App.Desktop/Services/Auth/DisabledDesktopSessionStore.cs
@@ -1,0 +1,34 @@
+using App.Desktop.Boundaries;
+
+namespace App.Desktop.Services.Auth;
+
+public sealed class DisabledDesktopSessionStore : IDesktopSessionStore
+{
+    private const string DisabledReason =
+        "Secure desktop token persistence is disabled in S2-50; approved Windows secure storage requires a separate task.";
+
+    public ValueTask<DesktopStoredSession?> LoadAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return ValueTask.FromResult<DesktopStoredSession?>(null);
+    }
+
+    public ValueTask<DesktopSessionStoreResult> SaveAsync(
+        DesktopStoredSession session,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // TODO(S2-50 follow-up): replace only after an approved Windows secure token storage task.
+        return ValueTask.FromResult(DesktopSessionStoreResult.Disabled(DisabledReason));
+    }
+
+    public ValueTask<DesktopSessionStoreResult> ClearAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return ValueTask.FromResult(DesktopSessionStoreResult.Disabled(DisabledReason));
+    }
+}

--- a/src/App.Desktop/Services/Auth/HttpDesktopAuthClient.cs
+++ b/src/App.Desktop/Services/Auth/HttpDesktopAuthClient.cs
@@ -1,0 +1,112 @@
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+using App.Desktop.Boundaries;
+
+namespace App.Desktop.Services.Auth;
+
+public sealed class HttpDesktopAuthClient : IDesktopAuthClient
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly HttpClient _httpClient;
+    private readonly Uri _signInEndpoint;
+
+    public HttpDesktopAuthClient(HttpClient httpClient)
+        : this(httpClient, new Uri("/api/auth/sign-in", UriKind.Relative))
+    {
+    }
+
+    public HttpDesktopAuthClient(HttpClient httpClient, Uri signInEndpoint)
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
+        ArgumentNullException.ThrowIfNull(signInEndpoint);
+
+        _httpClient = httpClient;
+        _signInEndpoint = signInEndpoint;
+    }
+
+    public async ValueTask<DesktopAuthResult> SignInAsync(
+        DesktopSignInRequest request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        using var response = await _httpClient.PostAsJsonAsync(
+            _signInEndpoint,
+            new SignInRequestPayload(request.Login, request.Password, request.DeviceId),
+            JsonOptions,
+            cancellationToken);
+
+        if (response.StatusCode == HttpStatusCode.Unauthorized)
+        {
+            return DesktopAuthResult.Rejected(
+                "invalid_credentials",
+                "Control-plane sign-in rejected the supplied credentials.");
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            return DesktopAuthResult.Failed(
+                "sign_in_http_error",
+                $"Control-plane sign-in failed with HTTP {(int)response.StatusCode}.");
+        }
+
+        var payload = await response.Content.ReadFromJsonAsync<SignInResponsePayload>(
+            JsonOptions,
+            cancellationToken);
+
+        if (payload?.User is null
+            || payload.Session is null
+            || string.IsNullOrWhiteSpace(payload.AccessToken))
+        {
+            return DesktopAuthResult.Failed(
+                "sign_in_invalid_response",
+                "Control-plane sign-in returned an invalid session response.");
+        }
+
+        var displayName = string.IsNullOrWhiteSpace(payload.User.DisplayName)
+            ? payload.User.UserName
+            : payload.User.DisplayName;
+
+        var session = DesktopAuthenticatedSession.Create(
+            payload.Session.SessionId,
+            payload.User.UserId,
+            payload.Session.DeviceId,
+            displayName,
+            payload.AccessToken,
+            payload.RefreshToken,
+            payload.Session.IssuedAtUtc,
+            payload.Session.ExpiresAtUtc,
+            payload.Session.IsOfflineRestricted);
+
+        return DesktopAuthResult.Succeeded(session);
+    }
+
+    private sealed record SignInRequestPayload(
+        string Login,
+        string Password,
+        Guid? DeviceId);
+
+    private sealed record SignInResponsePayload(
+        CurrentUserPayload User,
+        SessionPayload Session,
+        string? AccessToken,
+        string? RefreshToken);
+
+    private sealed record CurrentUserPayload(
+        Guid UserId,
+        string UserName,
+        string DisplayName);
+
+    private sealed record SessionPayload(
+        Guid SessionId,
+        Guid UserId,
+        Guid? DeviceId,
+        bool IsOfflineRestricted,
+        DateTimeOffset IssuedAtUtc,
+        DateTimeOffset ExpiresAtUtc);
+}

--- a/src/App.Desktop/Services/Auth/HttpDesktopAuthClient.cs
+++ b/src/App.Desktop/Services/Auth/HttpDesktopAuthClient.cs
@@ -35,55 +35,90 @@ public sealed class HttpDesktopAuthClient : IDesktopAuthClient
         ArgumentNullException.ThrowIfNull(request);
         cancellationToken.ThrowIfCancellationRequested();
 
-        using var response = await _httpClient.PostAsJsonAsync(
-            _signInEndpoint,
-            new SignInRequestPayload(request.Login, request.Password, request.DeviceId),
-            JsonOptions,
-            cancellationToken);
-
-        if (response.StatusCode == HttpStatusCode.Unauthorized)
+        try
         {
-            return DesktopAuthResult.Rejected(
-                "invalid_credentials",
-                "Control-plane sign-in rejected the supplied credentials.");
-        }
+            using var response = await _httpClient.PostAsJsonAsync(
+                _signInEndpoint,
+                new SignInRequestPayload(request.Login, request.Password, request.DeviceId),
+                JsonOptions,
+                cancellationToken);
 
-        if (!response.IsSuccessStatusCode)
+            if (response.StatusCode == HttpStatusCode.Unauthorized)
+            {
+                return DesktopAuthResult.Rejected(
+                    "invalid_credentials",
+                    "Control-plane sign-in rejected the supplied credentials.");
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                return DesktopAuthResult.Failed(
+                    "sign_in_http_error",
+                    $"Control-plane sign-in failed with HTTP {(int)response.StatusCode}.");
+            }
+
+            SignInResponsePayload? payload = await response.Content.ReadFromJsonAsync<SignInResponsePayload>(
+                JsonOptions,
+                cancellationToken);
+
+            if (payload?.User is null
+                || payload.Session is null
+                || string.IsNullOrWhiteSpace(payload.AccessToken))
+            {
+                return InvalidSessionResponse();
+            }
+
+            string? displayName = string.IsNullOrWhiteSpace(payload.User.DisplayName)
+                ? payload.User.UserName
+                : payload.User.DisplayName;
+
+            DesktopAuthenticatedSession session = DesktopAuthenticatedSession.Create(
+                payload.Session.SessionId,
+                payload.User.UserId,
+                payload.Session.DeviceId,
+                displayName,
+                payload.AccessToken,
+                payload.RefreshToken,
+                payload.Session.IssuedAtUtc,
+                payload.Session.ExpiresAtUtc,
+                payload.Session.IsOfflineRestricted);
+
+            return DesktopAuthResult.Succeeded(session);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
         {
-            return DesktopAuthResult.Failed(
-                "sign_in_http_error",
-                $"Control-plane sign-in failed with HTTP {(int)response.StatusCode}.");
+            return SignInUnavailable();
         }
-
-        var payload = await response.Content.ReadFromJsonAsync<SignInResponsePayload>(
-            JsonOptions,
-            cancellationToken);
-
-        if (payload?.User is null
-            || payload.Session is null
-            || string.IsNullOrWhiteSpace(payload.AccessToken))
+        catch (HttpRequestException)
         {
-            return DesktopAuthResult.Failed(
-                "sign_in_invalid_response",
-                "Control-plane sign-in returned an invalid session response.");
+            return SignInUnavailable();
         }
+        catch (InvalidOperationException)
+        {
+            return SignInUnavailable();
+        }
+        catch (JsonException)
+        {
+            return InvalidSessionResponse();
+        }
+        catch (NotSupportedException)
+        {
+            return InvalidSessionResponse();
+        }
+    }
 
-        var displayName = string.IsNullOrWhiteSpace(payload.User.DisplayName)
-            ? payload.User.UserName
-            : payload.User.DisplayName;
+    private static DesktopAuthResult SignInUnavailable()
+    {
+        return DesktopAuthResult.Unavailable(
+            "sign_in_unavailable",
+            "Control-plane sign-in is temporarily unavailable.");
+    }
 
-        var session = DesktopAuthenticatedSession.Create(
-            payload.Session.SessionId,
-            payload.User.UserId,
-            payload.Session.DeviceId,
-            displayName,
-            payload.AccessToken,
-            payload.RefreshToken,
-            payload.Session.IssuedAtUtc,
-            payload.Session.ExpiresAtUtc,
-            payload.Session.IsOfflineRestricted);
-
-        return DesktopAuthResult.Succeeded(session);
+    private static DesktopAuthResult InvalidSessionResponse()
+    {
+        return DesktopAuthResult.Failed(
+            "sign_in_invalid_response",
+            "Control-plane sign-in returned an invalid session response.");
     }
 
     private sealed record SignInRequestPayload(

--- a/src/App.Desktop/Services/Auth/UnavailableDesktopAuthClient.cs
+++ b/src/App.Desktop/Services/Auth/UnavailableDesktopAuthClient.cs
@@ -1,0 +1,18 @@
+using App.Desktop.Boundaries;
+
+namespace App.Desktop.Services.Auth;
+
+public sealed class UnavailableDesktopAuthClient : IDesktopAuthClient
+{
+    public ValueTask<DesktopAuthResult> SignInAsync(
+        DesktopSignInRequest request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return ValueTask.FromResult(DesktopAuthResult.Unavailable(
+            "desktop_auth_not_configured",
+            "S2-50 registers the desktop auth boundary; control-plane sign-in endpoint configuration is deferred."));
+    }
+}

--- a/src/App.Desktop/Services/Placeholders/PlaceholderSecureSessionStorage.cs
+++ b/src/App.Desktop/Services/Placeholders/PlaceholderSecureSessionStorage.cs
@@ -16,8 +16,8 @@ public sealed class PlaceholderSecureSessionStorage : ISecureSessionStorage
         ArgumentNullException.ThrowIfNull(session);
         cancellationToken.ThrowIfCancellationRequested();
 
-        throw new NotSupportedException(
-            "S2-48 defines the secure storage boundary only; token persistence is deferred.");
+        // TODO(S2-50 follow-up): replace only after an approved Windows secure token storage task.
+        return ValueTask.CompletedTask;
     }
 
     public ValueTask ClearSessionAsync(CancellationToken cancellationToken)

--- a/tests/Unit/App.Desktop.Tests/DesktopAuthClientBoundaryTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopAuthClientBoundaryTests.cs
@@ -1,0 +1,142 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+
+using App.Desktop.Boundaries;
+using App.Desktop.Services.Auth;
+
+namespace App.Desktop.Tests;
+
+public sealed class DesktopAuthClientBoundaryTests
+{
+    [Fact]
+    public async Task UnavailableAuthClientReturnsSafeFailureWithoutCredentialValues()
+    {
+        var client = new UnavailableDesktopAuthClient();
+        var password = CreateSensitiveValue("password");
+        var request = new DesktopSignInRequest("desktop-operator", password, Guid.NewGuid());
+
+        var result = await client.SignInAsync(request, CancellationToken.None);
+
+        Assert.Equal(DesktopAuthStatus.Unavailable, result.Status);
+        Assert.Null(result.Session);
+        Assert.NotNull(result.Error);
+        Assert.DoesNotContain("desktop-operator", result.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(password, result.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("desktop-operator", request.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(password, request.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task HttpAuthClientUsesExistingSignInEndpointAndReturnsSession()
+    {
+        var accessToken = CreateSensitiveValue("access");
+        var refreshToken = CreateSensitiveValue("refresh");
+        var deviceId = Guid.NewGuid();
+        var handler = new StubHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = JsonContent(new
+            {
+                user = new
+                {
+                    userId = Guid.NewGuid(),
+                    userName = "desktop-operator",
+                    displayName = "Desktop Operator"
+                },
+                session = new
+                {
+                    sessionId = Guid.NewGuid(),
+                    userId = Guid.NewGuid(),
+                    deviceId,
+                    isOfflineRestricted = false,
+                    issuedAtUtc = DateTimeOffset.UtcNow,
+                    expiresAtUtc = DateTimeOffset.UtcNow.AddMinutes(15)
+                },
+                accessToken,
+                refreshToken
+            })
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://control-plane.local")
+        };
+        var client = new HttpDesktopAuthClient(httpClient);
+
+        var result = await client.SignInAsync(
+            new DesktopSignInRequest("desktop-operator", CreateSensitiveValue("password"), deviceId),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(DesktopAuthStatus.Succeeded, result.Status);
+        Assert.Equal(accessToken, result.Session!.AccessToken);
+        Assert.Equal(refreshToken, result.Session.RefreshToken);
+        Assert.NotNull(handler.LastRequest);
+        Assert.Equal(HttpMethod.Post, handler.LastRequest.Method);
+        Assert.Equal("/api/auth/sign-in", handler.LastRequest.RequestUri?.AbsolutePath);
+        Assert.DoesNotContain(accessToken, result.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(refreshToken, result.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(accessToken, result.Session.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(refreshToken, result.Session.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task HttpAuthFailureDoesNotExposeCredentialsOrTokenLikeResponseValues()
+    {
+        var password = CreateSensitiveValue("password");
+        var responseToken = CreateSensitiveValue("access");
+        var handler = new StubHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.Unauthorized)
+        {
+            Content = JsonContent(new
+            {
+                password,
+                accessToken = responseToken
+            })
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://control-plane.local")
+        };
+        var client = new HttpDesktopAuthClient(httpClient);
+
+        var result = await client.SignInAsync(
+            new DesktopSignInRequest("desktop-operator", password, Guid.NewGuid()),
+            CancellationToken.None);
+
+        Assert.Equal(DesktopAuthStatus.Rejected, result.Status);
+        Assert.Null(result.Session);
+        Assert.DoesNotContain("desktop-operator", result.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(password, result.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(responseToken, result.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(password, result.Error!.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain(responseToken, result.Error.Message, StringComparison.Ordinal);
+    }
+
+    private static StringContent JsonContent<T>(T value)
+    {
+        return new StringContent(
+            JsonSerializer.Serialize(value),
+            Encoding.UTF8,
+            "application/json");
+    }
+
+    private static string CreateSensitiveValue(string prefix)
+    {
+        return $"{prefix}-{Guid.NewGuid():N}";
+    }
+
+    private sealed class StubHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> responseFactory) :
+        HttpMessageHandler
+    {
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            LastRequest = request;
+            return Task.FromResult(responseFactory(request));
+        }
+    }
+}

--- a/tests/Unit/App.Desktop.Tests/DesktopAuthClientBoundaryTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopAuthClientBoundaryTests.cs
@@ -111,6 +111,119 @@ public sealed class DesktopAuthClientBoundaryTests
         Assert.DoesNotContain(responseToken, result.Error.Message, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public async Task HttpTransportFailureReturnsUnavailableWithoutExposingSecrets()
+    {
+        var login = $"desktop-{Guid.NewGuid():N}";
+        var password = CreateSensitiveValue("password");
+        var tokenLikeValue = CreateSensitiveValue("access");
+        var handler = new StubHttpMessageHandler(_ => throw new HttpRequestException(
+            $"Transport failed for {login} {password} {tokenLikeValue}"));
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://control-plane.local")
+        };
+        var client = new HttpDesktopAuthClient(httpClient);
+
+        var result = await client.SignInAsync(
+            new DesktopSignInRequest(login, password, Guid.NewGuid()),
+            CancellationToken.None);
+
+        Assert.Equal(DesktopAuthStatus.Unavailable, result.Status);
+        Assert.Null(result.Session);
+        Assert.NotNull(result.Error);
+        Assert.DoesNotContain(login, result.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(password, result.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(tokenLikeValue, result.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(login, result.Error.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain(password, result.Error.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain(tokenLikeValue, result.Error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task HttpMalformedJsonReturnsFailedWithoutExposingSecrets()
+    {
+        var login = $"desktop-{Guid.NewGuid():N}";
+        var password = CreateSensitiveValue("password");
+        var tokenLikeValue = CreateSensitiveValue("access");
+        var handler = new StubHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(
+                $"{{\"accessToken\":\"{tokenLikeValue}\",",
+                Encoding.UTF8,
+                "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://control-plane.local")
+        };
+        var client = new HttpDesktopAuthClient(httpClient);
+
+        var result = await client.SignInAsync(
+            new DesktopSignInRequest(login, password, Guid.NewGuid()),
+            CancellationToken.None);
+
+        Assert.Equal(DesktopAuthStatus.Failed, result.Status);
+        Assert.Null(result.Session);
+        Assert.NotNull(result.Error);
+        Assert.DoesNotContain(login, result.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(password, result.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(tokenLikeValue, result.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(login, result.Error.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain(password, result.Error.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain(tokenLikeValue, result.Error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task HttpInvalidSuccessPayloadReturnsFailedWithoutExposingSecrets()
+    {
+        var login = $"desktop-{Guid.NewGuid():N}";
+        var password = CreateSensitiveValue("password");
+        var tokenLikeValue = CreateSensitiveValue("refresh");
+        var handler = new StubHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = JsonContent(new
+            {
+                user = new
+                {
+                    userId = Guid.NewGuid(),
+                    userName = login,
+                    displayName = "Desktop Operator"
+                },
+                session = new
+                {
+                    sessionId = Guid.NewGuid(),
+                    userId = Guid.NewGuid(),
+                    deviceId = Guid.NewGuid(),
+                    isOfflineRestricted = false,
+                    issuedAtUtc = DateTimeOffset.UtcNow,
+                    expiresAtUtc = DateTimeOffset.UtcNow.AddMinutes(15)
+                },
+                accessToken = "",
+                refreshToken = tokenLikeValue
+            })
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://control-plane.local")
+        };
+        var client = new HttpDesktopAuthClient(httpClient);
+
+        var result = await client.SignInAsync(
+            new DesktopSignInRequest(login, password, Guid.NewGuid()),
+            CancellationToken.None);
+
+        Assert.Equal(DesktopAuthStatus.Failed, result.Status);
+        Assert.Null(result.Session);
+        Assert.NotNull(result.Error);
+        Assert.DoesNotContain(login, result.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(password, result.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(tokenLikeValue, result.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(login, result.Error.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain(password, result.Error.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain(tokenLikeValue, result.Error.Message, StringComparison.Ordinal);
+    }
+
     private static StringContent JsonContent<T>(T value)
     {
         return new StringContent(

--- a/tests/Unit/App.Desktop.Tests/DesktopCompositionRootTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopCompositionRootTests.cs
@@ -1,0 +1,21 @@
+using App.Desktop.Boundaries;
+using App.Desktop.Composition;
+using App.Desktop.Services.Auth;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace App.Desktop.Tests;
+
+public sealed class DesktopCompositionRootTests
+{
+    [Fact]
+    public void BuildServicesResolvesDesktopAuthAndSessionBoundaries()
+    {
+        using var services = DesktopCompositionRoot.BuildServices();
+
+        Assert.IsType<DesktopSessionState>(services.GetRequiredService<IDesktopSessionState>());
+        Assert.IsType<DesktopSessionState>(services.GetRequiredService<IDesktopAuthSessionBoundary>());
+        Assert.IsType<DisabledDesktopSessionStore>(services.GetRequiredService<IDesktopSessionStore>());
+        Assert.IsType<UnavailableDesktopAuthClient>(services.GetRequiredService<IDesktopAuthClient>());
+    }
+}

--- a/tests/Unit/App.Desktop.Tests/DesktopSessionStateTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopSessionStateTests.cs
@@ -44,6 +44,28 @@ public sealed class DesktopSessionStateTests
     }
 
     [Fact]
+    public async Task SetSignedInSessionDoesNotMutateStateWhenStoreSaveThrows()
+    {
+        var store = new ThrowingDesktopSessionStore(new InvalidOperationException("store save failed"));
+        var state = new DesktopSessionState(store);
+        var session = CreateAuthenticatedSession();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await state.SetSignedInAsync(session, CancellationToken.None));
+
+        var boundarySnapshot = await ((IDesktopAuthSessionBoundary)state).GetCurrentSessionAsync(
+            CancellationToken.None);
+
+        Assert.Equal(DesktopSessionStatus.SignedOut, state.Current.Status);
+        Assert.False(state.Current.IsSignedIn);
+        Assert.False(state.Current.HasAccessToken);
+        Assert.False(state.Current.HasRefreshToken);
+        Assert.False(boundarySnapshot.IsAuthenticated);
+        Assert.Null(boundarySnapshot.DisplayName);
+        Assert.Equal(1, store.SaveCount);
+    }
+
+    [Fact]
     public async Task SignOutClearsCurrentSessionAndStoreBoundary()
     {
         var store = new RecordingDesktopSessionStore();
@@ -141,6 +163,36 @@ public sealed class DesktopSessionStateTests
 
             ClearCount++;
             SavedSession = null;
+            return ValueTask.FromResult(DesktopSessionStoreResult.Cleared("cleared by test helper"));
+        }
+    }
+
+    private sealed class ThrowingDesktopSessionStore(Exception exception) : IDesktopSessionStore
+    {
+        public int SaveCount { get; private set; }
+
+        public ValueTask<DesktopStoredSession?> LoadAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            return ValueTask.FromResult<DesktopStoredSession?>(null);
+        }
+
+        public ValueTask<DesktopSessionStoreResult> SaveAsync(
+            DesktopStoredSession session,
+            CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(session);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            SaveCount++;
+            throw exception;
+        }
+
+        public ValueTask<DesktopSessionStoreResult> ClearAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
             return ValueTask.FromResult(DesktopSessionStoreResult.Cleared("cleared by test helper"));
         }
     }

--- a/tests/Unit/App.Desktop.Tests/DesktopSessionStateTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopSessionStateTests.cs
@@ -1,0 +1,147 @@
+using App.Desktop.Boundaries;
+using App.Desktop.Services.Auth;
+
+namespace App.Desktop.Tests;
+
+public sealed class DesktopSessionStateTests
+{
+    [Fact]
+    public async Task SessionStateStartsSignedOut()
+    {
+        var state = new DesktopSessionState(new RecordingDesktopSessionStore());
+
+        Assert.Equal(DesktopSessionStatus.SignedOut, state.Current.Status);
+        Assert.False(state.Current.IsSignedIn);
+        Assert.False(state.Current.HasAccessToken);
+        Assert.False(state.Current.HasRefreshToken);
+
+        var snapshot = await state.LoadAsync(CancellationToken.None);
+
+        Assert.Equal(DesktopSessionStatus.SignedOut, snapshot.Status);
+        Assert.False(snapshot.IsSignedIn);
+        Assert.Null(snapshot.UserId);
+        Assert.Null(snapshot.DisplayName);
+    }
+
+    [Fact]
+    public async Task SetSignedInSessionUpdatesSanitizedSnapshotAndStoresThroughBoundary()
+    {
+        var store = new RecordingDesktopSessionStore();
+        var state = new DesktopSessionState(store);
+        var session = CreateAuthenticatedSession();
+
+        var snapshot = await state.SetSignedInAsync(session, CancellationToken.None);
+
+        Assert.Equal(DesktopSessionStatus.SignedIn, snapshot.Status);
+        Assert.True(snapshot.IsSignedIn);
+        Assert.Equal(session.UserId, snapshot.UserId);
+        Assert.Equal(session.DisplayName, snapshot.DisplayName);
+        Assert.True(snapshot.HasAccessToken);
+        Assert.True(snapshot.HasRefreshToken);
+        Assert.Equal(session.ExpiresAtUtc, snapshot.ExpiresAtUtc);
+        Assert.NotNull(store.SavedSession);
+        Assert.Equal(session.AccessToken, store.SavedSession.AccessToken);
+    }
+
+    [Fact]
+    public async Task SignOutClearsCurrentSessionAndStoreBoundary()
+    {
+        var store = new RecordingDesktopSessionStore();
+        var state = new DesktopSessionState(store);
+
+        await state.SetSignedInAsync(CreateAuthenticatedSession(), CancellationToken.None);
+        var snapshot = await state.SignOutAsync(CancellationToken.None);
+
+        Assert.Equal(DesktopSessionStatus.SignedOut, snapshot.Status);
+        Assert.False(snapshot.IsSignedIn);
+        Assert.False(snapshot.HasAccessToken);
+        Assert.False(snapshot.HasRefreshToken);
+        Assert.Null(snapshot.UserId);
+        Assert.Equal(1, store.ClearCount);
+        Assert.Same(snapshot, state.Current);
+    }
+
+    [Fact]
+    public async Task LegacyAuthSessionBoundaryUsesSanitizedSessionState()
+    {
+        var state = new DesktopSessionState(new RecordingDesktopSessionStore());
+        var boundary = (IDesktopAuthSessionBoundary)state;
+
+        await state.SetSignedInAsync(CreateAuthenticatedSession(), CancellationToken.None);
+
+        var snapshot = await boundary.GetCurrentSessionAsync(CancellationToken.None);
+
+        Assert.True(snapshot.IsAuthenticated);
+        Assert.Equal("Desktop Operator", snapshot.DisplayName);
+    }
+
+    [Fact]
+    public async Task SessionDiagnosticsDoNotIncludeTokenValues()
+    {
+        var store = new RecordingDesktopSessionStore();
+        var state = new DesktopSessionState(store);
+        var session = CreateAuthenticatedSession();
+
+        var snapshot = await state.SetSignedInAsync(session, CancellationToken.None);
+
+        Assert.DoesNotContain(session.AccessToken, snapshot.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(session.RefreshToken!, snapshot.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(session.AccessToken, session.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(session.RefreshToken!, session.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(session.AccessToken, store.SavedSession!.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(session.RefreshToken!, store.SavedSession.ToString(), StringComparison.Ordinal);
+    }
+
+    private static DesktopAuthenticatedSession CreateAuthenticatedSession()
+    {
+        return DesktopAuthenticatedSession.Create(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            "Desktop Operator",
+            CreateSensitiveValue("access"),
+            CreateSensitiveValue("refresh"),
+            DateTimeOffset.UtcNow,
+            DateTimeOffset.UtcNow.AddMinutes(15),
+            isOfflineRestricted: false);
+    }
+
+    private static string CreateSensitiveValue(string prefix)
+    {
+        return $"{prefix}-{Guid.NewGuid():N}";
+    }
+
+    private sealed class RecordingDesktopSessionStore : IDesktopSessionStore
+    {
+        public DesktopStoredSession? SavedSession { get; private set; }
+
+        public int ClearCount { get; private set; }
+
+        public ValueTask<DesktopStoredSession?> LoadAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            return ValueTask.FromResult<DesktopStoredSession?>(null);
+        }
+
+        public ValueTask<DesktopSessionStoreResult> SaveAsync(
+            DesktopStoredSession session,
+            CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(session);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            SavedSession = session;
+            return ValueTask.FromResult(DesktopSessionStoreResult.Saved("recorded by test helper"));
+        }
+
+        public ValueTask<DesktopSessionStoreResult> ClearAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            ClearCount++;
+            SavedSession = null;
+            return ValueTask.FromResult(DesktopSessionStoreResult.Cleared("cleared by test helper"));
+        }
+    }
+}

--- a/tests/Unit/App.Desktop.Tests/DisabledDesktopSessionStoreTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DisabledDesktopSessionStoreTests.cs
@@ -1,0 +1,68 @@
+using App.Desktop.Boundaries;
+using App.Desktop.Services.Auth;
+
+namespace App.Desktop.Tests;
+
+public sealed class DisabledDesktopSessionStoreTests
+{
+    [Fact]
+    public async Task LoadSaveAndClearAreExplicitlyDisabledAndSafe()
+    {
+        var store = new DisabledDesktopSessionStore();
+        var storedSession = CreateStoredSession();
+
+        var loaded = await store.LoadAsync(CancellationToken.None);
+        var saveResult = await store.SaveAsync(storedSession, CancellationToken.None);
+        var clearResult = await store.ClearAsync(CancellationToken.None);
+
+        Assert.Null(loaded);
+        Assert.Equal(DesktopSessionStoreStatus.Disabled, saveResult.Status);
+        Assert.Equal(DesktopSessionStoreStatus.Disabled, clearResult.Status);
+        Assert.Contains("disabled", saveResult.Reason, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("secure", saveResult.Reason, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(storedSession.AccessToken, saveResult.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(storedSession.RefreshToken!, saveResult.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task DisabledStoreDoesNotCreatePlaintextPersistenceFiles()
+    {
+        var tempDirectory = Directory.CreateTempSubdirectory("aa-desktop-session-store-");
+
+        try
+        {
+            var store = new DisabledDesktopSessionStore();
+
+            _ = await store.SaveAsync(CreateStoredSession(), CancellationToken.None);
+            _ = await store.ClearAsync(CancellationToken.None);
+
+            Assert.Empty(Directory.EnumerateFileSystemEntries(
+                tempDirectory.FullName,
+                "*",
+                SearchOption.AllDirectories));
+        }
+        finally
+        {
+            tempDirectory.Delete(recursive: true);
+        }
+    }
+
+    private static DesktopStoredSession CreateStoredSession()
+    {
+        return DesktopStoredSession.Create(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            "Desktop Operator",
+            CreateSensitiveValue("access"),
+            CreateSensitiveValue("refresh"),
+            DateTimeOffset.UtcNow,
+            DateTimeOffset.UtcNow.AddMinutes(15),
+            isOfflineRestricted: false);
+    }
+
+    private static string CreateSensitiveValue(string prefix)
+    {
+        return $"{prefix}-{Guid.NewGuid():N}";
+    }
+}


### PR DESCRIPTION
﻿Coder: Coder 1 acting as Coder 2 / Desktop Client

Task ID: S2-50 Runtime: Desktop Auth/Session Boundary Implementation

Module: App.Desktop / Auth and session boundary

Scope:
- Implemented the first narrow desktop auth/session boundary slice only.
- Added desktop session state model, disabled secure session store boundary, auth client boundary, and focused tests.
- Kept UI unchanged; no full SignIn UI and no upload flow.

Changed areas:
- src/App.Desktop/**
- tests/Unit/App.Desktop.Tests/**

Base main SHA: aae939268279fb0086e3634f5623ba4814de852e

Coordination log entries reviewed:
- Issue #89 TEAM COORDINATION LOG
- PR #101 Desktop client form architecture update
- PR #102 S2-45 Replace stale S2-18 Web prompt with desktop-client prompt
- PR #103 S2-46 Desktop UI Technology Decision Task
- PR #104 S2-47 Desktop UI Technology Owner Decision
- PR #105 S2-48 Desktop Application Skeleton Task Card
- PR #107 S2-48 Desktop Application Skeleton
- PR #110 S2-49A Desktop Skeleton Launch Fix
- PR #114 S2-50 Desktop Auth Session Boundary Task Card
- Manual coordination replay for PR #113 REPORT-06

Handoff/task cards reviewed:
- 00_START_HERE_README.txt
- 01_MASTER_PLAN_AND_ARCHITECTURE.txt
- 02_SHARED_RULES_AND_PROTOCOLS.txt
- 04_GITHUB_WORKFLOW_AND_INFRA_RULES.txt
- docs/task-cards/S2-48_desktop-application-skeleton-task-card.txt
- docs/handoffs/S2_48_DESKTOP_APPLICATION_SKELETON_PROMPT.md
- docs/task-cards/S2-49A_desktop-skeleton-launch-fix.txt
- docs/task-cards/S2-50_desktop-auth-session-boundary-task-card.txt
- docs/handoffs/S2_50_DESKTOP_AUTH_SESSION_BOUNDARY_PROMPT.md
- src/App.Desktop/**
- tests/Unit/App.Desktop.Tests/**

Contracts:
- No shared DTO/contracts changes.
- Desktop HTTP auth client boundary is aligned to existing POST /api/auth/sign-in shape read from App.Api and BuildingBlocks.Contracts.Auth.
- No refresh-token behavior implemented.

Migrations: None.

Feature flags: None.

API impact:
- No App.Api changes.
- No API route changes.
- App.Api remains control plane.

Web impact:
- No App.Web changes.
- App.Web is not used as a desktop auth surface.

Android impact:
- No App.Mobile.Android changes.

Offline behavior:
- No offline queue or offline auth behavior implemented.
- Snapshot exposes only safe metadata and token availability booleans.

Rollback:
- Revert this PR to remove the S2-50 desktop auth/session boundary runtime slice.

Validation:
- git diff --check: passed
- dotnet restore AnalyticsAutomation-Core.sln -nologo: passed
- dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore: passed
- dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal: passed
- dotnet build AnalyticsAutomation-Core.sln -nologo -v minimal: passed
- dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal: passed, 15/15
- Hidden/bidirectional Unicode scanner over changed text files: passed
- App.Desktop bounded launch smoke: passed; process started and was stopped after bounded wait, no credentials entered

Handoff docs:
- No handoff/task-card docs changed.

Next step:
- Review and merge S2-50 runtime slice if scope and validation are acceptable.
- A separate approved task is needed for real Windows secure token storage and any real SignIn UI wiring.

NO-GO / Deferred:
- No full SignIn UI.
- No upload flow.
- No GroupTree UI.
- No PreUploadCheck UI.
- No site upload.
- No UploadReceipt.
- No offline queue.
- No duplicate/fraud/admin review UI.
- No App.Web-as-desktop usage.
- No App.Api/contracts/migrations/deploy/workflow changes.
- Secure token persistence remains disabled pending a separate approved Windows secure storage task.
---

Automated update after main advanced:
- POST-SYNC MAIN SHA: 46656f3ba949a2aec4036ccae1cf12e46f9e3c64
- Feature branch updated by merging latest origin/main into S2-50 PR branch.
- TEAM COORDINATION LOG issue #89 re-read during update gate.
- Revalidation after update:
  - git diff --check
  - dotnet restore AnalyticsAutomation-Core.sln -nologo
  - dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore
  - dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal
  - dotnet build AnalyticsAutomation-Core.sln -nologo -v minimal
  - dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal
- No deploy.