### PR TITLE
feat(mobile): enable local create from last report draft

### DIFF
--- a/docs/reports/coder3-canonical-mobile-import.md
+++ b/docs/reports/coder3-canonical-mobile-import.md
@@ -1,10 +1,10 @@
 # Coder 3 canonical mobile import report
 
 ## Current step
-- MOB-CANON-REPORT-06 local report draft snapshot persistence.
+- MOB-CANON-REPORT-07 local create-from-last FPV draft action.
 
 ## Main baseline
-- Base main SHA: b9fc98b
+- Base main SHA: aae9392
 - IMPORT-01..07 are in main.
 - BACKEND-00 readiness is in main.
 - BACKEND-01 unresolved business-object binding guard is in main.
@@ -12,19 +12,22 @@
 - REPORT-04 local field editing and selector prototype is in main.
 - REPORT-05 local validation and ready-to-queue gating is in main.
 - REPORT-05 Russian localization fixes are preserved.
+- REPORT-06 local report draft snapshot persistence is in main.
+- PR #113 manual replay is recorded in TEAM COORDINATION LOG:
+  https://github.com/uVormik/AnalyticsAutomation-Core/issues/89#issuecomment-4324921544
 - TEAM COORDINATION LOG #89 records the Android businessObjectKey decision:
   https://github.com/uVormik/AnalyticsAutomation-Core/issues/89#issuecomment-4321720298
 
 ## Current slice
-This PR slice adds Android-local JSON metadata snapshots for FPV report drafts so local draft fields and attachment metadata survive a full app restart without backend save.
+This PR slice adds an Android-local create-from-last helper for FPV report drafts after local snapshot persistence is in main.
 
 What changes:
-- local report draft JSON metadata snapshots;
-- restored field values;
-- restored attachment metadata;
-- metadata-only note for restored attachments;
-- validation after restore;
-- local queue action after restore.
+- local "Создать из последнего" action;
+- copied draft receives a new DraftId;
+- latest local draft field values are copied;
+- attachments are not copied;
+- queued-local state is not copied;
+- copied draft is persisted through the local snapshot store.
 
 ## Explicitly not included
 - production PreUploadCheck;
@@ -32,10 +35,6 @@ What changes:
 - backend create-report;
 - approved backend endpoint/source for businessObjectKey;
 - backend validation rules;
-- media byte persistence;
-- file copy;
-- stream persistence;
-- SQLite or local database;
 - App.UI.Shared changes;
 - shared contracts changes;
 - backend/runtime integration.
@@ -44,7 +43,7 @@ What changes:
 - Production direction is Option 1: Android must obtain businessObjectKey from a backend-controlled report/business-object binding source before PreUploadCheck.
 - Concrete backend source/endpoint/contract is still not documented.
 - Local report draft ids are not businessObjectKey.
-- Local JSON snapshot ids and attachment metadata are not businessObjectKey.
+- Local copied draft ids are not businessObjectKey.
 - Production PreUploadCheck runtime remains blocked.
 
 ## Validation plan
@@ -54,20 +53,11 @@ What changes:
 - git diff --check
 
 ## Manual steps pending
-- none for REPORT-06.
+- physical Android check for create-from-last behavior.
 
-## Physical Android runtime check
+## REPORT-06 physical Android runtime check
 - Result: passed.
 - Runtime status: report06 phone ok.
-- Confirmed:
-  - local drafts survive full app restart;
-  - edited fields survive full app restart;
-  - attachment metadata survives full app restart;
-  - restored attachments are metadata-only;
-  - validation still works after restore;
-  - local report queue action still works after restore;
-  - no fake businessObjectKey is shown;
-  - production PreUploadCheck remains blocked.
 
 ## Next code step
-- REPORT-07 create-from-last, or wait for backend concrete businessObjectKey source.
+- wait for physical Android REPORT-07 check before push/PR.

--- a/docs/reports/coder3-canonical-mobile-import.md
+++ b/docs/reports/coder3-canonical-mobile-import.md
@@ -53,11 +53,25 @@ What changes:
 - git diff --check
 
 ## Manual steps pending
