### PR TITLE
S2-52 identity bootstrap first admin runtime

### DIFF
--- a/tests/Integration/App.Maintenance/AppMaintenanceProgramTests.cs
+++ b/tests/Integration/App.Maintenance/AppMaintenanceProgramTests.cs
@@ -1,4 +1,5 @@
 using App.Maintenance.IncidentRoutingAdmins;
+using App.Maintenance.IdentityBootstrap;
 using App.Maintenance.IntegrationAccounts;
 
 using BuildingBlocks.Infrastructure.Persistence;
@@ -18,6 +19,118 @@ namespace App.Maintenance.Tests;
 
 public sealed class AppMaintenanceProgramTests
 {
+    [Fact]
+    public async Task RunAsyncIdentityBootstrapFirstAdminWritesSafeOutputOnly()
+    {
+        const string login = "first-admin-smoke";
+        var password = CreateEphemeralSecret();
+
+        using var bootstrapEnabledScope = new EnvironmentVariableScope(
+            FirstAdminBootstrapMaintenanceService.EnabledEnvironmentVariableName,
+            "true");
+        using var loginScope = new EnvironmentVariableScope(
+            FirstAdminBootstrapMaintenanceService.LoginEnvironmentVariableName,
+            login);
+        using var passwordScope = new EnvironmentVariableScope(
+            FirstAdminBootstrapMaintenanceService.PasswordEnvironmentVariableName,
+            password);
+        using var displayNameScope = new EnvironmentVariableScope(
+            FirstAdminBootstrapMaintenanceService.DisplayNameEnvironmentVariableName,
+            "First Admin Smoke");
+
+        var databaseName = $"app-maintenance-program-first-admin-{Guid.NewGuid():N}";
+        var databaseRoot = new InMemoryDatabaseRoot();
+
+        await using (var setupContext = CreateDbContext(databaseName, databaseRoot))
+        {
+            await SeedRoleAndRootAsync(setupContext);
+        }
+
+        var stdout = new StringWriter();
+        var stderr = new StringWriter();
+
+        var exitCode = await AppMaintenanceProgram.RunAsync(
+            ["identity-bootstrap", "first-admin"],
+            () => CreateHost(databaseName, databaseRoot),
+            stdout,
+            stderr,
+            CancellationToken.None);
+
+        await using var assertContext = CreateDbContext(databaseName, databaseRoot);
+        var user = await assertContext.AuthUsers
+            .SingleAsync(item => item.NormalizedLogin == "FIRST-ADMIN-SMOKE");
+
+        var standardOutput = stdout.ToString();
+        var errorOutput = stderr.ToString();
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(string.Empty, errorOutput);
+        Assert.Contains("login: first-admin-smoke", standardOutput, StringComparison.Ordinal);
+        Assert.Contains("status: created", standardOutput, StringComparison.Ordinal);
+        Assert.Contains("role: platform_owner", standardOutput, StringComparison.Ordinal);
+        Assert.Contains("role-link: created", standardOutput, StringComparison.Ordinal);
+        Assert.Contains("group-node: root", standardOutput, StringComparison.Ordinal);
+        Assert.Contains("assignment: created", standardOutput, StringComparison.Ordinal);
+        Assert.Contains("audit: first_admin_bootstrapped", standardOutput, StringComparison.Ordinal);
+        Assert.DoesNotContain(password, standardOutput, StringComparison.Ordinal);
+        Assert.DoesNotContain(user.PasswordHash, standardOutput, StringComparison.Ordinal);
+        Assert.DoesNotContain("accessToken", standardOutput, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("refreshToken", standardOutput, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Authorization", standardOutput, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task RunAsyncIdentityBootstrapFirstAdminFailsSafelyWhenDisabled()
+    {
+        using var bootstrapEnabledScope = new EnvironmentVariableScope(
+            FirstAdminBootstrapMaintenanceService.EnabledEnvironmentVariableName,
+            null);
+        using var loginScope = new EnvironmentVariableScope(
+            FirstAdminBootstrapMaintenanceService.LoginEnvironmentVariableName,
+            "first-admin-smoke");
+        using var passwordScope = new EnvironmentVariableScope(
+            FirstAdminBootstrapMaintenanceService.PasswordEnvironmentVariableName,
+            CreateEphemeralSecret());
+        using var displayNameScope = new EnvironmentVariableScope(
+            FirstAdminBootstrapMaintenanceService.DisplayNameEnvironmentVariableName,
+            null);
+
+        var databaseName = $"app-maintenance-program-first-admin-disabled-{Guid.NewGuid():N}";
+        var databaseRoot = new InMemoryDatabaseRoot();
+
+        await using (var setupContext = CreateDbContext(databaseName, databaseRoot))
+        {
+            await SeedRoleAndRootAsync(setupContext);
+        }
+
+        var stdout = new StringWriter();
+        var stderr = new StringWriter();
+
+        var exitCode = await AppMaintenanceProgram.RunAsync(
+            ["identity-bootstrap", "first-admin"],
+            () => CreateHost(databaseName, databaseRoot),
+            stdout,
+            stderr,
+            CancellationToken.None);
+
+        var standardOutput = stdout.ToString();
+        var errorOutput = stderr.ToString();
+
+        await using var assertContext = CreateDbContext(databaseName, databaseRoot);
+
+        Assert.Equal(1, exitCode);
+        Assert.Equal(string.Empty, standardOutput);
+        Assert.Contains(
+            FirstAdminBootstrapMaintenanceService.EnabledEnvironmentVariableName,
+            errorOutput,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("accessToken", errorOutput, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("refreshToken", errorOutput, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Authorization", errorOutput, StringComparison.OrdinalIgnoreCase);
+        Assert.False(await assertContext.AuthUsers.AnyAsync());
+        Assert.False(await assertContext.AuditRecords.AnyAsync());
+    }
+
     [Fact]
     public async Task RunAsyncIncidentRoutingAdminUpsertWritesSafeOutputOnly()
     {
@@ -118,6 +231,7 @@ public sealed class AppMaintenanceProgramTests
             options => options.UseInMemoryDatabase(databaseName, databaseRoot));
         builder.Services.AddSingleton<IPasswordHasher<AuthUser>, PasswordHasher<AuthUser>>();
         builder.Services.AddScoped<IncidentRoutingAdminMaintenanceService>();
+        builder.Services.AddScoped<FirstAdminBootstrapMaintenanceService>();
         builder.Services.AddScoped<IntegrationAccountMaintenanceService>();
 
         return builder.Build();
@@ -152,6 +266,11 @@ public sealed class AppMaintenanceProgramTests
             .Options;
 
         return new PlatformDbContext(options);
+    }
+
+    private static string CreateEphemeralSecret()
+    {
+        return $"{Guid.NewGuid():N}{Guid.NewGuid():N}";
     }
 
     private sealed class EnvironmentVariableScope : IDisposable

--- a/tests/Integration/App.Maintenance/FirstAdminBootstrapMaintenanceServiceTests.cs
+++ b/tests/Integration/App.Maintenance/FirstAdminBootstrapMaintenanceServiceTests.cs
@@ -96,6 +96,90 @@ public sealed class FirstAdminBootstrapMaintenanceServiceTests
     }
 
     [Fact]
+    public async Task BootstrapAsyncCreatesFirstAdminWhenPlatformOwnerServiceAccountHasNoRootAssignment()
+    {
+        const string login = "first-admin-smoke";
+        const string normalizedLogin = "FIRST-ADMIN-SMOKE";
+        var password = CreateEphemeralSecret();
+
+        using var environment = new FirstAdminBootstrapEnvironment(
+            enabled: "true",
+            login,
+            password,
+            displayName: null);
+
+        using var dbContext = CreateDbContext();
+        var role = new AuthRole
+        {
+            Id = Guid.NewGuid(),
+            Code = FirstAdminBootstrapMaintenanceService.PlatformOwnerRoleCode,
+            Name = "Platform Owner"
+        };
+        var rootNode = new GroupNode
+        {
+            Id = Guid.NewGuid(),
+            Code = FirstAdminBootstrapMaintenanceService.RootGroupNodeCode,
+            Name = "Root",
+            Depth = 0,
+            IsActive = true
+        };
+        var serviceAccount = new AuthUser
+        {
+            Id = Guid.NewGuid(),
+            Login = "integration-web-android",
+            NormalizedLogin = "INTEGRATION-WEB-ANDROID",
+            DisplayName = "Web/Android Integration Account",
+            PasswordHash = "service-hash",
+            IsActive = true,
+            CurrentGroupNodeId = rootNode.Id,
+            CreatedAtUtc = DateTimeOffset.UtcNow.AddDays(-1)
+        };
+
+        serviceAccount.UserRoles.Add(new AuthUserRole
+        {
+            UserId = serviceAccount.Id,
+            RoleId = role.Id
+        });
+
+        dbContext.AuthRoles.Add(role);
+        dbContext.GroupNodes.Add(rootNode);
+        dbContext.AuthUsers.Add(serviceAccount);
+        await dbContext.SaveChangesAsync();
+
+        var passwordHasher = new PasswordHasher<AuthUser>();
+        var service = new FirstAdminBootstrapMaintenanceService(dbContext, passwordHasher);
+
+        var result = await service.BootstrapAsync(CancellationToken.None);
+
+        dbContext.ChangeTracker.Clear();
+
+        var users = await dbContext.AuthUsers
+            .Include(item => item.UserRoles)
+            .OrderBy(item => item.Login)
+            .ToArrayAsync();
+        var createdAdmin = users.Single(item => item.NormalizedLogin == normalizedLogin);
+        var unchangedServiceAccount = users.Single(item => item.NormalizedLogin == "INTEGRATION-WEB-ANDROID");
+        var assignment = await dbContext.GroupAdminAssignments
+            .SingleAsync(item => item.GroupNodeId == rootNode.Id && item.UserId == createdAdmin.Id);
+        var auditRecord = await dbContext.AuditRecords.SingleAsync();
+
+        Assert.Equal(FirstAdminBootstrapStatus.Created, result.Status);
+        Assert.Equal(login, result.Login);
+        Assert.Equal(2, users.Length);
+        Assert.Equal("service-hash", unchangedServiceAccount.PasswordHash);
+        Assert.Single(createdAdmin.UserRoles);
+        Assert.Equal(role.Id, createdAdmin.UserRoles.Single().RoleId);
+        Assert.Equal(rootNode.Id, assignment.GroupNodeId);
+        Assert.Equal(createdAdmin.Id, assignment.UserId);
+        Assert.NotEqual(
+            PasswordVerificationResult.Failed,
+            passwordHasher.VerifyHashedPassword(createdAdmin, createdAdmin.PasswordHash, password));
+        Assert.Equal("first_admin_bootstrapped", auditRecord.Action);
+        Assert.Equal(createdAdmin.Id, auditRecord.SubjectUserId);
+        Assert.DoesNotContain(password, auditRecord.PayloadJson, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task BootstrapAsyncSkipsWithoutPasswordChangeWhenActivePlatformOwnerAlreadyExists()
     {
         const string requestedLogin = "requested-first-admin";
@@ -143,6 +227,12 @@ public sealed class FirstAdminBootstrapMaintenanceServiceTests
         dbContext.AuthRoles.Add(role);
         dbContext.GroupNodes.Add(rootNode);
         dbContext.AuthUsers.Add(existingAdmin);
+        dbContext.GroupAdminAssignments.Add(new GroupAdminAssignment
+        {
+            GroupNodeId = rootNode.Id,
+            UserId = existingAdmin.Id,
+            AssignedAtUtc = DateTimeOffset.UtcNow.AddDays(-1)
+        });
         await dbContext.SaveChangesAsync();
 
         var service = new FirstAdminBootstrapMaintenanceService(
@@ -166,7 +256,7 @@ public sealed class FirstAdminBootstrapMaintenanceServiceTests
         Assert.Equal("old-hash", user.PasswordHash);
         Assert.Equal(1, await dbContext.AuthUsers.CountAsync());
         Assert.Equal(1, await dbContext.AuthUserRoles.CountAsync());
-        Assert.False(await dbContext.GroupAdminAssignments.AnyAsync());
+        Assert.Equal(1, await dbContext.GroupAdminAssignments.CountAsync());
         Assert.Equal("first_admin_bootstrap_skipped_existing_admin", auditRecord.Action);
         Assert.DoesNotContain(password, auditRecord.PayloadJson, StringComparison.Ordinal);
         Assert.DoesNotContain("accessToken", auditRecord.PayloadJson, StringComparison.OrdinalIgnoreCase);

--- a/tests/Integration/App.Maintenance/FirstAdminBootstrapMaintenanceServiceTests.cs
+++ b/tests/Integration/App.Maintenance/FirstAdminBootstrapMaintenanceServiceTests.cs
@@ -1,0 +1,324 @@
+using App.Maintenance.IdentityBootstrap;
+
+using BuildingBlocks.Infrastructure.Observability;
+using BuildingBlocks.Infrastructure.Persistence;
+using BuildingBlocks.Infrastructure.Persistence.Entities.Auth;
+using BuildingBlocks.Infrastructure.Persistence.Entities.GroupTree;
+
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+
+using Xunit;
+
+namespace App.Maintenance.Tests;
+
+public sealed class FirstAdminBootstrapMaintenanceServiceTests
+{
+    [Fact]
+    public async Task BootstrapAsyncCreatesFirstAdminWithRootGroupRoleAssignmentAndAudit()
+    {
+        const string login = "first-admin-smoke";
+        const string normalizedLogin = "FIRST-ADMIN-SMOKE";
+        const string displayName = "First Admin Smoke";
+        var password = CreateEphemeralSecret();
+
+        using var environment = new FirstAdminBootstrapEnvironment(
+            enabled: "true",
+            login,
+            password,
+            displayName);
+
+        using var dbContext = CreateDbContext();
+        var role = new AuthRole
+        {
+            Id = Guid.NewGuid(),
+            Code = FirstAdminBootstrapMaintenanceService.PlatformOwnerRoleCode,
+            Name = "Platform Owner"
+        };
+        var rootNode = new GroupNode
+        {
+            Id = Guid.NewGuid(),
+            Code = FirstAdminBootstrapMaintenanceService.RootGroupNodeCode,
+            Name = "Root",
+            Depth = 0,
+            IsActive = true
+        };
+
+        dbContext.AuthRoles.Add(role);
+        dbContext.GroupNodes.Add(rootNode);
+        await dbContext.SaveChangesAsync();
+
+        var passwordHasher = new PasswordHasher<AuthUser>();
+        var service = new FirstAdminBootstrapMaintenanceService(dbContext, passwordHasher);
+
+        var result = await service.BootstrapAsync(CancellationToken.None);
+
+        dbContext.ChangeTracker.Clear();
+
+        var user = await dbContext.AuthUsers
+            .Include(item => item.UserRoles)
+            .SingleAsync(item => item.NormalizedLogin == normalizedLogin);
+        var assignment = await dbContext.GroupAdminAssignments
+            .SingleAsync(item => item.GroupNodeId == rootNode.Id && item.UserId == user.Id);
+        var auditRecord = await dbContext.AuditRecords.SingleAsync();
+
+        Assert.Equal(FirstAdminBootstrapStatus.Created, result.Status);
+        Assert.Equal(login, result.Login);
+        Assert.Equal(FirstAdminBootstrapMaintenanceService.PlatformOwnerRoleCode, result.AssignedRoleCode);
+        Assert.True(result.WasRoleLinkCreated);
+        Assert.Equal(FirstAdminBootstrapMaintenanceService.RootGroupNodeCode, result.AssignedGroupNodeCode);
+        Assert.True(result.WasAssignmentCreated);
+        Assert.Equal("first_admin_bootstrapped", result.AuditAction);
+        Assert.Equal(login, user.Login);
+        Assert.Equal(displayName, user.DisplayName);
+        Assert.True(user.IsActive);
+        Assert.Equal(rootNode.Id, user.CurrentGroupNodeId);
+        Assert.Single(user.UserRoles);
+        Assert.Equal(role.Id, user.UserRoles.Single().RoleId);
+        Assert.Equal(rootNode.Id, assignment.GroupNodeId);
+        Assert.Equal(user.Id, assignment.UserId);
+        Assert.NotEqual(
+            PasswordVerificationResult.Failed,
+            passwordHasher.VerifyHashedPassword(user, user.PasswordHash, password));
+        Assert.Equal(AuditCategories.Authentication, auditRecord.Category);
+        Assert.Equal("first_admin_bootstrapped", auditRecord.Action);
+        Assert.Equal(user.Id, auditRecord.SubjectUserId);
+        Assert.Equal("auth_user", auditRecord.EntityType);
+        Assert.Equal(user.Id.ToString("D"), auditRecord.EntityId);
+        Assert.Equal("App.Maintenance identity-bootstrap first-admin", auditRecord.RequestPath);
+        Assert.Contains(login, auditRecord.PayloadJson, StringComparison.Ordinal);
+        Assert.DoesNotContain(password, auditRecord.PayloadJson, StringComparison.Ordinal);
+        Assert.DoesNotContain(user.PasswordHash, auditRecord.PayloadJson, StringComparison.Ordinal);
+        Assert.DoesNotContain("accessToken", auditRecord.PayloadJson, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("refreshToken", auditRecord.PayloadJson, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Authorization", auditRecord.PayloadJson, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task BootstrapAsyncSkipsWithoutPasswordChangeWhenActivePlatformOwnerAlreadyExists()
+    {
+        const string requestedLogin = "requested-first-admin";
+        var password = CreateEphemeralSecret();
+
+        using var environment = new FirstAdminBootstrapEnvironment(
+            enabled: "true",
+            login: requestedLogin,
+            password,
+            displayName: null);
+
+        using var dbContext = CreateDbContext();
+        var role = new AuthRole
+        {
+            Id = Guid.NewGuid(),
+            Code = FirstAdminBootstrapMaintenanceService.PlatformOwnerRoleCode,
+            Name = "Platform Owner"
+        };
+        var rootNode = new GroupNode
+        {
+            Id = Guid.NewGuid(),
+            Code = FirstAdminBootstrapMaintenanceService.RootGroupNodeCode,
+            Name = "Root",
+            Depth = 0,
+            IsActive = true
+        };
+        var existingAdmin = new AuthUser
+        {
+            Id = Guid.NewGuid(),
+            Login = "existing-admin",
+            NormalizedLogin = "EXISTING-ADMIN",
+            DisplayName = "Existing Admin",
+            PasswordHash = "old-hash",
+            IsActive = true,
+            CurrentGroupNodeId = rootNode.Id,
+            CreatedAtUtc = DateTimeOffset.UtcNow.AddDays(-1)
+        };
+
+        existingAdmin.UserRoles.Add(new AuthUserRole
+        {
+            UserId = existingAdmin.Id,
+            RoleId = role.Id
+        });
+
+        dbContext.AuthRoles.Add(role);
+        dbContext.GroupNodes.Add(rootNode);
+        dbContext.AuthUsers.Add(existingAdmin);
+        await dbContext.SaveChangesAsync();
+
+        var service = new FirstAdminBootstrapMaintenanceService(
+            dbContext,
+            new PasswordHasher<AuthUser>());
+
+        var result = await service.BootstrapAsync(CancellationToken.None);
+
+        dbContext.ChangeTracker.Clear();
+
+        var user = await dbContext.AuthUsers
+            .Include(item => item.UserRoles)
+            .SingleAsync();
+        var auditRecord = await dbContext.AuditRecords.SingleAsync();
+
+        Assert.Equal(FirstAdminBootstrapStatus.SkippedExistingAdmin, result.Status);
+        Assert.Equal(existingAdmin.Login, result.Login);
+        Assert.False(result.WasRoleLinkCreated);
+        Assert.False(result.WasAssignmentCreated);
+        Assert.Equal("first_admin_bootstrap_skipped_existing_admin", result.AuditAction);
+        Assert.Equal("old-hash", user.PasswordHash);
+        Assert.Equal(1, await dbContext.AuthUsers.CountAsync());
+        Assert.Equal(1, await dbContext.AuthUserRoles.CountAsync());
+        Assert.False(await dbContext.GroupAdminAssignments.AnyAsync());
+        Assert.Equal("first_admin_bootstrap_skipped_existing_admin", auditRecord.Action);
+        Assert.DoesNotContain(password, auditRecord.PayloadJson, StringComparison.Ordinal);
+        Assert.DoesNotContain("accessToken", auditRecord.PayloadJson, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("refreshToken", auditRecord.PayloadJson, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task BootstrapAsyncThrowsWhenBootstrapIsDisabled()
+    {
+        using var environment = new FirstAdminBootstrapEnvironment(
+            enabled: null,
+            login: "first-admin-smoke",
+            password: CreateEphemeralSecret(),
+            displayName: null);
+
+        using var dbContext = CreateDbContext();
+        var service = new FirstAdminBootstrapMaintenanceService(
+            dbContext,
+            new PasswordHasher<AuthUser>());
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.BootstrapAsync(CancellationToken.None));
+
+        Assert.Equal(
+            $"Environment variable {FirstAdminBootstrapMaintenanceService.EnabledEnvironmentVariableName} must be set to 'true' to run first-admin bootstrap.",
+            exception.Message);
+        Assert.False(await dbContext.AuthUsers.AnyAsync());
+        Assert.False(await dbContext.AuditRecords.AnyAsync());
+    }
+
+    [Fact]
+    public async Task BootstrapAsyncThrowsWhenPasswordEnvironmentVariableIsMissing()
+    {
+        using var environment = new FirstAdminBootstrapEnvironment(
+            enabled: "true",
+            login: "first-admin-smoke",
+            password: null,
+            displayName: null);
+
+        using var dbContext = CreateDbContext();
+        var service = new FirstAdminBootstrapMaintenanceService(
+            dbContext,
+            new PasswordHasher<AuthUser>());
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.BootstrapAsync(CancellationToken.None));
+
+        Assert.Equal(
+            $"Environment variable {FirstAdminBootstrapMaintenanceService.PasswordEnvironmentVariableName} is required. The tool does not accept command-line passwords.",
+            exception.Message);
+        Assert.False(await dbContext.AuthUsers.AnyAsync());
+        Assert.False(await dbContext.AuditRecords.AnyAsync());
+    }
+
+    [Fact]
+    public async Task BootstrapAsyncThrowsWhenLoginEnvironmentVariableIsMissing()
+    {
+        using var environment = new FirstAdminBootstrapEnvironment(
+            enabled: "true",
+            login: null,
+            password: CreateEphemeralSecret(),
+            displayName: null);
+
+        using var dbContext = CreateDbContext();
+        var service = new FirstAdminBootstrapMaintenanceService(
+            dbContext,
+            new PasswordHasher<AuthUser>());
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.BootstrapAsync(CancellationToken.None));
+
+        Assert.Equal(
+            $"Environment variable {FirstAdminBootstrapMaintenanceService.LoginEnvironmentVariableName} is required for First admin login.",
+            exception.Message);
+        Assert.False(await dbContext.AuthUsers.AnyAsync());
+        Assert.False(await dbContext.AuditRecords.AnyAsync());
+    }
+
+    private static PlatformDbContext CreateDbContext()
+    {
+        return CreateDbContext(
+            $"first-admin-bootstrap-tests-{Guid.NewGuid():N}",
+            new InMemoryDatabaseRoot());
+    }
+
+    private static string CreateEphemeralSecret()
+    {
+        return $"{Guid.NewGuid():N}{Guid.NewGuid():N}";
+    }
+
+    private static PlatformDbContext CreateDbContext(
+        string databaseName,
+        InMemoryDatabaseRoot databaseRoot)
+    {
+        var options = new DbContextOptionsBuilder<PlatformDbContext>()
+            .UseInMemoryDatabase(databaseName, databaseRoot)
+            .Options;
+
+        return new PlatformDbContext(options);
+    }
+
+    private sealed class FirstAdminBootstrapEnvironment : IDisposable
+    {
+        private readonly EnvironmentVariableScope enabled;
+        private readonly EnvironmentVariableScope login;
+        private readonly EnvironmentVariableScope password;
+        private readonly EnvironmentVariableScope displayName;
+
+        public FirstAdminBootstrapEnvironment(
+            string? enabled,
+            string? login,
+            string? password,
+            string? displayName)
+        {
+            this.enabled = new EnvironmentVariableScope(
+                FirstAdminBootstrapMaintenanceService.EnabledEnvironmentVariableName,
+                enabled);
+            this.login = new EnvironmentVariableScope(
+                FirstAdminBootstrapMaintenanceService.LoginEnvironmentVariableName,
+                login);
+            this.password = new EnvironmentVariableScope(
+                FirstAdminBootstrapMaintenanceService.PasswordEnvironmentVariableName,
+                password);
+            this.displayName = new EnvironmentVariableScope(
+                FirstAdminBootstrapMaintenanceService.DisplayNameEnvironmentVariableName,
+                displayName);
+        }
+
+        public void Dispose()
+        {
+            displayName.Dispose();
+            password.Dispose();
+            login.Dispose();
+            enabled.Dispose();
+        }
+    }
+
+    private sealed class EnvironmentVariableScope : IDisposable
+    {
+        private readonly string name;
+        private readonly string? originalValue;
+
+        public EnvironmentVariableScope(string name, string? value)
+        {
+            this.name = name;
+            originalValue = Environment.GetEnvironmentVariable(name);
+            Environment.SetEnvironmentVariable(name, value);
+        }
+
+        public void Dispose()
+        {
+            Environment.SetEnvironmentVariable(name, originalValue);
+        }
+    }
+}

--- a/tools/App.Maintenance/IdentityBootstrap/FirstAdminBootstrapMaintenanceService.cs
+++ b/tools/App.Maintenance/IdentityBootstrap/FirstAdminBootstrapMaintenanceService.cs
@@ -1,0 +1,281 @@
+using System.Text.Json;
+
+using BuildingBlocks.Infrastructure.Observability;
+using BuildingBlocks.Infrastructure.Persistence;
+using BuildingBlocks.Infrastructure.Persistence.Entities.Audit;
+using BuildingBlocks.Infrastructure.Persistence.Entities.Auth;
+using BuildingBlocks.Infrastructure.Persistence.Entities.GroupTree;
+
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+
+namespace App.Maintenance.IdentityBootstrap;
+
+public sealed class FirstAdminBootstrapMaintenanceService(
+    PlatformDbContext dbContext,
+    IPasswordHasher<AuthUser> passwordHasher)
+{
+    public const string EnabledEnvironmentVariableName = "AA_FIRST_ADMIN_BOOTSTRAP_ENABLED";
+    public const string LoginEnvironmentVariableName = "AA_FIRST_ADMIN_LOGIN";
+    public const string PasswordEnvironmentVariableName = "AA_FIRST_ADMIN_PASSWORD";
+    public const string DisplayNameEnvironmentVariableName = "AA_FIRST_ADMIN_DISPLAY_NAME";
+    public const string PlatformOwnerRoleCode = "platform_owner";
+    public const string RootGroupNodeCode = "root";
+
+    private const string MaintenanceRequestPath = "App.Maintenance identity-bootstrap first-admin";
+
+    public async Task<FirstAdminBootstrapResult> BootstrapAsync(CancellationToken cancellationToken)
+    {
+        EnsureExplicitlyEnabled();
+
+        var login = ReadRequiredText(LoginEnvironmentVariableName, "First admin login", 128);
+        var password = ReadRequiredPassword();
+        var displayName = ReadOptionalText(DisplayNameEnvironmentVariableName, 256) ?? login;
+
+        var role = await dbContext.AuthRoles
+            .SingleOrDefaultAsync(
+                item => item.Code == PlatformOwnerRoleCode,
+                cancellationToken)
+            ?? throw new InvalidOperationException(
+                $"Role '{PlatformOwnerRoleCode}' was not found. Aborting without changes.");
+
+        var rootGroupNode = await dbContext.GroupNodes
+            .SingleOrDefaultAsync(
+                item => item.Code == RootGroupNodeCode && item.IsActive,
+                cancellationToken)
+            ?? throw new InvalidOperationException(
+                $"Active group node '{RootGroupNodeCode}' was not found. Aborting without changes.");
+
+        var existingActiveAdmin = await dbContext.AuthUsers
+            .AsNoTracking()
+            .Where(item => item.IsActive)
+            .Where(item => item.UserRoles.Any(roleLink => roleLink.RoleId == role.Id))
+            .OrderBy(item => item.CreatedAtUtc)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (existingActiveAdmin is not null)
+        {
+            await WriteAuditRecordAsync(
+                "first_admin_bootstrap_skipped_existing_admin",
+                existingActiveAdmin.Id,
+                existingActiveAdmin.Login,
+                role.Code,
+                rootGroupNode.Code,
+                wasCreated: false,
+                wasRoleLinkCreated: false,
+                wasAssignmentCreated: false,
+                cancellationToken);
+
+            await dbContext.SaveChangesAsync(cancellationToken);
+
+            return new FirstAdminBootstrapResult(
+                existingActiveAdmin.Login,
+                FirstAdminBootstrapStatus.SkippedExistingAdmin,
+                role.Code,
+                WasRoleLinkCreated: false,
+                rootGroupNode.Code,
+                WasAssignmentCreated: false,
+                "first_admin_bootstrap_skipped_existing_admin");
+        }
+
+        var normalizedLogin = NormalizeLogin(login);
+        var user = await dbContext.AuthUsers
+            .Include(item => item.UserRoles)
+            .SingleOrDefaultAsync(
+                item => item.NormalizedLogin == normalizedLogin,
+                cancellationToken);
+
+        var wasCreated = user is null;
+        if (user is null)
+        {
+            user = new AuthUser
+            {
+                Id = Guid.NewGuid(),
+                CreatedAtUtc = DateTimeOffset.UtcNow
+            };
+
+            dbContext.AuthUsers.Add(user);
+        }
+
+        user.Login = login;
+        user.NormalizedLogin = normalizedLogin;
+        user.DisplayName = displayName;
+        user.IsActive = true;
+        user.CurrentGroupNodeId = rootGroupNode.Id;
+        user.PasswordHash = passwordHasher.HashPassword(user, password);
+
+        var wasRoleLinkCreated = false;
+        if (!user.UserRoles.Any(item => item.RoleId == role.Id))
+        {
+            user.UserRoles.Add(new AuthUserRole
+            {
+                UserId = user.Id,
+                RoleId = role.Id
+            });
+
+            wasRoleLinkCreated = true;
+        }
+
+        var assignment = await dbContext.GroupAdminAssignments
+            .SingleOrDefaultAsync(
+                item => item.GroupNodeId == rootGroupNode.Id && item.UserId == user.Id,
+                cancellationToken);
+
+        var wasAssignmentCreated = assignment is null;
+        if (assignment is null)
+        {
+            dbContext.GroupAdminAssignments.Add(new GroupAdminAssignment
+            {
+                GroupNodeId = rootGroupNode.Id,
+                UserId = user.Id,
+                AssignedAtUtc = DateTimeOffset.UtcNow
+            });
+        }
+
+        await WriteAuditRecordAsync(
+            "first_admin_bootstrapped",
+            user.Id,
+            user.Login,
+            role.Code,
+            rootGroupNode.Code,
+            wasCreated,
+            wasRoleLinkCreated,
+            wasAssignmentCreated,
+            cancellationToken);
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return new FirstAdminBootstrapResult(
+            user.Login,
+            wasCreated ? FirstAdminBootstrapStatus.Created : FirstAdminBootstrapStatus.Updated,
+            role.Code,
+            wasRoleLinkCreated,
+            rootGroupNode.Code,
+            wasAssignmentCreated,
+            "first_admin_bootstrapped");
+    }
+
+    private Task WriteAuditRecordAsync(
+        string action,
+        Guid subjectUserId,
+        string login,
+        string roleCode,
+        string groupNodeCode,
+        bool wasCreated,
+        bool wasRoleLinkCreated,
+        bool wasAssignmentCreated,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var payload = new
+        {
+            login,
+            roleCode,
+            groupNodeCode,
+            wasCreated,
+            wasRoleLinkCreated,
+            wasAssignmentCreated
+        };
+
+        dbContext.AuditRecords.Add(new AuditRecord
+        {
+            Id = Guid.NewGuid(),
+            Category = AuditCategories.Authentication,
+            Action = action,
+            SubjectUserId = subjectUserId,
+            EntityType = "auth_user",
+            EntityId = subjectUserId.ToString("D"),
+            RequestPath = MaintenanceRequestPath,
+            PayloadJson = JsonSerializer.Serialize(payload),
+            OccurredAtUtc = DateTimeOffset.UtcNow
+        });
+
+        return Task.CompletedTask;
+    }
+
+    private static void EnsureExplicitlyEnabled()
+    {
+        var value = Environment.GetEnvironmentVariable(EnabledEnvironmentVariableName);
+
+        if (!string.Equals(value, "true", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                $"Environment variable {EnabledEnvironmentVariableName} must be set to 'true' to run first-admin bootstrap.");
+        }
+    }
+
+    private static string ReadRequiredPassword()
+    {
+        var password = Environment.GetEnvironmentVariable(PasswordEnvironmentVariableName);
+        if (string.IsNullOrWhiteSpace(password))
+        {
+            throw new InvalidOperationException(
+                $"Environment variable {PasswordEnvironmentVariableName} is required. The tool does not accept command-line passwords.");
+        }
+
+        return password;
+    }
+
+    private static string ReadRequiredText(
+        string environmentVariableName,
+        string valueName,
+        int maxLength)
+    {
+        var value = ReadOptionalText(environmentVariableName, maxLength);
+        if (value is null)
+        {
+            throw new InvalidOperationException(
+                $"Environment variable {environmentVariableName} is required for {valueName}.");
+        }
+
+        return value;
+    }
+
+    private static string? ReadOptionalText(
+        string environmentVariableName,
+        int maxLength)
+    {
+        var value = Environment.GetEnvironmentVariable(environmentVariableName);
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        value = value.Trim();
+        if (value.Length > maxLength)
+        {
+            throw new InvalidOperationException(
+                $"Environment variable {environmentVariableName} must be {maxLength} characters or fewer.");
+        }
+
+        if (value.Any(char.IsControl))
+        {
+            throw new InvalidOperationException(
+                $"Environment variable {environmentVariableName} must not contain control characters.");
+        }
+
+        return value;
+    }
+
+    private static string NormalizeLogin(string login)
+    {
+        return login.Trim().ToUpperInvariant();
+    }
+}
+
+public enum FirstAdminBootstrapStatus
+{
+    Created,
+    Updated,
+    SkippedExistingAdmin
+}
+
+public sealed record FirstAdminBootstrapResult(
+    string Login,
+    FirstAdminBootstrapStatus Status,
+    string AssignedRoleCode,
+    bool WasRoleLinkCreated,
+    string AssignedGroupNodeCode,
+    bool WasAssignmentCreated,
+    string AuditAction);

--- a/tools/App.Maintenance/IdentityBootstrap/FirstAdminBootstrapMaintenanceService.cs
+++ b/tools/App.Maintenance/IdentityBootstrap/FirstAdminBootstrapMaintenanceService.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using System.Text.Json;
 
 using BuildingBlocks.Infrastructure.Observability;
@@ -8,6 +9,7 @@ using BuildingBlocks.Infrastructure.Persistence.Entities.GroupTree;
 
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
 
 namespace App.Maintenance.IdentityBootstrap;
 
@@ -32,6 +34,8 @@ public sealed class FirstAdminBootstrapMaintenanceService(
         var password = ReadRequiredPassword();
         var displayName = ReadOptionalText(DisplayNameEnvironmentVariableName, 256) ?? login;
 
+        await using var transaction = await BeginSerializableTransactionIfSupportedAsync(cancellationToken);
+
         var role = await dbContext.AuthRoles
             .SingleOrDefaultAsync(
                 item => item.Code == PlatformOwnerRoleCode,
@@ -50,6 +54,8 @@ public sealed class FirstAdminBootstrapMaintenanceService(
             .AsNoTracking()
             .Where(item => item.IsActive)
             .Where(item => item.UserRoles.Any(roleLink => roleLink.RoleId == role.Id))
+            .Where(item => dbContext.GroupAdminAssignments.Any(assignment =>
+                assignment.GroupNodeId == rootGroupNode.Id && assignment.UserId == item.Id))
             .OrderBy(item => item.CreatedAtUtc)
             .FirstOrDefaultAsync(cancellationToken);
 
@@ -67,6 +73,7 @@ public sealed class FirstAdminBootstrapMaintenanceService(
                 cancellationToken);
 
             await dbContext.SaveChangesAsync(cancellationToken);
+            await CommitIfStartedAsync(transaction, cancellationToken);
 
             return new FirstAdminBootstrapResult(
                 existingActiveAdmin.Login,
@@ -144,6 +151,7 @@ public sealed class FirstAdminBootstrapMaintenanceService(
             cancellationToken);
 
         await dbContext.SaveChangesAsync(cancellationToken);
+        await CommitIfStartedAsync(transaction, cancellationToken);
 
         return new FirstAdminBootstrapResult(
             user.Login,
@@ -153,6 +161,34 @@ public sealed class FirstAdminBootstrapMaintenanceService(
             rootGroupNode.Code,
             wasAssignmentCreated,
             "first_admin_bootstrapped");
+    }
+
+    private async Task<IDbContextTransaction?> BeginSerializableTransactionIfSupportedAsync(
+        CancellationToken cancellationToken)
+    {
+        if (string.Equals(
+            dbContext.Database.ProviderName,
+            "Microsoft.EntityFrameworkCore.InMemory",
+            StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        return await dbContext.Database.BeginTransactionAsync(
+            IsolationLevel.Serializable,
+            cancellationToken);
+    }
+
+    private static async Task CommitIfStartedAsync(
+        IDbContextTransaction? transaction,
+        CancellationToken cancellationToken)
+    {
+        if (transaction is null)
+        {
+            return;
+        }
+
+        await transaction.CommitAsync(cancellationToken);
     }
 
     private Task WriteAuditRecordAsync(

--- a/tools/App.Maintenance/Program.cs
+++ b/tools/App.Maintenance/Program.cs
@@ -1,4 +1,5 @@
 using App.Maintenance.Configuration;
+using App.Maintenance.IdentityBootstrap;
 using App.Maintenance.IncidentRoutingAdmins;
 using App.Maintenance.IntegrationAccounts;
 
@@ -62,6 +63,15 @@ internal static class AppMaintenanceProgram
                         return 0;
                     }
 
+                case MaintenanceCommand.IdentityBootstrapFirstAdmin:
+                    {
+                        var service = scope.ServiceProvider.GetRequiredService<FirstAdminBootstrapMaintenanceService>();
+                        var result = await service.BootstrapAsync(cancellationToken);
+
+                        WriteFirstAdminBootstrapResult(standardOutput, result);
+                        return 0;
+                    }
+
                 default:
                     throw new InvalidOperationException("Maintenance command is not supported.");
             }
@@ -88,6 +98,7 @@ internal static class AppMaintenanceProgram
         builder.Services.AddPlatformPersistence(databaseOptions);
         builder.Services.AddSingleton<IPasswordHasher<AuthUser>, PasswordHasher<AuthUser>>();
         builder.Services.AddScoped<IncidentRoutingAdminMaintenanceService>();
+        builder.Services.AddScoped<FirstAdminBootstrapMaintenanceService>();
         builder.Services.AddScoped<IntegrationAccountMaintenanceService>();
 
         return builder.Build();
@@ -108,6 +119,14 @@ internal static class AppMaintenanceProgram
             && string.Equals(args[1], "upsert", StringComparison.OrdinalIgnoreCase))
         {
             command = MaintenanceCommand.IncidentRoutingAdminUpsert;
+            return true;
+        }
+
+        if (args.Length == 2
+            && string.Equals(args[0], "identity-bootstrap", StringComparison.OrdinalIgnoreCase)
+            && string.Equals(args[1], "first-admin", StringComparison.OrdinalIgnoreCase))
+        {
+            command = MaintenanceCommand.IdentityBootstrapFirstAdmin;
             return true;
         }
 
@@ -137,16 +156,54 @@ internal static class AppMaintenanceProgram
         writer.WriteLine($"assignment: {(result.WasAssignmentCreated ? "created" : "exists")}");
     }
 
+    private static void WriteFirstAdminBootstrapResult(
+        TextWriter writer,
+        FirstAdminBootstrapResult result)
+    {
+        writer.WriteLine($"login: {result.Login}");
+        writer.WriteLine($"status: {FormatFirstAdminStatus(result.Status)}");
+        writer.WriteLine($"role: {result.AssignedRoleCode}");
+        writer.WriteLine($"role-link: {FormatCreatedOrExists(result.WasRoleLinkCreated, result.Status)}");
+        writer.WriteLine($"group-node: {result.AssignedGroupNodeCode}");
+        writer.WriteLine($"assignment: {FormatCreatedOrExists(result.WasAssignmentCreated, result.Status)}");
+        writer.WriteLine($"audit: {result.AuditAction}");
+    }
+
+    private static string FormatFirstAdminStatus(FirstAdminBootstrapStatus status)
+    {
+        return status switch
+        {
+            FirstAdminBootstrapStatus.Created => "created",
+            FirstAdminBootstrapStatus.Updated => "updated",
+            FirstAdminBootstrapStatus.SkippedExistingAdmin => "skipped_existing_admin",
+            _ => "unknown"
+        };
+    }
+
+    private static string FormatCreatedOrExists(
+        bool wasCreated,
+        FirstAdminBootstrapStatus status)
+    {
+        if (status == FirstAdminBootstrapStatus.SkippedExistingAdmin)
+        {
+            return "skipped";
+        }
+
+        return wasCreated ? "created" : "exists";
+    }
+
     private static void WriteUsage(TextWriter writer)
     {
         writer.WriteLine("Usage:");
         writer.WriteLine("  dotnet run --project tools\\App.Maintenance\\App.Maintenance.csproj -- integration-account upsert");
         writer.WriteLine("  dotnet run --project tools\\App.Maintenance\\App.Maintenance.csproj -- incident-routing-admin upsert");
+        writer.WriteLine("  dotnet run --project tools\\App.Maintenance\\App.Maintenance.csproj -- identity-bootstrap first-admin");
     }
 
     private enum MaintenanceCommand
     {
         IntegrationAccountUpsert,
-        IncidentRoutingAdminUpsert
+        IncidentRoutingAdminUpsert,
+        IdentityBootstrapFirstAdmin
     }
 }


### PR DESCRIPTION
Coder: Codex (Coder 1 acting as Coder 2 / Desktop Client + server/auth coordination)

Task ID: S2-52

Module: tools/App.Maintenance / Modules.Auth coordination

Scope:
- Added an operator-only first-admin bootstrap command in App.Maintenance.
- Kept App.Api sign-in contract backward-compatible.
- Added focused maintenance integration tests for create, already-existing admin no-op, disabled gate, missing input, audit, and safe output.

Changed areas:
- tools/App.Maintenance/Program.cs
- tools/App.Maintenance/IdentityBootstrap/FirstAdminBootstrapMaintenanceService.cs
- tests/Integration/App.Maintenance/AppMaintenanceProgramTests.cs
- tests/Integration/App.Maintenance/FirstAdminBootstrapMaintenanceServiceTests.cs

Base main SHA: ccc8fc1228a9f95476b09e0a71d4e3a6490f448e

Coordination log entries reviewed:
- Issue #89 TEAM COORDINATION LOG
- PR #115 S2-50 desktop auth session boundary runtime
- PR #117 S2-51 Desktop SignIn Runtime Enablement Task Card
- PR #118 S2-51 desktop signin runtime enablement
- PR #119 S2-52 identity bootstrap first admin task card

Handoff/task cards reviewed:
- 00_START_HERE_README.txt
- 01_MASTER_PLAN_AND_ARCHITECTURE.txt
- 02_SHARED_RULES_AND_PROTOCOLS.txt
- 04_GITHUB_WORKFLOW_AND_INFRA_RULES.txt
- docs/task-cards/S2-50_desktop-auth-session-boundary-task-card.txt
- docs/handoffs/S2_50_DESKTOP_AUTH_SESSION_BOUNDARY_PROMPT.md
- docs/task-cards/S2-51_desktop-signin-runtime-enablement-task-card.txt
- docs/handoffs/S2_51_DESKTOP_SIGNIN_RUNTIME_ENABLEMENT_PROMPT.md
- docs/task-cards/S2-52_identity-bootstrap-first-admin-task-card.txt
- docs/handoffs/S2_52_IDENTITY_BOOTSTRAP_FIRST_ADMIN_PROMPT.md

Contracts:
- No shared contract changes.
- No new public API/bootstrap endpoint.
- Existing /api/auth/sign-in remains unchanged and backward-compatible.

Migrations:
- None.

Feature flags:
- No repo feature flag added.
- Bootstrap command is disabled by default behind the operator-local AA_FIRST_ADMIN_BOOTSTRAP_ENABLED gate.

API impact:
- None. App.Api was not changed.

Web impact:
- None. App.Web was not changed.

Android impact:
- None. App.Mobile.Android was not changed.

Offline behavior:
- None. Bootstrap remains an online/operator provisioning concern.

Rollback:
- Revert this PR/commit to remove the maintenance command and tests.
- No migration rollback is needed.

Validation:
- git fetch origin --prune: passed
- main sync pull in C:\Codex\Worktrees\_AnalyticsAutomation-Core-main-sync: already up to date
- gh issue view 89 --repo uVormik/AnalyticsAutomation-Core --comments --json ...: passed
- git diff --check: passed (Git emitted LF-to-CRLF working-copy notices only)
- dotnet restore AnalyticsAutomation-Core.sln -nologo: passed
- dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore: passed
- dotnet build AnalyticsAutomation-Core.sln -nologo -v minimal: passed, 0 warnings, 0 errors on final run
- dotnet test tests\Integration\App.Maintenance\App.Maintenance.Tests.csproj -nologo -v minimal: passed, 15/15
- dotnet test AnalyticsAutomation-Core.sln -nologo -v minimal: passed, 259/259
- hidden/control Unicode scan over changed text files: passed

Handoff docs:
- No docs changed in this runtime PR.
- S2-52 task card and handoff were used as implementation source.

Next step:
- Review this PR.
- After merge and a separate manual deployment, an operator can run the approved maintenance bootstrap procedure with operator-local environment variables, then perform the App.Desktop SignIn smoke against the target control-plane URL.

NO-GO / Deferred:
- No deploy performed.
- No manual Korobochka/App.Desktop SignIn smoke performed in this PR because it requires operator-provided credentials and separately approved manual deployment.
- No open public registration.
- No desktop user creation.
- No public bootstrap endpoint.
- No passwords/tokens/Authorization values were added to files, logs, reports, or this PR body.