### PR TITLE
S2-51 desktop signin runtime enablement

### DIFF
--- a/src/App.Desktop/App.xaml.cs
+++ b/src/App.Desktop/App.xaml.cs
@@ -15,7 +15,7 @@ public partial class DesktopApplication : Application
     {
         base.OnStartup(e);
 
-        _services = DesktopCompositionRoot.BuildServices();
+        _services = DesktopCompositionRoot.BuildServicesFromEnvironment();
         _services
             .GetRequiredService<IDesktopShellLifecycle>()
             .OnStartingAsync(CancellationToken.None)

--- a/src/App.Desktop/Boundaries/DesktopSignInBoundary.cs
+++ b/src/App.Desktop/Boundaries/DesktopSignInBoundary.cs
@@ -1,0 +1,135 @@
+namespace App.Desktop.Boundaries;
+
+public interface IDesktopSignInService
+{
+    ValueTask<DesktopSignInResult> SignInAsync(
+        string login,
+        string password,
+        Guid? deviceId,
+        CancellationToken cancellationToken);
+}
+
+public sealed class DesktopSignInResult
+{
+    private DesktopSignInResult(
+        DesktopSignInStatus status,
+        DesktopSessionSnapshot? session,
+        DesktopSignInError? error,
+        string message)
+    {
+        Status = status;
+        Session = session;
+        Error = error;
+        Message = message;
+    }
+
+    public DesktopSignInStatus Status { get; }
+
+    public DesktopSessionSnapshot? Session { get; }
+
+    public DesktopSignInError? Error { get; }
+
+    public string Message { get; }
+
+    public bool IsSuccess => Status == DesktopSignInStatus.Succeeded;
+
+    public static DesktopSignInResult NotStarted { get; } = new(
+        DesktopSignInStatus.NotStarted,
+        session: null,
+        error: null,
+        "Sign-in has not been attempted.");
+
+    public static DesktopSignInResult Succeeded(DesktopSessionSnapshot session)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+
+        return new DesktopSignInResult(
+            DesktopSignInStatus.Succeeded,
+            session,
+            error: null,
+            "Signed in.");
+    }
+
+    public static DesktopSignInResult Rejected(string? code)
+    {
+        return WithError(
+            DesktopSignInStatus.Rejected,
+            code,
+            fallbackCode: "sign_in_rejected",
+            message: "Sign-in was rejected.");
+    }
+
+    public static DesktopSignInResult Failed(string? code)
+    {
+        return WithError(
+            DesktopSignInStatus.Failed,
+            code,
+            fallbackCode: "sign_in_failed",
+            message: "Sign-in failed.");
+    }
+
+    public static DesktopSignInResult Unavailable(string? code)
+    {
+        return WithError(
+            DesktopSignInStatus.Unavailable,
+            code,
+            fallbackCode: "sign_in_unavailable",
+            message: "Desktop sign-in is unavailable.");
+    }
+
+    public override string ToString()
+    {
+        return $"{nameof(DesktopSignInResult)} {{ Status = {Status}, HasSession = {Session is not null}, "
+            + $"Error = {Error}, Message = {Message} }}";
+    }
+
+    private static DesktopSignInResult WithError(
+        DesktopSignInStatus status,
+        string? code,
+        string fallbackCode,
+        string message)
+    {
+        return new DesktopSignInResult(
+            status,
+            session: null,
+            new DesktopSignInError(NormalizeCode(code, fallbackCode), message),
+            message);
+    }
+
+    private static string NormalizeCode(string? code, string fallbackCode)
+    {
+        if (string.IsNullOrWhiteSpace(code))
+        {
+            return fallbackCode;
+        }
+
+        string trimmed = code.Trim();
+        if (trimmed.Length > 64)
+        {
+            return fallbackCode;
+        }
+
+        foreach (char value in trimmed)
+        {
+            if (!char.IsAsciiLetterOrDigit(value) && value is not '_' and not '-' and not '.')
+            {
+                return fallbackCode;
+            }
+        }
+
+        return trimmed;
+    }
+}
+
+public sealed record DesktopSignInError(
+    string Code,
+    string Message);
+
+public enum DesktopSignInStatus
+{
+    NotStarted,
+    Succeeded,
+    Rejected,
+    Failed,
+    Unavailable
+}

--- a/src/App.Desktop/Components/DesktopShell.razor
+++ b/src/App.Desktop/Components/DesktopShell.razor
@@ -1,4 +1,5 @@
 @inject IBlazorWebViewHostBoundary BlazorHostBoundary