-- physical Android check for create-from-last behavior.
+- none for REPORT-07.
+
+## REPORT-07 physical Android runtime check
+- Result: passed.
+- Runtime status: report07 phone ok.
+- Confirmed:
+  - "Создать из последнего" works when at least one draft exists;
+  - no-draft warning/disabled state works;
+  - copied draft has new DraftId;
+  - copied draft copies field values;
+  - copied draft does not copy attachments;
+  - copied draft status is Draft;
+  - copied draft can be edited, receive new video, validate, and queue locally;
+  - no fake businessObjectKey is shown;
+  - production PreUploadCheck remains blocked.
 
 ## REPORT-06 physical Android runtime check
 - Result: passed.
 - Runtime status: report06 phone ok.
 
 ## Next code step
-- wait for physical Android REPORT-07 check before push/PR.
+- UX polishing, or wait for backend concrete businessObjectKey source.

--- a/docs/reports/coder3-mobile-foundation-reconciliation.md
+++ b/docs/reports/coder3-mobile-foundation-reconciliation.md
@@ -1,7 +1,7 @@
 # Coder 3 mobile foundation reconciliation
 
 ## Canonical App.Mobile.Android current state
-The canonical repository contains the Android media/outbox/report foundation through REPORT-05:
+The canonical repository contains the Android media/outbox/report foundation through REPORT-06:
 
 - IMPORT-01..07 media/outbox foundation;
 - BACKEND-00 backend readiness checkpoint;
@@ -9,26 +9,25 @@ The canonical repository contains the Android media/outbox/report foundation thr
 - REPORT-00..03 local report-first baseline;
 - REPORT-04 local field editing and selector prototype;
 - REPORT-05 local validation and ready-to-queue gating;
-- REPORT-05 Russian localization fixes.
+- REPORT-05 Russian localization fixes;
+- REPORT-06 local report draft snapshot persistence.
 
 ## Current local UX slice
-MOB-CANON-REPORT-06 is the current Android-local restart-resilience slice.
+MOB-CANON-REPORT-07 is the current Android-local report helper slice.
 
-REPORT-06 means:
-- local FPV report drafts are persisted as JSON metadata snapshots;
-- edited field values are restored after app restart;
-- attachment metadata is restored after app restart;
-- restored attachments are clearly metadata-only;
-- local validation and queue gating still run after restore.
+REPORT-07 means:
+- users can create a new local FPV draft from the latest local draft;
+- copied drafts receive a new DraftId;
+- copied drafts copy field values only;
+- copied drafts do not copy attachments;
+- copied drafts do not copy queued-local state;
+- copied drafts persist through the existing local snapshot store.
 
-REPORT-06 does not mean:
+REPORT-07 does not mean:
 - backend save;
 - backend validation;
 - create-report API;
-- media byte persistence;
-- file copy;
-- stream persistence;
-- SQLite/local DB;
+- backend-side create-from-last;
 - production report flow.
 
 ## BusinessObject and backend boundary
@@ -37,7 +36,7 @@ REPORT-06 does not mean:
 - Android must obtain businessObjectKey from a backend-controlled report/business-object binding source before PreUploadCheck.
 - The concrete backend source/endpoint/contract remains undocumented.
 - Local report draft id is not businessObjectKey.
-- JSON snapshot metadata is not businessObjectKey.
+- Copied local report draft id is not businessObjectKey.
 - Production PreUploadCheck remains blocked.
 
 ## Scope guard

--- a/docs/task-cards/MOB-CANON-REPORT-07.txt
+++ b/docs/task-cards/MOB-CANON-REPORT-07.txt
@@ -1,0 +1,74 @@
+Title: MOB-CANON-REPORT-07 - Local create-from-last FPV draft action
+Coder: 3
+Module: App.Mobile.Android
+Task type: Android-local UX foundation / local report draft helper
+
+Goal:
+Enable local "Создать из последнего" behavior for FPV drafts after report draft persistence is in main.
+
+Base main SHA:
+aae9392
+
+Coordination log entries reviewed:
+- TEAM COORDINATION LOG #89 latest entries reviewed on 2026-04-27.
+- PR #113 manual replay comment: https://github.com/uVormik/AnalyticsAutomation-Core/issues/89#issuecomment-4324921544
+- Android businessObjectKey decision comment: https://github.com/uVormik/AnalyticsAutomation-Core/issues/89#issuecomment-4321720298
+
+Handoff/task cards reviewed:
+- docs/reports/coder3-android-backend-readiness.md
+- docs/task-cards/MOB-CANON-BACKEND-00.txt
+- docs/task-cards/MOB-CANON-BACKEND-01.txt
+- docs/handoffs/MOB-CANON-BACKEND-01_ANDROID_BUSINESS_OBJECT_BINDING_BLOCKER.md
+- docs/task-cards/MOB-CANON-REPORT-00-03.txt
+- docs/task-cards/MOB-CANON-REPORT-04.txt
+- docs/task-cards/MOB-CANON-REPORT-05.txt
+- docs/task-cards/MOB-CANON-REPORT-06.txt
+- docs/task-cards/MOB-CANON-REPORT-07.txt
+
+What changes:
+- local create-from-last action
+- copies field values from latest draft
+- does not copy attachments
+- does not copy queue state
+- persists copied draft through local snapshot store
+
+Contracts:
+- shared DTO/contracts unchanged
+
+Migration:
+- none
+
+Feature flags:
+- local mobile stub flags only if used
+
+Offline behavior:
+- local snapshot-backed draft creation only
+- no backend save
+- no sync
+- no upload
+
+Security:
+- no auth/session/device binding
+- no tokens/secrets
+
+BusinessObject:
+- businessObjectKey source remains unresolved
+- local report draft id is not businessObjectKey
+- production PreUploadCheck remains blocked
+
+Rollback:
+- revert this PR
+
+Definition of done:
+- build succeeds
+- unit tests pass
+- format/diff-check pass
+- "Создать из последнего" works when drafts exist
+- warning/disabled state works when no drafts exist
+- copied draft has new DraftId
+- copied draft copies field values
+- copied draft does not copy attachments
+- copied draft status is Draft
+- copied draft can be edited, receive new video, validate, and queue locally
+- no backend integration
+- no App.UI.Shared changes

--- a/src/App.Mobile.Android/Components/Pages/Reports.razor
+++ b/src/App.Mobile.Android/Components/Pages/Reports.razor
@@ -26,7 +26,18 @@ else
 
         <div class="reports-shell-actions">
             <button type="button" class="btn btn-primary" @onclick="CreateDraftAsync">@MobileUiText.ReportsCreateFpvDraftButton</button>
+            <button type="button"
+                    class="btn btn-outline-primary"
+                    disabled="@(Drafts.Count == 0)"
+                    @onclick="CreateFromLastDraftAsync">
+                @MobileUiText.ReportsCreateFromLastFpvDraftButton
+            </button>
         </div>
+
+        @if (!string.IsNullOrWhiteSpace(ActionResultText))
+        {
+            <p class="reports-action-result">@ActionResultText</p>
+        }
 
         <p class="reports-local-note">@MobileUiText.GetReportDraftLocalSnapshotNoteText()</p>
 
@@ -82,6 +93,8 @@ else
 
     private bool IsLoading { get; set; }
 
+    private string ActionResultText { get; set; } = string.Empty;
+
     private bool ShowReportDraftShell =>
         FeatureFlagReader.IsEnabled(global::App.Mobile.Android.Services.Stubs.StubFeatureFlagReader.ReportDraftShellFlag);
 
@@ -101,6 +114,19 @@ else
     {
         var draft = await ReportDraftStore.CreateFpvDraftAsync();
         NavigationManager.NavigateTo(GetDraftRoute(draft.DraftId));
+    }
+
+    private async Task CreateFromLastDraftAsync()
+    {
+        var result = await ReportDraftStore.CreateFromLastFpvDraftAsync();
+        if (result.Applied && result.Draft is not null)
+        {
+            NavigationManager.NavigateTo(GetDraftRoute(result.Draft.DraftId));
+            return;
+        }
+
+        ActionResultText = result.Message;
+        await LoadDraftsAsync();
     }
 
     private async Task LoadDraftsAsync()