+@inject DesktopSignInViewModel SignInViewModel
 
 <div class="desktop-shell">
     <header class="desktop-shell__header">
@@ -6,10 +7,59 @@
             <p class="desktop-shell__eyebrow">@BlazorHostBoundary.SurfaceName</p>
             <h1>AnalyticsAutomation Desktop</h1>
         </div>
-        <span class="desktop-shell__status">Skeleton</span>
+        <span class="desktop-shell__status">SignIn</span>
     </header>
 
     <main class="desktop-shell__main">
+        <section class="desktop-signin" aria-labelledby="desktop-signin-title">
+            <div class="desktop-signin__heading">
+                <h2 id="desktop-signin-title">Sign in</h2>
+                @if (SignInViewModel.LastResult.Status != DesktopSignInStatus.NotStarted)
+                {
+                    <p class="@GetSignInStatusClass()">@SignInViewModel.LastResult.Message</p>
+                }
+            </div>
+
+            <form class="desktop-signin__form" @onsubmit="SignInAsync" @onsubmit:preventDefault="true">
+                <label class="desktop-signin__field" for="desktop-signin-login">
+                    <span>Login</span>
+                    <input
+                        id="desktop-signin-login"
+                        name="login"
+                        autocomplete="username"
+                        @bind="SignInViewModel.Login" />
+                </label>
+
+                <label class="desktop-signin__field" for="desktop-signin-password">
+                    <span>Password</span>
+                    <input
+                        id="desktop-signin-password"
+                        name="password"
+                        type="password"
+                        autocomplete="current-password"
+                        @bind="SignInViewModel.Password" />
+                </label>
+
+                <button class="desktop-signin__submit" type="submit" disabled="@SignInViewModel.IsBusy">
+                    @(SignInViewModel.IsBusy ? "Signing in" : "Sign in")
+                </button>
+            </form>
+        </section>
+
         <UploadPlaceholder />
     </main>
 </div>
+
+@code {
+    private async Task SignInAsync()
+    {
+        await SignInViewModel.SignInAsync(CancellationToken.None);
+    }
+
+    private string GetSignInStatusClass()
+    {
+        return SignInViewModel.LastResult.Status == DesktopSignInStatus.Succeeded
+            ? "desktop-signin__message desktop-signin__message--success"
+            : "desktop-signin__message desktop-signin__message--neutral";
+    }
+}

--- a/src/App.Desktop/Components/_Imports.razor
+++ b/src/App.Desktop/Components/_Imports.razor
@@ -1,3 +1,4 @@
 @using global::App.Desktop.Boundaries
+@using global::App.Desktop.Services.Auth
 @using global::App.UI.Shared.Pages
 @using Microsoft.AspNetCore.Components

--- a/src/App.Desktop/Composition/DesktopCompositionRoot.cs
+++ b/src/App.Desktop/Composition/DesktopCompositionRoot.cs
@@ -1,3 +1,5 @@
+using System.Net.Http;
+
 using App.Desktop.Boundaries;
 using App.Desktop.Services.Auth;
 using App.Desktop.Services.Placeholders;