--- a/src/App.Mobile.Android/Components/Pages/Reports.razor.css
+++ b/src/App.Mobile.Android/Components/Pages/Reports.razor.css
@@ -41,7 +41,19 @@
 
 .reports-shell-actions {
     display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
     justify-content: flex-start;
+}
+
+.reports-action-result {
+    margin: 0;
+    padding: 0.75rem 0.85rem;
+    border-radius: 0.75rem;
+    background: #fff7ed;
+    border: 1px solid #fed7aa;
+    color: #9a3412;
+    line-height: 1.45;
 }
 
 .reports-local-note,

--- a/src/App.Mobile.Android/Localization/MobileUiText.cs
+++ b/src/App.Mobile.Android/Localization/MobileUiText.cs
@@ -22,6 +22,9 @@ internal static class MobileUiText
         "Локальная оболочка черновиков отчетов сейчас скрыта флагом функции.";
     public const string ReportsLoadingText = "Загружается локальный список черновиков...";
     public const string ReportsCreateFpvDraftButton = "Создать отчет FPV";
+    public const string ReportsCreateFromLastFpvDraftButton = "Создать из последнего";
+    public const string ReportCreateFromLastNoPreviousDraftWarningText =
+        "Сначала создайте хотя бы один локальный FPV-черновик. Копировать пока нечего.";
     public const string ReportsEmptyTitle = "Черновиков пока нет";
     public const string ReportsEmptyMessage =
         "Создайте локальный FPV-черновик, чтобы проверить report-first оболочку без серверного сохранения, синхронизации и загрузки.";
@@ -466,6 +469,16 @@ internal static class MobileUiText
     public static string GetReportDraftTitle(int sequence)
     {
         return $"FPV-отчет #{sequence}";
+    }
+
+    public static string GetReportDraftCreateFromLastTitle(int sequence)
+    {
+        return $"FPV-отчет из последнего #{sequence}";
+    }
+
+    public static string GetReportCreateFromLastSuccessText(string sourceTitle)
+    {
+        return $"Создан новый локальный черновик из «{sourceTitle}». Поля скопированы, вложения и очередь не скопированы.";
     }
 
     public static string GetLookupStubOptionText(int sequence)

--- a/src/App.Mobile.Android/Services/Abstractions/IMobileReportDraftStore.cs
+++ b/src/App.Mobile.Android/Services/Abstractions/IMobileReportDraftStore.cs
@@ -12,6 +12,9 @@ internal interface IMobileReportDraftStore
     Task<global::App.Mobile.Android.Reports.MobileReportDraft> CreateFpvDraftAsync(
         CancellationToken cancellationToken = default);
 
+    Task<global::App.Mobile.Android.Reports.MobileReportDraftOperationResult> CreateFromLastFpvDraftAsync(
+        CancellationToken cancellationToken = default);
+
     Task<global::App.Mobile.Android.Reports.MobileReportDraftOperationResult> AttachSelectedVideoAsync(
         string draftId,
         global::App.Mobile.Android.Media.LocalSelectedMediaDescriptor descriptor,

--- a/src/App.Mobile.Android/Services/Local/InMemoryMobileReportDraftStore.cs
+++ b/src/App.Mobile.Android/Services/Local/InMemoryMobileReportDraftStore.cs
@@ -104,6 +104,63 @@ internal sealed class InMemoryMobileReportDraftStore :
         return draft;
     }
 
+    public async Task<global::App.Mobile.Android.Reports.MobileReportDraftOperationResult> CreateFromLastFpvDraftAsync(
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        await EnsureSnapshotLoadedAsync(cancellationToken);
+
+        global::App.Mobile.Android.Reports.MobileReportDraftOperationResult operationResult;
+        global::App.Mobile.Android.Reports.MobileReportDraft[]? persistedDrafts = null;
+
+        lock (_gate)
+        {
+            var latestDraft = _drafts
+                .OrderByDescending(draft => draft.UpdatedAtUtc)
+                .ThenByDescending(draft => draft.CreatedAtUtc)
+                .FirstOrDefault();
+
+            if (latestDraft is null)
+            {
+                return new global::App.Mobile.Android.Reports.MobileReportDraftOperationResult(
+                    Applied: false,
+                    Message: global::App.Mobile.Android.Localization.MobileUiText.ReportCreateFromLastNoPreviousDraftWarningText,
+                    Draft: null,
+                    Attachment: null);
+            }
+
+            var now = DateTimeOffset.UtcNow;
+            var sequence = Interlocked.Increment(ref _sequence);
+            var copiedFields = latestDraft.Fields
+                .Select(field => field with
+                {
+                    LastUpdatedAtUtc = field.IsPlaceholder ? null : now
+                })
+                .ToArray();
+
+            var createdDraft = new global::App.Mobile.Android.Reports.MobileReportDraft(
+                DraftId: Guid.NewGuid().ToString("N"),
+                CreatedAtUtc: now,
+                UpdatedAtUtc: now,
+                Title: global::App.Mobile.Android.Localization.MobileUiText.GetReportDraftCreateFromLastTitle(sequence),
+                Status: global::App.Mobile.Android.Reports.MobileReportDraftStatus.Draft,
+                Fields: copiedFields,
+                Attachments: Array.Empty<global::App.Mobile.Android.Reports.MobileReportAttachment>());
+
+            _drafts.Insert(0, createdDraft);
+            persistedDrafts = _drafts.ToArray();
+            operationResult = new global::App.Mobile.Android.Reports.MobileReportDraftOperationResult(
+                Applied: true,
+                Message: global::App.Mobile.Android.Localization.MobileUiText.GetReportCreateFromLastSuccessText(
+                    latestDraft.Title),
+                Draft: createdDraft,
+                Attachment: null);
+        }
+
+        await _snapshotStore.SaveAsync(persistedDrafts, cancellationToken);
+        return operationResult;
+    }
+
     public async Task<global::App.Mobile.Android.Reports.MobileReportDraftOperationResult> AttachSelectedVideoAsync(
         string draftId,
         global::App.Mobile.Android.Media.LocalSelectedMediaDescriptor descriptor,

--- a/tests/Unit/App.Mobile.Android.Foundation.Tests/InMemoryMobileReportDraftStoreTests.cs
+++ b/tests/Unit/App.Mobile.Android.Foundation.Tests/InMemoryMobileReportDraftStoreTests.cs
@@ -138,6 +138,145 @@ public sealed class InMemoryMobileReportDraftStoreTests
     }
 
     [Fact]