@@ -10,6 +12,18 @@ public static class DesktopCompositionRoot
 {
     public static ServiceProvider BuildServices()
     {
+        return BuildServices(DesktopAuthOptions.Disabled);
+    }
+
+    public static ServiceProvider BuildServicesFromEnvironment()
+    {
+        return BuildServices(DesktopAuthOptions.FromEnvironment());
+    }
+
+    public static ServiceProvider BuildServices(DesktopAuthOptions authOptions)
+    {
+        ArgumentNullException.ThrowIfNull(authOptions);
+
         var services = new ServiceCollection();
 
         services.AddWpfBlazorWebView();
@@ -17,6 +31,7 @@ public static class DesktopCompositionRoot
         services.AddBlazorWebViewDeveloperTools();
 #endif
 
+        services.AddSingleton(authOptions);
         services.AddSingleton<IDesktopShellLifecycle, PlaceholderDesktopShellLifecycle>();
         services.AddSingleton<IDesktopSessionStore, DisabledDesktopSessionStore>();
         services.AddSingleton<DesktopSessionState>();
@@ -24,7 +39,21 @@ public static class DesktopCompositionRoot
             serviceProvider => serviceProvider.GetRequiredService<DesktopSessionState>());
         services.AddSingleton<IDesktopAuthSessionBoundary>(
             serviceProvider => serviceProvider.GetRequiredService<DesktopSessionState>());
-        services.AddSingleton<IDesktopAuthClient, UnavailableDesktopAuthClient>();
+        if (authOptions.IsControlPlaneSignInConfigured)
+        {
+            services.AddSingleton(_ => new HttpClient
+            {
+                BaseAddress = authOptions.ControlPlaneBaseAddress
+            });
+            services.AddSingleton<IDesktopAuthClient, HttpDesktopAuthClient>();
+        }
+        else
+        {
+            services.AddSingleton<IDesktopAuthClient, UnavailableDesktopAuthClient>();
+        }
+
+        services.AddSingleton<IDesktopSignInService, DesktopSignInService>();
+        services.AddTransient<DesktopSignInViewModel>();
         services.AddSingleton<ISecureSessionStorage, PlaceholderSecureSessionStorage>();
         services.AddSingleton<IDesktopFilePicker, PlaceholderDesktopFilePicker>();
         services.AddSingleton<ILocalFileMetadataService, PlaceholderLocalFileMetadataService>();

--- a/src/App.Desktop/Services/Auth/DesktopAuthOptions.cs
+++ b/src/App.Desktop/Services/Auth/DesktopAuthOptions.cs
@@ -1,0 +1,73 @@
+namespace App.Desktop.Services.Auth;
+
+public sealed class DesktopAuthOptions
+{
+    public const string ControlPlaneBaseAddressEnvironmentVariable =
+        "AA_DESKTOP_CONTROL_PLANE_BASE_ADDRESS";
+
+    private DesktopAuthOptions(Uri? controlPlaneBaseAddress)
+    {
+        ControlPlaneBaseAddress = controlPlaneBaseAddress;
+    }
+
+    public static DesktopAuthOptions Disabled { get; } = new(controlPlaneBaseAddress: null);
+
+    public Uri? ControlPlaneBaseAddress { get; }
+
+    public bool IsControlPlaneSignInConfigured => ControlPlaneBaseAddress is not null;
+
+    public static DesktopAuthOptions FromEnvironment()
+    {
+        return FromControlPlaneBaseAddress(
+            Environment.GetEnvironmentVariable(ControlPlaneBaseAddressEnvironmentVariable));
+    }
+
+    public static DesktopAuthOptions FromControlPlaneBaseAddress(string? baseAddress)
+    {
+        if (string.IsNullOrWhiteSpace(baseAddress))
+        {
+            return Disabled;
+        }
+
+        return Uri.TryCreate(baseAddress.Trim(), UriKind.Absolute, out var parsed)
+            ? FromControlPlaneBaseAddress(parsed)
+            : Disabled;
+    }
+
+    public static DesktopAuthOptions FromControlPlaneBaseAddress(Uri? baseAddress)
+    {
+        if (baseAddress is null || !IsSafeControlPlaneBaseAddress(baseAddress))
+        {
+            return Disabled;
+        }
+
+        return new DesktopAuthOptions(baseAddress);
+    }
+
+    public override string ToString()
+    {
+        return $"{nameof(DesktopAuthOptions)} {{ IsControlPlaneSignInConfigured = {IsControlPlaneSignInConfigured}, "
+            + $"Scheme = {ControlPlaneBaseAddress?.Scheme ?? "<none>"}, Host = {ControlPlaneBaseAddress?.Host ?? "<none>"} }}";
+    }
+
+    private static bool IsSafeControlPlaneBaseAddress(Uri baseAddress)
+    {
+        if (!baseAddress.IsAbsoluteUri || string.IsNullOrWhiteSpace(baseAddress.Host))
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(baseAddress.UserInfo))
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrEmpty(baseAddress.Query) || !string.IsNullOrEmpty(baseAddress.Fragment))
+        {
+            return false;
+        }
+
+        return baseAddress.Scheme == Uri.UriSchemeHttps
+            || baseAddress.Scheme == Uri.UriSchemeHttp;
+    }
+}

--- a/src/App.Desktop/Services/Auth/DesktopAuthOptions.cs
+++ b/src/App.Desktop/Services/Auth/DesktopAuthOptions.cs
@@ -67,6 +67,11 @@ public sealed class DesktopAuthOptions
             return false;
         }
 