+    public async Task CreateFromLastFpvDraftAsync_WithNoDrafts_ReturnsAppliedFalse()
+    {
+        using var scope = CreateScope();
+        var store = scope.CreateStore();
+
+        var result = await store.CreateFromLastFpvDraftAsync();
+
+        Assert.False(result.Applied);
+        Assert.Null(result.Draft);
+        Assert.Equal(
+            global::App.Mobile.Android.Localization.MobileUiText.ReportCreateFromLastNoPreviousDraftWarningText,
+            result.Message);
+    }
+
+    [Fact]
+    public async Task CreateFromLastFpvDraftAsync_AfterEditedDraft_CopiesFieldValuesWithNewDraftId()
+    {
+        using var scope = CreateScope();
+        var store = scope.CreateStore();
+        var originalDraft = await store.CreateFpvDraftAsync();
+        await store.UpdateFieldValueAsync(originalDraft.DraftId, "serial_number", "SN-FROM-LAST-001");
+        await store.UpdateFieldValueAsync(originalDraft.DraftId, "reason", "Заглушка - значение 3");
+
+        var result = await store.CreateFromLastFpvDraftAsync();
+
+        Assert.True(result.Applied);
+        Assert.NotNull(result.Draft);
+        Assert.NotEqual(originalDraft.DraftId, result.Draft!.DraftId);
+        Assert.Equal(global::App.Mobile.Android.Reports.MobileReportDraftStatus.Draft, result.Draft.Status);
+        Assert.Equal(
+            "SN-FROM-LAST-001",
+            Assert.Single(result.Draft.Fields, field => field.FieldKey == "serial_number").ValueText);
+        Assert.Equal(
+            "Заглушка - значение 3",
+            Assert.Single(result.Draft.Fields, field => field.FieldKey == "reason").ValueText);
+    }
+
+    [Fact]
+    public async Task CreateFromLastFpvDraftAsync_DoesNotCopyAttachments()
+    {
+        using var scope = CreateScope();
+        var store = scope.CreateStore();
+        var originalDraft = await store.CreateFpvDraftAsync();
+        await store.AttachSelectedVideoAsync(
+            originalDraft.DraftId,
+            CreateDescriptor(cacheKey: "copy-source", fileName: "source.mp4"));
+
+        var result = await store.CreateFromLastFpvDraftAsync();
+
+        Assert.True(result.Applied);
+        Assert.NotNull(result.Draft);
+        Assert.Empty(result.Draft!.Attachments);
+    }
+
+    [Fact]
+    public async Task CreateFromLastFpvDraftAsync_DoesNotCopyQueuedLocalStatus()
+    {
+        using var scope = CreateScope();
+        var store = scope.CreateStore();
+        var originalDraft = await store.CreateFpvDraftAsync();
+        await store.MarkDraftQueuedLocalAsync(originalDraft.DraftId);
+
+        var result = await store.CreateFromLastFpvDraftAsync();
+
+        Assert.True(result.Applied);
+        Assert.NotNull(result.Draft);
+        Assert.Equal(global::App.Mobile.Android.Reports.MobileReportDraftStatus.Draft, result.Draft!.Status);
+    }
+
+    [Fact]
+    public async Task CreateFromLastFpvDraftAsync_CopiedDraftCanBeEditedAndReceiveVideo()
+    {
+        using var scope = CreateScope();
+        var store = scope.CreateStore();
+        var originalDraft = await store.CreateFpvDraftAsync();
+        await store.UpdateFieldValueAsync(originalDraft.DraftId, "serial_number", "SN-BEFORE-COPY");
+        var copyResult = await store.CreateFromLastFpvDraftAsync();
+
+        var updateResult = await store.UpdateFieldValueAsync(
+            copyResult.Draft!.DraftId,
+            "serial_number",
+            "SN-AFTER-COPY");
+        var attachResult = await store.AttachSelectedVideoAsync(
+            copyResult.Draft.DraftId,
+            CreateDescriptor(cacheKey: "copy-draft-video", fileName: "copy-video.mp4"));
+
+        Assert.True(copyResult.Applied);
+        Assert.True(updateResult.Applied);
+        Assert.True(attachResult.Applied);
+        Assert.Equal(
+            "SN-AFTER-COPY",
+            Assert.Single(updateResult.Draft!.Fields, field => field.FieldKey == "serial_number").ValueText);
+        Assert.Single(attachResult.Draft!.Attachments);
+    }
+
+    [Fact]
+    public async Task CreateFromLastFpvDraftAsync_CopiedDraftPersistsInSnapshotStore()
+    {
+        using var scope = CreateScope();
+
+        var firstStore = scope.CreateStore();
+        var originalDraft = await firstStore.CreateFpvDraftAsync();
+        await firstStore.UpdateFieldValueAsync(originalDraft.DraftId, "serial_number", "SN-PERSIST-COPY");
+        var createResult = await firstStore.CreateFromLastFpvDraftAsync();
+
+        var secondStore = scope.CreateStore();
+        var restoredDraft = await secondStore.GetDraftAsync(createResult.Draft!.DraftId);
+
+        Assert.True(createResult.Applied);
+        Assert.NotNull(restoredDraft);
+        Assert.Equal(global::App.Mobile.Android.Reports.MobileReportDraftStatus.Draft, restoredDraft!.Status);
+        Assert.Empty(restoredDraft.Attachments);
+        Assert.True(restoredDraft.IsRestoredFromSnapshot);
+        Assert.Equal(
+            "SN-PERSIST-COPY",
+            Assert.Single(restoredDraft.Fields, field => field.FieldKey == "serial_number").ValueText);
+    }
+
+    [Fact]
+    public async Task CreateFromLastFpvDraftAsync_UsesLatestUpdatedDraft()
+    {
+        using var scope = CreateScope();
+        var store = scope.CreateStore();
+        var firstDraft = await store.CreateFpvDraftAsync();
+        var secondDraft = await store.CreateFpvDraftAsync();
+        await store.UpdateFieldValueAsync(secondDraft.DraftId, "serial_number", "SN-OLDER");
+        await Task.Delay(TimeSpan.FromMilliseconds(10));
+        await store.UpdateFieldValueAsync(firstDraft.DraftId, "serial_number", "SN-LATEST");
+
+        var result = await store.CreateFromLastFpvDraftAsync();
+
+        Assert.True(result.Applied);
+        Assert.NotNull(result.Draft);
+        Assert.Equal(
+            "SN-LATEST",
+            Assert.Single(result.Draft!.Fields, field => field.FieldKey == "serial_number").ValueText);
+    }
+
+    [Fact]
     public async Task UpdateFieldValueAsync_UpdatesExistingField()
     {
         using var scope = CreateScope();

--- a/tests/Unit/App.Mobile.Android.Foundation.Tests/InMemoryMobileReportDraftStoreTests.cs
+++ b/tests/Unit/App.Mobile.Android.Foundation.Tests/InMemoryMobileReportDraftStoreTests.cs
@@ -1,4 +1,4 @@
-﻿namespace App.Mobile.Android.Foundation.Tests;
+namespace App.Mobile.Android.Foundation.Tests;
 
 public sealed class InMemoryMobileReportDraftStoreTests
 {


### PR DESCRIPTION
﻿Base main SHA:
aae9392

Coordination log entries reviewed:
- TEAM COORDINATION LOG #89 latest entries reviewed on 2026-04-27.
- PR #113 manual replay comment: https://github.com/uVormik/AnalyticsAutomation-Core/issues/89#issuecomment-4324921544
- Android businessObjectKey decision comment: https://github.com/uVormik/AnalyticsAutomation-Core/issues/89#issuecomment-4321720298

Handoff/task cards reviewed:
- docs/reports/coder3-android-backend-readiness.md
- docs/task-cards/MOB-CANON-BACKEND-00.txt
- docs/task-cards/MOB-CANON-BACKEND-01.txt
- docs/handoffs/MOB-CANON-BACKEND-01_ANDROID_BUSINESS_OBJECT_BINDING_BLOCKER.md
- docs/task-cards/MOB-CANON-REPORT-00-03.txt
- docs/task-cards/MOB-CANON-REPORT-04.txt
- docs/task-cards/MOB-CANON-REPORT-05.txt
- docs/task-cards/MOB-CANON-REPORT-06.txt
- docs/task-cards/MOB-CANON-REPORT-07.txt

Purpose:
Enable local create-from-last FPV draft action after local report draft persistence is in main.

Module:
App.Mobile.Android / mobile unit tests / mobile docs.

Contracts:
Shared DTO/contracts unchanged.

Migration:
None.

Feature flags:
Local mobile stub flags only if used.

Offline behavior:
Local snapshot-backed draft creation only. No backend save, no sync, no upload.

Manual check:
Physical Android runtime check passed:
- Создать из последнего works when at least one draft exists
- no-draft warning/disabled state works
- copied draft has new DraftId
- copied draft copies field values
- copied draft does not copy attachments
- copied draft status is Draft
- copied draft can be edited, receive new video, validate, and queue locally
- no fake businessObjectKey is shown
- production PreUploadCheck remains blocked

Tests:
dotnet test .\tests\Unit\App.Mobile.Android.Foundation.Tests\App.Mobile.Android.Foundation.Tests.csproj -c Debug
Result: passed, 116/116.

Build:
dotnet build .\src\App.Mobile.Android\App.Mobile.Android.csproj -f net10.0-android -m:1
Result: success.

Format:
dotnet format whitespace .\AnalyticsAutomation-Core.sln --verify-no-changes --no-restore
Result: success.

git diff --check:
Result: passed.

Rollback:
Revert this PR / remove local create-from-last action.

Out of scope:
- no backend integration
- no App.Api changes
- no Modules changes
- no BuildingBlocks.Contracts changes
- no shared DTO/contracts changes
- no App.UI.Shared changes
- no auth/session/device binding
- no create-report API
- no businessObjectKey invention
- no backend validation rules
- no PreUploadCheck runtime
- no UploadReceipt runtime
- no direct upload runtime
- no production reports engine
- no desktop implementation
- no UX-01..UX-05 replay