+        if (baseAddress.AbsolutePath is not "" and not "/")
+        {
+            return false;
+        }
+
         return baseAddress.Scheme == Uri.UriSchemeHttps
             || baseAddress.Scheme == Uri.UriSchemeHttp;
     }

--- a/src/App.Desktop/Services/Auth/DesktopSignInService.cs
+++ b/src/App.Desktop/Services/Auth/DesktopSignInService.cs
@@ -1,0 +1,78 @@
+using App.Desktop.Boundaries;
+
+namespace App.Desktop.Services.Auth;
+
+public sealed class DesktopSignInService(
+    IDesktopAuthClient authClient,
+    IDesktopSessionState sessionState) : IDesktopSignInService
+{
+    public async ValueTask<DesktopSignInResult> SignInAsync(
+        string login,
+        string password,
+        Guid? deviceId,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (string.IsNullOrWhiteSpace(login) || string.IsNullOrWhiteSpace(password))
+        {
+            return DesktopSignInResult.Rejected("missing_credentials");
+        }
+
+        DesktopAuthResult authResult;
+        try
+        {
+            authResult = await authClient.SignInAsync(
+                new DesktopSignInRequest(login, password, deviceId),
+                cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch
+        {
+            return DesktopSignInResult.Unavailable("sign_in_unavailable");
+        }
+
+        if (!authResult.IsSuccess)
+        {
+            return ToSignInFailure(authResult);
+        }
+
+        if (authResult.Session is null)
+        {
+            return DesktopSignInResult.Failed("sign_in_invalid_session");
+        }
+
+        try
+        {
+            var snapshot = await sessionState.SetSignedInAsync(
+                authResult.Session,
+                cancellationToken);
+
+            return DesktopSignInResult.Succeeded(snapshot);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch
+        {
+            return DesktopSignInResult.Failed("session_update_failed");
+        }
+    }
+
+    private static DesktopSignInResult ToSignInFailure(DesktopAuthResult authResult)
+    {
+        string? code = authResult.Error?.Code;
+
+        return authResult.Status switch
+        {
+            DesktopAuthStatus.Rejected => DesktopSignInResult.Rejected(code),
+            DesktopAuthStatus.Failed => DesktopSignInResult.Failed(code),
+            DesktopAuthStatus.Unavailable => DesktopSignInResult.Unavailable(code),
+            _ => DesktopSignInResult.Failed("sign_in_failed")
+        };
+    }
+}

--- a/src/App.Desktop/Services/Auth/DesktopSignInViewModel.cs
+++ b/src/App.Desktop/Services/Auth/DesktopSignInViewModel.cs
@@ -1,0 +1,38 @@
+using App.Desktop.Boundaries;
+
+namespace App.Desktop.Services.Auth;
+
+public sealed class DesktopSignInViewModel(IDesktopSignInService signInService)
+{
+    public string Login { get; set; } = string.Empty;
+
+    public string Password { get; set; } = string.Empty;
+
+    public Guid? DeviceId { get; set; }
+
+    public bool IsBusy { get; private set; }
+
+    public DesktopSignInResult LastResult { get; private set; } = DesktopSignInResult.NotStarted;
+
+    public async ValueTask<DesktopSignInResult> SignInAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        IsBusy = true;
+        try
+        {
+            LastResult = await signInService.SignInAsync(
+                Login,
+                Password,
+                DeviceId,
+                cancellationToken);
+
+            return LastResult;
+        }
+        finally
+        {
+            Password = string.Empty;
+            IsBusy = false;
+        }
+    }
+}

--- a/src/App.Desktop/wwwroot/app.css
+++ b/src/App.Desktop/wwwroot/app.css
@@ -49,7 +49,97 @@ body {
 
 .desktop-shell__main {
     flex: 1;
-    display: grid;
-    place-items: center;
+    width: 100%;
+    max-width: 960px;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 24px;
+    box-sizing: border-box;
+    margin: 0 auto;
     padding: 32px;
+}
+
+.desktop-signin {
+    display: grid;
+    grid-template-columns: minmax(180px, 0.8fr) minmax(320px, 1.2fr);
+    gap: 20px;
+    align-items: start;
+    width: 100%;
+    box-sizing: border-box;
+    padding: 22px;
+    background: #ffffff;
+    border: 1px solid #d7dde5;
+    border-radius: 8px;
+}
+
+.desktop-signin__heading h2 {
+    margin: 0;
+    font-size: 1.1rem;
+    font-weight: 650;
+}
+
+.desktop-signin__message {
+    margin: 10px 0 0;
+    font-size: 0.9rem;
+    font-weight: 600;
+}
+
+.desktop-signin__message--success {
+    color: #17643c;
+}
+
+.desktop-signin__message--neutral {
+    color: #6b4b00;
+}
+
+.desktop-signin__form {
+    display: grid;
+    grid-template-columns: 1fr 1fr auto;
+    gap: 14px;
+    align-items: end;
+}
+
+.desktop-signin__field {
+    display: grid;
+    gap: 6px;
+    color: #2b3644;
+    font-size: 0.85rem;
+    font-weight: 600;
+}
+
+.desktop-signin__field input {
+    min-width: 0;
+    height: 38px;
+    box-sizing: border-box;
+    padding: 7px 9px;
+    border: 1px solid #bac4d0;
+    border-radius: 6px;
+    color: #18212f;
+    font: inherit;
+    font-weight: 400;
+}
+
+.desktop-signin__submit {
+    min-height: 38px;
+    padding: 0 14px;
+    border: 1px solid #18406b;
+    border-radius: 6px;
+    background: #18406b;
+    color: #ffffff;
+    font: inherit;
+    font-size: 0.9rem;
+    font-weight: 650;
+}
+
+.desktop-signin__submit:disabled {
+    border-color: #8da3b8;
+    background: #8da3b8;
+}
+
+@media (max-width: 860px) {
+    .desktop-signin,
+    .desktop-signin__form {
+        grid-template-columns: 1fr;
+    }
 }

--- a/tests/Unit/App.Desktop.Tests/DesktopCompositionRootTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopCompositionRootTests.cs
@@ -9,7 +9,7 @@ namespace App.Desktop.Tests;
 public sealed class DesktopCompositionRootTests
 {
     [Fact]
-    public void BuildServicesResolvesDesktopAuthAndSessionBoundaries()
+    public void BuildServicesWithoutConfiguredBaseAddressKeepsUnavailableAuthClient()
     {
         using var services = DesktopCompositionRoot.BuildServices();
 
@@ -17,5 +17,36 @@ public sealed class DesktopCompositionRootTests
         Assert.IsType<DesktopSessionState>(services.GetRequiredService<IDesktopAuthSessionBoundary>());
         Assert.IsType<DisabledDesktopSessionStore>(services.GetRequiredService<IDesktopSessionStore>());
         Assert.IsType<UnavailableDesktopAuthClient>(services.GetRequiredService<IDesktopAuthClient>());
+        Assert.IsType<DesktopSignInService>(services.GetRequiredService<IDesktopSignInService>());
+    }
+
+    [Fact]
+    public void BuildServicesWithConfiguredBaseAddressResolvesHttpAuthClient()
+    {
+        using var services = DesktopCompositionRoot.BuildServices(
+            DesktopAuthOptions.FromControlPlaneBaseAddress("https://control-plane.local"));
+
+        Assert.IsType<HttpDesktopAuthClient>(services.GetRequiredService<IDesktopAuthClient>());
+        Assert.IsType<DisabledDesktopSessionStore>(services.GetRequiredService<IDesktopSessionStore>());
+        Assert.True(services.GetRequiredService<DesktopAuthOptions>().IsControlPlaneSignInConfigured);
+        Assert.Equal(
+            new Uri("https://control-plane.local"),
+            services.GetRequiredService<HttpClient>().BaseAddress);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not a uri")]
+    [InlineData("ftp://control-plane.local")]
+    [InlineData("https://operator:secret@control-plane.local")]
+    [InlineData("https://control-plane.local?token=secret")]
+    [InlineData("https://control-plane.local#secret")]
+    public void InvalidBaseAddressOptionsKeepUnavailableAuthClient(string baseAddress)
+    {
+        using var services = DesktopCompositionRoot.BuildServices(
+            DesktopAuthOptions.FromControlPlaneBaseAddress(baseAddress));
+
+        Assert.IsType<UnavailableDesktopAuthClient>(services.GetRequiredService<IDesktopAuthClient>());
+        Assert.False(services.GetRequiredService<DesktopAuthOptions>().IsControlPlaneSignInConfigured);
     }
 }

--- a/tests/Unit/App.Desktop.Tests/DesktopCompositionRootTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopCompositionRootTests.cs
@@ -35,12 +35,28 @@ public sealed class DesktopCompositionRootTests
     }
 
     [Theory]
+    [InlineData("https://control-plane.local")]
+    [InlineData("https://control-plane.local/")]
+    [InlineData("http://control-plane.local")]
+    [InlineData("http://control-plane.local/")]
+    [InlineData("http://192.168.1.66/")]
+    public void RootBaseAddressOptionsAreConfigured(string baseAddress)
+    {
+        var options = DesktopAuthOptions.FromControlPlaneBaseAddress(baseAddress);
+
+        Assert.True(options.IsControlPlaneSignInConfigured);
+        Assert.NotNull(options.ControlPlaneBaseAddress);
+    }
+
+    [Theory]
     [InlineData("")]
     [InlineData("not a uri")]
     [InlineData("ftp://control-plane.local")]
     [InlineData("https://operator:secret@control-plane.local")]
     [InlineData("https://control-plane.local?token=secret")]
     [InlineData("https://control-plane.local#secret")]
+    [InlineData("https://control-plane.local/prefix")]
+    [InlineData("https://control-plane.local/prefix/")]
     public void InvalidBaseAddressOptionsKeepUnavailableAuthClient(string baseAddress)
     {
         using var services = DesktopCompositionRoot.BuildServices(

--- a/tests/Unit/App.Desktop.Tests/DesktopSignInServiceTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopSignInServiceTests.cs
@@ -1,0 +1,179 @@
+using App.Desktop.Boundaries;
+using App.Desktop.Services.Auth;
+
+namespace App.Desktop.Tests;
+
+public sealed class DesktopSignInServiceTests
+{
+    [Fact]
+    public async Task SuccessfulSignInCallsAuthClientAndUpdatesSessionState()
+    {
+        var session = CreateAuthenticatedSession();
+        var authClient = new RecordingAuthClient(DesktopAuthResult.Succeeded(session));
+        var sessionState = new DesktopSessionState(new DisabledDesktopSessionStore());
+        var service = new DesktopSignInService(authClient, sessionState);
+
+        var result = await service.SignInAsync(
+            " desktop-operator ",
+            CreateSensitiveValue("password"),
+            session.DeviceId,
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(DesktopSignInStatus.Succeeded, result.Status);
+        Assert.True(result.Session!.IsSignedIn);
+        Assert.Equal(session.UserId, sessionState.Current.UserId);
+        Assert.Equal(session.DisplayName, sessionState.Current.DisplayName);
+        Assert.Equal(1, authClient.CallCount);
+        Assert.Equal("desktop-operator", authClient.LastRequest!.Login);
+        Assert.DoesNotContain(session.AccessToken, result.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(session.RefreshToken!, result.ToString(), StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [MemberData(nameof(FailedAuthResults))]
+    public async Task FailedSignInDoesNotMutateExistingSignedInSession(DesktopAuthResult authResult)
+    {
+        var existingSession = CreateAuthenticatedSession();
+        var authClient = new RecordingAuthClient(authResult);
+        var sessionState = new DesktopSessionState(new DisabledDesktopSessionStore());
+        await sessionState.SetSignedInAsync(existingSession, CancellationToken.None);
+        var originalSnapshot = sessionState.Current;
+        var service = new DesktopSignInService(authClient, sessionState);
+
+        var result = await service.SignInAsync(
+            "desktop-operator",
+            CreateSensitiveValue("password"),
+            Guid.NewGuid(),
+            CancellationToken.None);
+
+        Assert.False(result.IsSuccess);
+        Assert.Same(originalSnapshot, sessionState.Current);
+        Assert.Equal(existingSession.UserId, sessionState.Current.UserId);
+        Assert.Equal(existingSession.DisplayName, sessionState.Current.DisplayName);
+    }
+
+    [Fact]
+    public async Task ErrorResultTextDoesNotExposeCredentialsTokensAuthorizationOrRawMessages()
+    {
+        var login = $"desktop-{Guid.NewGuid():N}";
+        var password = CreateSensitiveValue("password");
+        var accessToken = CreateSensitiveValue("access");
+        var refreshToken = CreateSensitiveValue("refresh");
+        const string authorizationHeader = "Authorization: Bearer secret-token";
+        const string rawBody = "{\"accessToken\":\"secret-token\"}";
+        const string rawException = "HttpRequestException secret detail";
+        string unsafeText = string.Join(
+            ' ',
+            login,
+            password,
+            accessToken,
+            refreshToken,
+            authorizationHeader,
+            rawBody,
+            rawException);
+        var authClient = new RecordingAuthClient(DesktopAuthResult.Failed(unsafeText, unsafeText));
+        var service = new DesktopSignInService(
+            authClient,
+            new DesktopSessionState(new DisabledDesktopSessionStore()));
+
+        var result = await service.SignInAsync(
+            login,
+            password,
+            Guid.NewGuid(),
+            CancellationToken.None);
+
+        Assert.Equal(DesktopSignInStatus.Failed, result.Status);
+        Assert.DoesNotContain(login, result.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(password, result.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(accessToken, result.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(refreshToken, result.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(authorizationHeader, result.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(rawBody, result.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(rawException, result.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(unsafeText, result.Error!.Code, StringComparison.Ordinal);
+        Assert.DoesNotContain(unsafeText, result.Error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ViewModelClearsPasswordAfterAttempt()
+    {
+        var password = CreateSensitiveValue("password");
+        var viewModel = new DesktopSignInViewModel(new DesktopSignInService(
+            new RecordingAuthClient(DesktopAuthResult.Rejected("invalid_credentials", "Rejected.")),
+            new DesktopSessionState(new DisabledDesktopSessionStore())))
+        {
+            Login = "desktop-operator",
+            Password = password
+        };
+
+        _ = await viewModel.SignInAsync(CancellationToken.None);
+
+        Assert.Equal(string.Empty, viewModel.Password);
+        Assert.DoesNotContain(password, viewModel.LastResult.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MissingCredentialsStayRejectedWithoutCallingAuthClient()
+    {
+        var authClient = new RecordingAuthClient(
+            DesktopAuthResult.Succeeded(CreateAuthenticatedSession()));
+        var service = new DesktopSignInService(
+            authClient,
+            new DesktopSessionState(new DisabledDesktopSessionStore()));
+
+        var result = await service.SignInAsync(
+            "desktop-operator",
+            "",
+            Guid.NewGuid(),
+            CancellationToken.None);
+
+        Assert.Equal(DesktopSignInStatus.Rejected, result.Status);
+        Assert.Equal(0, authClient.CallCount);
+    }
+
+    public static IEnumerable<object[]> FailedAuthResults()
+    {
+        yield return [DesktopAuthResult.Rejected("invalid_credentials", "Rejected.")];
+        yield return [DesktopAuthResult.Failed("sign_in_failed", "Failed.")];
+        yield return [DesktopAuthResult.Unavailable("sign_in_unavailable", "Unavailable.")];
+    }
+
+    private static DesktopAuthenticatedSession CreateAuthenticatedSession()
+    {
+        return DesktopAuthenticatedSession.Create(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            "Desktop Operator",
+            CreateSensitiveValue("access"),
+            CreateSensitiveValue("refresh"),
+            DateTimeOffset.UtcNow,
+            DateTimeOffset.UtcNow.AddMinutes(15),
+            isOfflineRestricted: false);
+    }
+
+    private static string CreateSensitiveValue(string prefix)
+    {
+        return $"{prefix}-{Guid.NewGuid():N}";
+    }
+
+    private sealed class RecordingAuthClient(DesktopAuthResult result) : IDesktopAuthClient
+    {
+        public int CallCount { get; private set; }
+
+        public DesktopSignInRequest? LastRequest { get; private set; }
+
+        public ValueTask<DesktopAuthResult> SignInAsync(
+            DesktopSignInRequest request,
+            CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(request);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            CallCount++;
+            LastRequest = request;
+            return ValueTask.FromResult(result);
+        }
+    }
+}


### PR DESCRIPTION
﻿## Coder
Coder 1 acting as Coder 2 / Desktop Client

## Task ID
S2-51 Desktop SignIn Runtime Enablement

## Module
App.Desktop / SignIn runtime enablement

## Scope
- Enables a narrow, online-only desktop SignIn runtime slice on top of S2-50 auth/session boundaries.
- Adds App.Desktop auth options for a safe control-plane base address gate.
- Wires HttpDesktopAuthClient only when a valid base address is configured.
- Keeps UnavailableDesktopAuthClient as the default fallback.
- Adds a minimal App.Desktop-local SignIn surface and testable service/view-model orchestration.
- Uses DesktopSessionState.SetSignedInAsync on successful sign-in.

## Changed areas
- src/App.Desktop/**
- tests/Unit/App.Desktop.Tests/**

## Base main SHA
29757d8dbc0abbd40dadbb94360c46b3e469fec7

## Coordination log entries reviewed
TEAM COORDINATION LOG issue #89 reviewed, including relevant entries:
- PR #105 S2-48 Desktop Application Skeleton Task Card
- PR #107 S2-48 Desktop Application Skeleton
- PR #110 S2-49A Desktop Skeleton Launch Fix
- PR #114 S2-50 Desktop Auth Session Boundary Task Card
- PR #115 S2-50 desktop auth session boundary runtime
- PR #117 S2-51 Desktop SignIn Runtime Enablement Task Card
- Android businessObjectKey decision context entries were also read as out-of-scope context.

## Handoff/task cards reviewed
- 00_START_HERE_README.txt
- 01_MASTER_PLAN_AND_ARCHITECTURE.txt
- 02_SHARED_RULES_AND_PROTOCOLS.txt
- 04_GITHUB_WORKFLOW_AND_INFRA_RULES.txt
- docs/task-cards/S2-48_desktop-application-skeleton-task-card.txt
- docs/handoffs/S2_48_DESKTOP_APPLICATION_SKELETON_PROMPT.md
- docs/task-cards/S2-49A_desktop-skeleton-launch-fix.txt
- docs/task-cards/S2-50_desktop-auth-session-boundary-task-card.txt
- docs/handoffs/S2_50_DESKTOP_AUTH_SESSION_BOUNDARY_PROMPT.md
- docs/task-cards/S2-51_desktop-signin-runtime-enablement-task-card.txt
- docs/handoffs/S2_51_DESKTOP_SIGNIN_RUNTIME_ENABLEMENT_PROMPT.md
- src/App.Desktop/**
- tests/Unit/App.Desktop.Tests/**

## Contracts
No shared DTO/contract changes. Uses only the existing S2-50 desktop auth client boundary for the existing /api/auth/sign-in endpoint shape.

## Migrations
No migrations.

## Feature flags/options
No server feature flags. Added App.Desktop-local DesktopAuthOptions gated by AA_DESKTOP_CONTROL_PLANE_BASE_ADDRESS. Missing/invalid values keep SignIn unavailable. Userinfo/query/fragment and non-http(s) base addresses are rejected.

## API impact
No App.Api changes, no API route changes, no control-plane contract changes.

## Web impact
No App.Web changes.

## Android impact
No App.Mobile.Android changes.

## Offline behavior
S2-51 remains online-only. No offline queue, cached-credential login, offline upload, or offline SignIn expansion.

## Rollback
Revert this PR. Scope is limited to App.Desktop runtime/test files and does not require DB, API, deploy, or contract rollback.

## Validation
- git diff --check: passed
- dotnet restore AnalyticsAutomation-Core.sln -nologo: passed
- dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore: passed
- dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal: passed, 0 warnings/errors
- dotnet build AnalyticsAutomation-Core.sln -nologo -v minimal: passed, 216 existing analyzer warnings, 0 errors
- dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal: passed, 33/33 tests
- hidden Unicode scanner over changed text files: passed
- App.Desktop bounded launch smoke: passed; process stayed alive for 10 seconds and was stopped, no credentials entered

## Handoff docs
Reviewed S2-48/S2-50/S2-51 task cards and handoff prompts listed above. No docs changed in this runtime PR.

## Next step
Review the narrow SignIn runtime slice. A later approved task is still needed for real Windows secure storage and any upload/GroupTree/PreUploadCheck/site upload/UploadReceipt work.

## NO-GO / Deferred
- No upload flow
- No GroupTree UI/runtime
- No PreUploadCheck UI/runtime
- No site upload
- No UploadReceipt
- No offline queue
- No duplicate/fraud/admin review UI
- No App.Api/contracts/migrations/deploy/workflow changes
- No App.Web/App.Mobile.Android/App.UI.Shared changes
- No real Windows secure storage
- No plaintext token persistence
- No refresh-token behavior beyond carrying the existing response value in the existing session model
---

Automated merge gate note:
- POST-SYNC MAIN SHA: 29757d8dbc0abbd40dadbb94360c46b3e469fec7
- TEAM COORDINATION LOG issue #89 re-read during merge gate.
- Revalidation in merge gate:
  - git diff --check
  - dotnet restore AnalyticsAutomation-Core.sln -nologo
  - dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore
  - dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal
  - dotnet build AnalyticsAutomation-Core.sln -nologo -v minimal
  - dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal
- No deploy.