### PR TITLE
S2-53 operator admin password recovery runtime

### DIFF
--- a/tests/Integration/App.Maintenance/AppMaintenanceProgramTests.cs
+++ b/tests/Integration/App.Maintenance/AppMaintenanceProgramTests.cs
@@ -1,4 +1,5 @@
 using App.Maintenance.IncidentRoutingAdmins;
+using App.Maintenance.IdentityAdmin;
 using App.Maintenance.IdentityBootstrap;
 using App.Maintenance.IntegrationAccounts;
 
@@ -19,6 +20,122 @@ namespace App.Maintenance.Tests;
 
 public sealed class AppMaintenanceProgramTests
 {
+    [Fact]
+    public async Task RunAsyncIdentityAdminResetPasswordWritesSafeOutputOnly()
+    {
+        const string login = "incident-routing-admin";
+        var oldPassword = CreateEphemeralSecret();
+        var newPassword = CreateEphemeralSecret();
+
+        using var recoveryEnabledScope = new EnvironmentVariableScope(
+            IdentityAdminPasswordRecoveryMaintenanceService.EnabledEnvironmentVariableName,
+            "true");
+        using var loginScope = new EnvironmentVariableScope(
+            IdentityAdminPasswordRecoveryMaintenanceService.LoginEnvironmentVariableName,
+            login);
+        using var passwordScope = new EnvironmentVariableScope(
+            IdentityAdminPasswordRecoveryMaintenanceService.PasswordEnvironmentVariableName,
+            newPassword);
+
+        var databaseName = $"app-maintenance-program-admin-recovery-{Guid.NewGuid():N}";
+        var databaseRoot = new InMemoryDatabaseRoot();
+        string oldHash;
+
+        await using (var setupContext = CreateDbContext(databaseName, databaseRoot))
+        {
+            var passwordHasher = new PasswordHasher<AuthUser>();
+            var seed = await SeedInteractiveRootAdminAsync(
+                setupContext,
+                passwordHasher,
+                login,
+                oldPassword);
+            oldHash = seed.PasswordHash;
+        }
+
+        var stdout = new StringWriter();
+        var stderr = new StringWriter();
+
+        var exitCode = await AppMaintenanceProgram.RunAsync(
+            ["identity-admin", "reset-password"],
+            () => CreateHost(databaseName, databaseRoot),
+            stdout,
+            stderr,
+            CancellationToken.None);
+
+        await using var assertContext = CreateDbContext(databaseName, databaseRoot);
+        var user = await assertContext.AuthUsers
+            .SingleAsync(item => item.NormalizedLogin == "INCIDENT-ROUTING-ADMIN");
+
+        var standardOutput = stdout.ToString();
+        var errorOutput = stderr.ToString();
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(string.Empty, errorOutput);
+        Assert.Contains("login: incident-routing-admin", standardOutput, StringComparison.Ordinal);
+        Assert.Contains("mode: reset-password", standardOutput, StringComparison.Ordinal);
+        Assert.Contains("status: password_reset", standardOutput, StringComparison.Ordinal);
+        Assert.Contains("role: platform_owner", standardOutput, StringComparison.Ordinal);
+        Assert.Contains("group-node: root", standardOutput, StringComparison.Ordinal);
+        Assert.Contains("audit: admin_password_recovery_succeeded", standardOutput, StringComparison.Ordinal);
+        Assert.DoesNotContain(oldPassword, standardOutput, StringComparison.Ordinal);
+        Assert.DoesNotContain(newPassword, standardOutput, StringComparison.Ordinal);
+        Assert.DoesNotContain(oldHash, standardOutput, StringComparison.Ordinal);
+        Assert.DoesNotContain(user.PasswordHash, standardOutput, StringComparison.Ordinal);
+        Assert.DoesNotContain("accessToken", standardOutput, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("refreshToken", standardOutput, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Authorization", standardOutput, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task RunAsyncIdentityAdminResetPasswordFailsSafelyWhenDisabled()
+    {
+        using var recoveryEnabledScope = new EnvironmentVariableScope(
+            IdentityAdminPasswordRecoveryMaintenanceService.EnabledEnvironmentVariableName,
+            null);
+        using var loginScope = new EnvironmentVariableScope(
+            IdentityAdminPasswordRecoveryMaintenanceService.LoginEnvironmentVariableName,
+            "incident-routing-admin");
+        using var passwordScope = new EnvironmentVariableScope(
+            IdentityAdminPasswordRecoveryMaintenanceService.PasswordEnvironmentVariableName,
+            CreateEphemeralSecret());
+
+        var databaseName = $"app-maintenance-program-admin-recovery-disabled-{Guid.NewGuid():N}";
+        var databaseRoot = new InMemoryDatabaseRoot();
+
+        await using (var setupContext = CreateDbContext(databaseName, databaseRoot))
+        {
+            await SeedInteractiveRootAdminAsync(
+                setupContext,
+                new PasswordHasher<AuthUser>(),
+                "incident-routing-admin",
+                CreateEphemeralSecret());
+        }
+
+        var stdout = new StringWriter();
+        var stderr = new StringWriter();
+
+        var exitCode = await AppMaintenanceProgram.RunAsync(
+            ["identity-admin", "reset-password"],
+            () => CreateHost(databaseName, databaseRoot),
+            stdout,
+            stderr,
+            CancellationToken.None);
+
+        var standardOutput = stdout.ToString();
+        var errorOutput = stderr.ToString();
+
+        Assert.Equal(1, exitCode);
+        Assert.Equal(string.Empty, standardOutput);
+        Assert.Contains(
+            IdentityAdminPasswordRecoveryMaintenanceService.EnabledEnvironmentVariableName,
+            errorOutput,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("accessToken", errorOutput, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("refreshToken", errorOutput, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Authorization", errorOutput, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("connection string", errorOutput, StringComparison.OrdinalIgnoreCase);
+    }
+
     [Fact]
     public async Task RunAsyncIdentityBootstrapFirstAdminWritesSafeOutputOnly()
     {
@@ -232,9 +349,62 @@ public sealed class AppMaintenanceProgramTests
         builder.Services.AddSingleton<IPasswordHasher<AuthUser>, PasswordHasher<AuthUser>>();
         builder.Services.AddScoped<IncidentRoutingAdminMaintenanceService>();
         builder.Services.AddScoped<FirstAdminBootstrapMaintenanceService>();
+        builder.Services.AddScoped<IdentityAdminPasswordRecoveryMaintenanceService>();
         builder.Services.AddScoped<IntegrationAccountMaintenanceService>();
 
         return builder.Build();
+    }
+
+    private static async Task<AuthUser> SeedInteractiveRootAdminAsync(
+        PlatformDbContext dbContext,
+        PasswordHasher<AuthUser> passwordHasher,
+        string login,
+        string password)
+    {
+        var role = new AuthRole
+        {
+            Id = Guid.NewGuid(),
+            Code = IdentityAdminPasswordRecoveryMaintenanceService.PlatformOwnerRoleCode,
+            Name = "Platform Owner"
+        };
+        var rootNode = new GroupNode
+        {
+            Id = Guid.NewGuid(),
+            Code = IdentityAdminPasswordRecoveryMaintenanceService.RootGroupNodeCode,
+            Name = "Root",
+            Depth = 0,
+            IsActive = true
+        };
+        var user = new AuthUser
+        {
+            Id = Guid.NewGuid(),
+            Login = login,
+            NormalizedLogin = login.Trim().ToUpperInvariant(),
+            DisplayName = login,
+            IsActive = true,
+            CurrentGroupNodeId = rootNode.Id,
+            CreatedAtUtc = DateTimeOffset.UtcNow.AddDays(-1)
+        };
+
+        user.PasswordHash = passwordHasher.HashPassword(user, password);
+        user.UserRoles.Add(new AuthUserRole
+        {
+            UserId = user.Id,
+            RoleId = role.Id
+        });
+
+        dbContext.AuthRoles.Add(role);
+        dbContext.GroupNodes.Add(rootNode);
+        dbContext.AuthUsers.Add(user);
+        dbContext.GroupAdminAssignments.Add(new GroupAdminAssignment
+        {
+            GroupNodeId = rootNode.Id,
+            UserId = user.Id,
+            AssignedAtUtc = DateTimeOffset.UtcNow.AddDays(-1)
+        });
+        await dbContext.SaveChangesAsync();
+
+        return user;
     }
 
     private static async Task SeedRoleAndRootAsync(PlatformDbContext dbContext)

--- a/tests/Integration/App.Maintenance/AppMaintenanceProgramTests.cs
+++ b/tests/Integration/App.Maintenance/AppMaintenanceProgramTests.cs
@@ -40,6 +40,8 @@ public sealed class AppMaintenanceProgramTests
         var databaseName = $"app-maintenance-program-admin-recovery-{Guid.NewGuid():N}";
         var databaseRoot = new InMemoryDatabaseRoot();
         string oldHash;
+        string sessionAccessTokenHash;
+        string sessionRefreshTokenHash;
 
         await using (var setupContext = CreateDbContext(databaseName, databaseRoot))
         {
@@ -50,6 +52,15 @@ public sealed class AppMaintenanceProgramTests
                 login,
                 oldPassword);
             oldHash = seed.PasswordHash;
+            sessionAccessTokenHash = "program-reset-active-access-hash";
+            sessionRefreshTokenHash = "program-reset-active-refresh-hash";
+            await AddAuthSessionAsync(
+                setupContext,
+                seed.Id,
+                sessionAccessTokenHash,
+                sessionRefreshTokenHash,
+                expiresAtUtc: DateTimeOffset.UtcNow.AddMinutes(30),
+                refreshExpiresAtUtc: DateTimeOffset.UtcNow.AddHours(12));
         }
 
         var stdout = new StringWriter();
@@ -65,6 +76,7 @@ public sealed class AppMaintenanceProgramTests
         await using var assertContext = CreateDbContext(databaseName, databaseRoot);
         var user = await assertContext.AuthUsers
             .SingleAsync(item => item.NormalizedLogin == "INCIDENT-ROUTING-ADMIN");
+        var session = await assertContext.AuthSessions.SingleAsync();
 
         var standardOutput = stdout.ToString();
         var errorOutput = stderr.ToString();
@@ -76,11 +88,15 @@ public sealed class AppMaintenanceProgramTests
         Assert.Contains("status: password_reset", standardOutput, StringComparison.Ordinal);
         Assert.Contains("role: platform_owner", standardOutput, StringComparison.Ordinal);
         Assert.Contains("group-node: root", standardOutput, StringComparison.Ordinal);
+        Assert.Contains("sessions-revoked: 1", standardOutput, StringComparison.Ordinal);
         Assert.Contains("audit: admin_password_recovery_succeeded", standardOutput, StringComparison.Ordinal);
+        Assert.NotNull(session.RevokedAtUtc);
         Assert.DoesNotContain(oldPassword, standardOutput, StringComparison.Ordinal);
         Assert.DoesNotContain(newPassword, standardOutput, StringComparison.Ordinal);
         Assert.DoesNotContain(oldHash, standardOutput, StringComparison.Ordinal);
         Assert.DoesNotContain(user.PasswordHash, standardOutput, StringComparison.Ordinal);
+        Assert.DoesNotContain(sessionAccessTokenHash, standardOutput, StringComparison.Ordinal);
+        Assert.DoesNotContain(sessionRefreshTokenHash, standardOutput, StringComparison.Ordinal);
         Assert.DoesNotContain("accessToken", standardOutput, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("refreshToken", standardOutput, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("Authorization", standardOutput, StringComparison.OrdinalIgnoreCase);
@@ -405,6 +421,30 @@ public sealed class AppMaintenanceProgramTests
         await dbContext.SaveChangesAsync();
 
         return user;
+    }
+
+    private static async Task AddAuthSessionAsync(
+        PlatformDbContext dbContext,
+        Guid userId,
+        string accessTokenHash,
+        string refreshTokenHash,
+        DateTimeOffset expiresAtUtc,
+        DateTimeOffset refreshExpiresAtUtc)
+    {
+        dbContext.AuthSessions.Add(new AuthSession
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            DeviceId = Guid.NewGuid(),
+            AccessTokenHash = accessTokenHash,
+            RefreshTokenHash = refreshTokenHash,
+            IsOfflineRestricted = false,
+            IssuedAtUtc = DateTimeOffset.UtcNow.AddMinutes(-5),
+            ExpiresAtUtc = expiresAtUtc,
+            RefreshExpiresAtUtc = refreshExpiresAtUtc
+        });
+
+        await dbContext.SaveChangesAsync();
     }
 
     private static async Task SeedRoleAndRootAsync(PlatformDbContext dbContext)

--- a/tests/Integration/App.Maintenance/IdentityAdminPasswordRecoveryMaintenanceServiceTests.cs
+++ b/tests/Integration/App.Maintenance/IdentityAdminPasswordRecoveryMaintenanceServiceTests.cs
@@ -33,6 +33,49 @@ public sealed class IdentityAdminPasswordRecoveryMaintenanceServiceTests
         var passwordHasher = new PasswordHasher<AuthUser>();
         var seed = await SeedInteractiveRootAdminAsync(dbContext, passwordHasher, login, oldPassword);
         var oldHash = seed.User.PasswordHash;
+        var otherUser = await SeedInteractiveUserAsync(
+            dbContext,
+            passwordHasher,
+            "branch-admin",
+            CreateEphemeralSecret(),
+            seed.RootNode.Id);
+        var targetActiveSession = await AddAuthSessionAsync(
+            dbContext,
+            seed.User.Id,
+            "target-active-access-hash",
+            "target-active-refresh-hash",
+            expiresAtUtc: DateTimeOffset.UtcNow.AddMinutes(30),
+            refreshExpiresAtUtc: DateTimeOffset.UtcNow.AddHours(12));
+        var targetRefreshOnlySession = await AddAuthSessionAsync(
+            dbContext,
+            seed.User.Id,
+            "target-refresh-only-access-hash",
+            "target-refresh-only-refresh-hash",
+            expiresAtUtc: DateTimeOffset.UtcNow.AddMinutes(-5),
+            refreshExpiresAtUtc: DateTimeOffset.UtcNow.AddHours(12));
+        var targetExpiredSession = await AddAuthSessionAsync(
+            dbContext,
+            seed.User.Id,
+            "target-expired-access-hash",
+            "target-expired-refresh-hash",
+            expiresAtUtc: DateTimeOffset.UtcNow.AddMinutes(-30),
+            refreshExpiresAtUtc: DateTimeOffset.UtcNow.AddMinutes(-1));
+        var alreadyRevokedAtUtc = DateTimeOffset.UtcNow.AddHours(-1);
+        var targetAlreadyRevokedSession = await AddAuthSessionAsync(
+            dbContext,
+            seed.User.Id,
+            "target-revoked-access-hash",
+            "target-revoked-refresh-hash",
+            expiresAtUtc: DateTimeOffset.UtcNow.AddMinutes(30),
+            refreshExpiresAtUtc: DateTimeOffset.UtcNow.AddHours(12),
+            revokedAtUtc: alreadyRevokedAtUtc);
+        var otherActiveSession = await AddAuthSessionAsync(
+            dbContext,
+            otherUser.Id,
+            "other-active-access-hash",
+            "other-active-refresh-hash",
+            expiresAtUtc: DateTimeOffset.UtcNow.AddMinutes(30),
+            refreshExpiresAtUtc: DateTimeOffset.UtcNow.AddHours(12));
         var service = new IdentityAdminPasswordRecoveryMaintenanceService(dbContext, passwordHasher);
 
         var result = await service.ResetPasswordAsync(CancellationToken.None);
@@ -50,6 +93,7 @@ public sealed class IdentityAdminPasswordRecoveryMaintenanceServiceTests
         Assert.Equal(login, result.Login);
         Assert.Equal(IdentityAdminPasswordRecoveryMaintenanceService.PlatformOwnerRoleCode, result.AssignedRoleCode);
         Assert.Equal(IdentityAdminPasswordRecoveryMaintenanceService.RootGroupNodeCode, result.AssignedGroupNodeCode);
+        Assert.Equal(2, result.SessionsRevoked);
         Assert.Equal("admin_password_recovery_succeeded", result.AuditAction);
         Assert.NotEqual(oldHash, user.PasswordHash);
         Assert.NotEqual(
@@ -64,10 +108,41 @@ public sealed class IdentityAdminPasswordRecoveryMaintenanceServiceTests
             item => item.GroupNodeId == seed.RootNode.Id && item.UserId == user.Id));
         Assert.Equal(2, auditRecords.Length);
         Assert.Contains(auditRecords, item => item.Action == "admin_password_recovery_attempted");
-        Assert.Contains(auditRecords, item => item.Action == "admin_password_recovery_succeeded");
+        Assert.Contains(auditRecords, item =>
+            item.Action == "admin_password_recovery_succeeded"
+            && item.PayloadJson!.Contains("\"sessionsRevoked\":2", StringComparison.Ordinal));
         Assert.All(auditRecords, item => Assert.Equal(AuditCategories.Authentication, item.Category));
         Assert.All(auditRecords, item => Assert.Equal("App.Maintenance identity-admin reset-password", item.RequestPath));
-        AssertAuditRecordsAreSecretSafe(auditRecords, oldPassword, newPassword, oldHash, user.PasswordHash);
+        await AssertSessionRevocationAsync(
+            dbContext,
+            targetActiveSession.Id,
+            expectedRevoked: true);
+        await AssertSessionRevocationAsync(
+            dbContext,
+            targetRefreshOnlySession.Id,
+            expectedRevoked: true);
+        await AssertSessionRevocationAsync(
+            dbContext,
+            targetExpiredSession.Id,
+            expectedRevoked: false);
+        await AssertSessionRevocationAsync(
+            dbContext,
+            targetAlreadyRevokedSession.Id,
+            alreadyRevokedAtUtc);
+        await AssertSessionRevocationAsync(
+            dbContext,
+            otherActiveSession.Id,
+            expectedRevoked: false);
+        AssertAuditRecordsAreSecretSafe(
+            auditRecords,
+            oldPassword,
+            newPassword,
+            oldHash,
+            user.PasswordHash,
+            targetActiveSession.AccessTokenHash,
+            targetActiveSession.RefreshTokenHash,
+            targetRefreshOnlySession.AccessTokenHash,
+            targetRefreshOnlySession.RefreshTokenHash);
     }
 
     [Fact]
@@ -86,6 +161,13 @@ public sealed class IdentityAdminPasswordRecoveryMaintenanceServiceTests
             "incident-routing-admin",
             CreateEphemeralSecret());
         var oldHash = seed.User.PasswordHash;
+        var activeSession = await AddAuthSessionAsync(
+            dbContext,
+            seed.User.Id,
+            "disabled-active-access-hash",
+            "disabled-active-refresh-hash",
+            expiresAtUtc: DateTimeOffset.UtcNow.AddMinutes(30),
+            refreshExpiresAtUtc: DateTimeOffset.UtcNow.AddHours(12));
         var service = new IdentityAdminPasswordRecoveryMaintenanceService(dbContext, passwordHasher);
 
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
@@ -98,6 +180,10 @@ public sealed class IdentityAdminPasswordRecoveryMaintenanceServiceTests
             $"Environment variable {IdentityAdminPasswordRecoveryMaintenanceService.EnabledEnvironmentVariableName} must be set to 'true' to run admin password recovery.",
             exception.Message);
         Assert.Equal(oldHash, user.PasswordHash);
+        await AssertSessionRevocationAsync(
+            dbContext,
+            activeSession.Id,
+            expectedRevoked: false);
         Assert.False(await dbContext.AuditRecords.AnyAsync());
     }
 
@@ -157,9 +243,27 @@ public sealed class IdentityAdminPasswordRecoveryMaintenanceServiceTests
 
         using var dbContext = CreateDbContext();
         await SeedRoleAndRootAsync(dbContext);
+        var rootNodeId = await dbContext.GroupNodes
+            .Where(item => item.Code == IdentityAdminPasswordRecoveryMaintenanceService.RootGroupNodeCode)
+            .Select(item => item.Id)
+            .SingleAsync();
+        var passwordHasher = new PasswordHasher<AuthUser>();
+        var otherUser = await SeedInteractiveUserAsync(
+            dbContext,
+            passwordHasher,
+            "other-admin",
+            CreateEphemeralSecret(),
+            rootNodeId);
+        var otherActiveSession = await AddAuthSessionAsync(
+            dbContext,
+            otherUser.Id,
+            "missing-target-other-access-hash",
+            "missing-target-other-refresh-hash",
+            expiresAtUtc: DateTimeOffset.UtcNow.AddMinutes(30),
+            refreshExpiresAtUtc: DateTimeOffset.UtcNow.AddHours(12));
         var service = new IdentityAdminPasswordRecoveryMaintenanceService(
             dbContext,
-            new PasswordHasher<AuthUser>());
+            passwordHasher);
 
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
             () => service.ResetPasswordAsync(CancellationToken.None));
@@ -169,7 +273,11 @@ public sealed class IdentityAdminPasswordRecoveryMaintenanceServiceTests
         Assert.Equal(
             "Interactive root/platform admin 'missing-admin' was not found. Password was not changed.",
             exception.Message);
-        Assert.False(await dbContext.AuthUsers.AnyAsync());
+        Assert.Equal(1, await dbContext.AuthUsers.CountAsync());
+        await AssertSessionRevocationAsync(
+            dbContext,
+            otherActiveSession.Id,
+            expectedRevoked: false);
         Assert.Equal(2, auditRecords.Length);
         Assert.Contains(auditRecords, item => item.Action == "admin_password_recovery_attempted");
         Assert.Contains(auditRecords, item =>
@@ -199,6 +307,13 @@ public sealed class IdentityAdminPasswordRecoveryMaintenanceServiceTests
         seed.User.DisplayName = IntegrationAccountMaintenanceService.IntegrationAccountDisplayName;
         await dbContext.SaveChangesAsync();
         var oldHash = seed.User.PasswordHash;
+        var activeSession = await AddAuthSessionAsync(
+            dbContext,
+            seed.User.Id,
+            "integration-account-access-hash",
+            "integration-account-refresh-hash",
+            expiresAtUtc: DateTimeOffset.UtcNow.AddMinutes(30),
+            refreshExpiresAtUtc: DateTimeOffset.UtcNow.AddHours(12));
         var service = new IdentityAdminPasswordRecoveryMaintenanceService(dbContext, passwordHasher);
 
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
@@ -212,10 +327,63 @@ public sealed class IdentityAdminPasswordRecoveryMaintenanceServiceTests
             $"Target account '{IntegrationAccountMaintenanceService.IntegrationAccountLogin}' is not eligible for admin password recovery.",
             exception.Message);
         Assert.Equal(oldHash, user.PasswordHash);
+        await AssertSessionRevocationAsync(
+            dbContext,
+            activeSession.Id,
+            expectedRevoked: false);
         Assert.Equal(2, auditRecords.Length);
         Assert.Contains(auditRecords, item =>
             item.Action == "admin_password_recovery_rejected"
             && item.PayloadJson!.Contains("target_is_non_interactive_account", StringComparison.Ordinal));
+        AssertAuditRecordsAreSecretSafe(auditRecords, oldPassword, newPassword, oldHash);
+    }
+
+    [Fact]
+    public async Task ResetPasswordAsyncRejectsInactiveAccountWithoutRevokingSessions()
+    {
+        const string login = "incident-routing-admin";
+        var oldPassword = CreateEphemeralSecret();
+        var newPassword = CreateEphemeralSecret();
+
+        using var environment = new IdentityAdminPasswordRecoveryEnvironment(
+            enabled: "true",
+            login,
+            password: newPassword);
+
+        using var dbContext = CreateDbContext();
+        var passwordHasher = new PasswordHasher<AuthUser>();
+        var seed = await SeedInteractiveRootAdminAsync(dbContext, passwordHasher, login, oldPassword);
+        seed.User.IsActive = false;
+        await dbContext.SaveChangesAsync();
+        var oldHash = seed.User.PasswordHash;
+        var activeSession = await AddAuthSessionAsync(
+            dbContext,
+            seed.User.Id,
+            "inactive-account-access-hash",
+            "inactive-account-refresh-hash",
+            expiresAtUtc: DateTimeOffset.UtcNow.AddMinutes(30),
+            refreshExpiresAtUtc: DateTimeOffset.UtcNow.AddHours(12));
+        var service = new IdentityAdminPasswordRecoveryMaintenanceService(dbContext, passwordHasher);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.ResetPasswordAsync(CancellationToken.None));
+
+        dbContext.ChangeTracker.Clear();
+        var user = await dbContext.AuthUsers.SingleAsync();
+        var auditRecords = await dbContext.AuditRecords.ToArrayAsync();
+
+        Assert.Equal(
+            "Target account 'incident-routing-admin' is not an active root/platform admin. Password was not changed.",
+            exception.Message);
+        Assert.Equal(oldHash, user.PasswordHash);
+        await AssertSessionRevocationAsync(
+            dbContext,
+            activeSession.Id,
+            expectedRevoked: false);
+        Assert.Equal(2, auditRecords.Length);
+        Assert.Contains(auditRecords, item =>
+            item.Action == "admin_password_recovery_rejected"
+            && item.PayloadJson!.Contains("target_admin_inactive", StringComparison.Ordinal));
         AssertAuditRecordsAreSecretSafe(auditRecords, oldPassword, newPassword, oldHash);
     }
 
@@ -250,6 +418,13 @@ public sealed class IdentityAdminPasswordRecoveryMaintenanceServiceTests
 
         await dbContext.SaveChangesAsync();
         var oldHash = seed.User.PasswordHash;
+        var activeSession = await AddAuthSessionAsync(
+            dbContext,
+            seed.User.Id,
+            $"policy-validation-access-hash-{hasPlatformOwnerRole}-{hasRootGroupAdminAssignment}",
+            $"policy-validation-refresh-hash-{hasPlatformOwnerRole}-{hasRootGroupAdminAssignment}",
+            expiresAtUtc: DateTimeOffset.UtcNow.AddMinutes(30),
+            refreshExpiresAtUtc: DateTimeOffset.UtcNow.AddHours(12));
         var service = new IdentityAdminPasswordRecoveryMaintenanceService(dbContext, passwordHasher);
 
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
@@ -263,6 +438,10 @@ public sealed class IdentityAdminPasswordRecoveryMaintenanceServiceTests
             "Target account 'branch-admin' is not an active root/platform admin. Password was not changed.",
             exception.Message);
         Assert.Equal(oldHash, user.PasswordHash);
+        await AssertSessionRevocationAsync(
+            dbContext,
+            activeSession.Id,
+            expectedRevoked: false);
         Assert.Equal(2, auditRecords.Length);
         Assert.Contains(auditRecords, item =>
             item.Action == "admin_password_recovery_rejected"
@@ -414,6 +593,95 @@ public sealed class IdentityAdminPasswordRecoveryMaintenanceServiceTests
         await dbContext.SaveChangesAsync();
 
         return (role, rootNode, user);
+    }
+
+    private static async Task<AuthUser> SeedInteractiveUserAsync(
+        PlatformDbContext dbContext,
+        PasswordHasher<AuthUser> passwordHasher,
+        string login,
+        string password,
+        Guid? currentGroupNodeId)
+    {
+        var user = new AuthUser
+        {
+            Id = Guid.NewGuid(),
+            Login = login,
+            NormalizedLogin = login.Trim().ToUpperInvariant(),
+            DisplayName = login,
+            IsActive = true,
+            CurrentGroupNodeId = currentGroupNodeId,
+            CreatedAtUtc = DateTimeOffset.UtcNow.AddDays(-1)
+        };
+
+        user.PasswordHash = passwordHasher.HashPassword(user, password);
+
+        dbContext.AuthUsers.Add(user);
+        await dbContext.SaveChangesAsync();
+
+        return user;
+    }
+
+    private static async Task<AuthSession> AddAuthSessionAsync(
+        PlatformDbContext dbContext,
+        Guid userId,
+        string accessTokenHash,
+        string refreshTokenHash,
+        DateTimeOffset expiresAtUtc,
+        DateTimeOffset refreshExpiresAtUtc,
+        DateTimeOffset? revokedAtUtc = null)
+    {
+        var session = new AuthSession
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            DeviceId = Guid.NewGuid(),
+            AccessTokenHash = accessTokenHash,
+            RefreshTokenHash = refreshTokenHash,
+            IsOfflineRestricted = false,
+            IssuedAtUtc = DateTimeOffset.UtcNow.AddMinutes(-5),
+            ExpiresAtUtc = expiresAtUtc,
+            RefreshExpiresAtUtc = refreshExpiresAtUtc,
+            RevokedAtUtc = revokedAtUtc
+        };
+
+        dbContext.AuthSessions.Add(session);
+        await dbContext.SaveChangesAsync();
+
+        return session;
+    }
+
+    private static async Task AssertSessionRevocationAsync(
+        PlatformDbContext dbContext,
+        Guid sessionId,
+        bool expectedRevoked)
+    {
+        var revokedAtUtc = await dbContext.AuthSessions
+            .AsNoTracking()
+            .Where(item => item.Id == sessionId)
+            .Select(item => item.RevokedAtUtc)
+            .SingleAsync();
+
+        if (expectedRevoked)
+        {
+            Assert.NotNull(revokedAtUtc);
+            return;
+        }
+
+        Assert.Null(revokedAtUtc);
+    }
+
+    private static async Task AssertSessionRevocationAsync(
+        PlatformDbContext dbContext,
+        Guid sessionId,
+        DateTimeOffset expectedRevokedAtUtc)
+    {
+        var revokedAtUtc = await dbContext.AuthSessions
+            .AsNoTracking()
+            .Where(item => item.Id == sessionId)
+            .Select(item => item.RevokedAtUtc)
+            .SingleAsync();
+
+        Assert.Equal(expectedRevokedAtUtc, revokedAtUtc);
     }
 
     private static async Task SeedRoleAndRootAsync(PlatformDbContext dbContext)

--- a/tests/Integration/App.Maintenance/IdentityAdminPasswordRecoveryMaintenanceServiceTests.cs
+++ b/tests/Integration/App.Maintenance/IdentityAdminPasswordRecoveryMaintenanceServiceTests.cs
@@ -1,0 +1,528 @@
+using App.Maintenance.IdentityAdmin;
+using App.Maintenance.IntegrationAccounts;
+
+using BuildingBlocks.Infrastructure.Observability;
+using BuildingBlocks.Infrastructure.Persistence;
+using BuildingBlocks.Infrastructure.Persistence.Entities.Audit;
+using BuildingBlocks.Infrastructure.Persistence.Entities.Auth;
+using BuildingBlocks.Infrastructure.Persistence.Entities.GroupTree;
+
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+
+using Xunit;
+
+namespace App.Maintenance.Tests;
+
+public sealed class IdentityAdminPasswordRecoveryMaintenanceServiceTests
+{
+    [Fact]
+    public async Task ResetPasswordAsyncResetsExistingInteractiveRootPlatformAdminPasswordAndWritesAudit()
+    {
+        const string login = "incident-routing-admin";
+        var oldPassword = CreateEphemeralSecret();
+        var newPassword = CreateEphemeralSecret();
+
+        using var environment = new IdentityAdminPasswordRecoveryEnvironment(
+            enabled: "true",
+            login,
+            password: newPassword);
+
+        using var dbContext = CreateDbContext();
+        var passwordHasher = new PasswordHasher<AuthUser>();
+        var seed = await SeedInteractiveRootAdminAsync(dbContext, passwordHasher, login, oldPassword);
+        var oldHash = seed.User.PasswordHash;
+        var service = new IdentityAdminPasswordRecoveryMaintenanceService(dbContext, passwordHasher);
+
+        var result = await service.ResetPasswordAsync(CancellationToken.None);
+
+        dbContext.ChangeTracker.Clear();
+
+        var user = await dbContext.AuthUsers
+            .Include(item => item.UserRoles)
+            .SingleAsync(item => item.NormalizedLogin == "INCIDENT-ROUTING-ADMIN");
+        var auditRecords = await dbContext.AuditRecords
+            .OrderBy(item => item.Action)
+            .ToArrayAsync();
+
+        Assert.Equal(IdentityAdminPasswordRecoveryStatus.PasswordReset, result.Status);
+        Assert.Equal(login, result.Login);
+        Assert.Equal(IdentityAdminPasswordRecoveryMaintenanceService.PlatformOwnerRoleCode, result.AssignedRoleCode);
+        Assert.Equal(IdentityAdminPasswordRecoveryMaintenanceService.RootGroupNodeCode, result.AssignedGroupNodeCode);
+        Assert.Equal("admin_password_recovery_succeeded", result.AuditAction);
+        Assert.NotEqual(oldHash, user.PasswordHash);
+        Assert.NotEqual(
+            PasswordVerificationResult.Failed,
+            passwordHasher.VerifyHashedPassword(user, user.PasswordHash, newPassword));
+        Assert.Equal(
+            PasswordVerificationResult.Failed,
+            passwordHasher.VerifyHashedPassword(user, user.PasswordHash, oldPassword));
+        Assert.Single(user.UserRoles);
+        Assert.Equal(seed.Role.Id, user.UserRoles.Single().RoleId);
+        Assert.True(await dbContext.GroupAdminAssignments.AnyAsync(
+            item => item.GroupNodeId == seed.RootNode.Id && item.UserId == user.Id));
+        Assert.Equal(2, auditRecords.Length);
+        Assert.Contains(auditRecords, item => item.Action == "admin_password_recovery_attempted");
+        Assert.Contains(auditRecords, item => item.Action == "admin_password_recovery_succeeded");
+        Assert.All(auditRecords, item => Assert.Equal(AuditCategories.Authentication, item.Category));
+        Assert.All(auditRecords, item => Assert.Equal("App.Maintenance identity-admin reset-password", item.RequestPath));
+        AssertAuditRecordsAreSecretSafe(auditRecords, oldPassword, newPassword, oldHash, user.PasswordHash);
+    }
+
+    [Fact]
+    public async Task ResetPasswordAsyncThrowsWhenRecoveryIsDisabled()
+    {
+        using var environment = new IdentityAdminPasswordRecoveryEnvironment(
+            enabled: null,
+            login: "incident-routing-admin",
+            password: CreateEphemeralSecret());
+
+        using var dbContext = CreateDbContext();
+        var passwordHasher = new PasswordHasher<AuthUser>();
+        var seed = await SeedInteractiveRootAdminAsync(
+            dbContext,
+            passwordHasher,
+            "incident-routing-admin",
+            CreateEphemeralSecret());
+        var oldHash = seed.User.PasswordHash;
+        var service = new IdentityAdminPasswordRecoveryMaintenanceService(dbContext, passwordHasher);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.ResetPasswordAsync(CancellationToken.None));
+
+        dbContext.ChangeTracker.Clear();
+        var user = await dbContext.AuthUsers.SingleAsync();
+
+        Assert.Equal(
+            $"Environment variable {IdentityAdminPasswordRecoveryMaintenanceService.EnabledEnvironmentVariableName} must be set to 'true' to run admin password recovery.",
+            exception.Message);
+        Assert.Equal(oldHash, user.PasswordHash);
+        Assert.False(await dbContext.AuditRecords.AnyAsync());
+    }
+
+    [Fact]
+    public async Task ResetPasswordAsyncThrowsWhenLoginEnvironmentVariableIsMissing()
+    {
+        using var environment = new IdentityAdminPasswordRecoveryEnvironment(
+            enabled: "true",
+            login: null,
+            password: CreateEphemeralSecret());
+
+        using var dbContext = CreateDbContext();
+        var service = new IdentityAdminPasswordRecoveryMaintenanceService(
+            dbContext,
+            new PasswordHasher<AuthUser>());
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.ResetPasswordAsync(CancellationToken.None));
+
+        Assert.Equal(
+            $"Environment variable {IdentityAdminPasswordRecoveryMaintenanceService.LoginEnvironmentVariableName} is required for Admin login.",
+            exception.Message);
+        Assert.False(await dbContext.AuditRecords.AnyAsync());
+    }
+
+    [Fact]
+    public async Task ResetPasswordAsyncThrowsWhenPasswordEnvironmentVariableIsMissing()
+    {
+        using var environment = new IdentityAdminPasswordRecoveryEnvironment(
+            enabled: "true",
+            login: "incident-routing-admin",
+            password: null);
+
+        using var dbContext = CreateDbContext();
+        var service = new IdentityAdminPasswordRecoveryMaintenanceService(
+            dbContext,
+            new PasswordHasher<AuthUser>());
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.ResetPasswordAsync(CancellationToken.None));
+
+        Assert.Equal(
+            $"Environment variable {IdentityAdminPasswordRecoveryMaintenanceService.PasswordEnvironmentVariableName} is required. The tool does not accept command-line passwords.",
+            exception.Message);
+        Assert.False(await dbContext.AuditRecords.AnyAsync());
+    }
+
+    [Fact]
+    public async Task ResetPasswordAsyncRejectsNonexistentAccountWithSafeAudit()
+    {
+        var password = CreateEphemeralSecret();
+
+        using var environment = new IdentityAdminPasswordRecoveryEnvironment(
+            enabled: "true",
+            login: "missing-admin",
+            password);
+
+        using var dbContext = CreateDbContext();
+        await SeedRoleAndRootAsync(dbContext);
+        var service = new IdentityAdminPasswordRecoveryMaintenanceService(
+            dbContext,
+            new PasswordHasher<AuthUser>());
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.ResetPasswordAsync(CancellationToken.None));
+
+        var auditRecords = await dbContext.AuditRecords.ToArrayAsync();
+
+        Assert.Equal(
+            "Interactive root/platform admin 'missing-admin' was not found. Password was not changed.",
+            exception.Message);
+        Assert.False(await dbContext.AuthUsers.AnyAsync());
+        Assert.Equal(2, auditRecords.Length);
+        Assert.Contains(auditRecords, item => item.Action == "admin_password_recovery_attempted");
+        Assert.Contains(auditRecords, item =>
+            item.Action == "admin_password_recovery_rejected"
+            && item.PayloadJson!.Contains("target_admin_not_found", StringComparison.Ordinal));
+        AssertAuditRecordsAreSecretSafe(auditRecords, password);
+    }
+
+    [Fact]
+    public async Task ResetPasswordAsyncRejectsKnownIntegrationAccount()
+    {
+        var oldPassword = CreateEphemeralSecret();
+        var newPassword = CreateEphemeralSecret();
+
+        using var environment = new IdentityAdminPasswordRecoveryEnvironment(
+            enabled: "true",
+            login: IntegrationAccountMaintenanceService.IntegrationAccountLogin,
+            password: newPassword);
+
+        using var dbContext = CreateDbContext();
+        var passwordHasher = new PasswordHasher<AuthUser>();
+        var seed = await SeedInteractiveRootAdminAsync(
+            dbContext,
+            passwordHasher,
+            IntegrationAccountMaintenanceService.IntegrationAccountLogin,
+            oldPassword);
+        seed.User.DisplayName = IntegrationAccountMaintenanceService.IntegrationAccountDisplayName;
+        await dbContext.SaveChangesAsync();
+        var oldHash = seed.User.PasswordHash;
+        var service = new IdentityAdminPasswordRecoveryMaintenanceService(dbContext, passwordHasher);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.ResetPasswordAsync(CancellationToken.None));
+
+        dbContext.ChangeTracker.Clear();
+        var user = await dbContext.AuthUsers.SingleAsync();
+        var auditRecords = await dbContext.AuditRecords.ToArrayAsync();
+
+        Assert.Equal(
+            $"Target account '{IntegrationAccountMaintenanceService.IntegrationAccountLogin}' is not eligible for admin password recovery.",
+            exception.Message);
+        Assert.Equal(oldHash, user.PasswordHash);
+        Assert.Equal(2, auditRecords.Length);
+        Assert.Contains(auditRecords, item =>
+            item.Action == "admin_password_recovery_rejected"
+            && item.PayloadJson!.Contains("target_is_non_interactive_account", StringComparison.Ordinal));
+        AssertAuditRecordsAreSecretSafe(auditRecords, oldPassword, newPassword, oldHash);
+    }
+
+    [Theory]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    public async Task ResetPasswordAsyncRejectsAccountsWithoutRootPlatformAdminPolicy(
+        bool hasPlatformOwnerRole,
+        bool hasRootGroupAdminAssignment)
+    {
+        const string login = "branch-admin";
+        var oldPassword = CreateEphemeralSecret();
+        var newPassword = CreateEphemeralSecret();
+
+        using var environment = new IdentityAdminPasswordRecoveryEnvironment(
+            enabled: "true",
+            login,
+            password: newPassword);
+
+        using var dbContext = CreateDbContext();
+        var passwordHasher = new PasswordHasher<AuthUser>();
+        var seed = await SeedInteractiveRootAdminAsync(dbContext, passwordHasher, login, oldPassword);
+        if (!hasPlatformOwnerRole)
+        {
+            seed.User.UserRoles.Clear();
+        }
+
+        if (!hasRootGroupAdminAssignment)
+        {
+            dbContext.GroupAdminAssignments.RemoveRange(dbContext.GroupAdminAssignments);
+        }
+
+        await dbContext.SaveChangesAsync();
+        var oldHash = seed.User.PasswordHash;
+        var service = new IdentityAdminPasswordRecoveryMaintenanceService(dbContext, passwordHasher);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.ResetPasswordAsync(CancellationToken.None));
+
+        dbContext.ChangeTracker.Clear();
+        var user = await dbContext.AuthUsers.SingleAsync();
+        var auditRecords = await dbContext.AuditRecords.ToArrayAsync();
+
+        Assert.Equal(
+            "Target account 'branch-admin' is not an active root/platform admin. Password was not changed.",
+            exception.Message);
+        Assert.Equal(oldHash, user.PasswordHash);
+        Assert.Equal(2, auditRecords.Length);
+        Assert.Contains(auditRecords, item =>
+            item.Action == "admin_password_recovery_rejected"
+            && item.PayloadJson!.Contains("target_not_root_platform_admin", StringComparison.Ordinal));
+        AssertAuditRecordsAreSecretSafe(auditRecords, oldPassword, newPassword, oldHash);
+    }
+
+    [Fact]
+    public async Task ResetPasswordAsyncIsIdempotentForExistingRootPlatformAdmin()
+    {
+        const string login = "incident-routing-admin";
+        var oldPassword = CreateEphemeralSecret();
+        var firstPassword = CreateEphemeralSecret();
+        var secondPassword = CreateEphemeralSecret();
+
+        using var dbContext = CreateDbContext();
+        var passwordHasher = new PasswordHasher<AuthUser>();
+        await SeedInteractiveRootAdminAsync(dbContext, passwordHasher, login, oldPassword);
+        var service = new IdentityAdminPasswordRecoveryMaintenanceService(dbContext, passwordHasher);
+
+        using (new IdentityAdminPasswordRecoveryEnvironment("true", login, firstPassword))
+        {
+            _ = await service.ResetPasswordAsync(CancellationToken.None);
+        }
+
+        using (new IdentityAdminPasswordRecoveryEnvironment("true", login, secondPassword))
+        {
+            _ = await service.ResetPasswordAsync(CancellationToken.None);
+        }
+
+        dbContext.ChangeTracker.Clear();
+        var user = await dbContext.AuthUsers
+            .Include(item => item.UserRoles)
+            .SingleAsync(item => item.NormalizedLogin == "INCIDENT-ROUTING-ADMIN");
+
+        Assert.Equal(1, await dbContext.AuthUsers.CountAsync());
+        Assert.Equal(1, await dbContext.AuthUserRoles.CountAsync());
+        Assert.Equal(1, await dbContext.GroupAdminAssignments.CountAsync());
+        Assert.Equal(4, await dbContext.AuditRecords.CountAsync());
+        Assert.NotEqual(
+            PasswordVerificationResult.Failed,
+            passwordHasher.VerifyHashedPassword(user, user.PasswordHash, secondPassword));
+        Assert.Equal(
+            PasswordVerificationResult.Failed,
+            passwordHasher.VerifyHashedPassword(user, user.PasswordHash, firstPassword));
+    }
+
+    [Fact]
+    public async Task ResetPasswordAsyncDoesNotChangePasswordWhenRootPolicyValidationFails()
+    {
+        const string login = "incident-routing-admin";
+        var oldPassword = CreateEphemeralSecret();
+        var newPassword = CreateEphemeralSecret();
+
+        using var environment = new IdentityAdminPasswordRecoveryEnvironment(
+            enabled: "true",
+            login,
+            password: newPassword);
+
+        using var dbContext = CreateDbContext();
+        var passwordHasher = new PasswordHasher<AuthUser>();
+        var role = new AuthRole
+        {
+            Id = Guid.NewGuid(),
+            Code = IdentityAdminPasswordRecoveryMaintenanceService.PlatformOwnerRoleCode,
+            Name = "Platform Owner"
+        };
+        var user = new AuthUser
+        {
+            Id = Guid.NewGuid(),
+            Login = login,
+            NormalizedLogin = "INCIDENT-ROUTING-ADMIN",
+            DisplayName = "Incident Routing Admin",
+            IsActive = true,
+            CreatedAtUtc = DateTimeOffset.UtcNow.AddDays(-1)
+        };
+        user.PasswordHash = passwordHasher.HashPassword(user, oldPassword);
+        user.UserRoles.Add(new AuthUserRole
+        {
+            UserId = user.Id,
+            RoleId = role.Id
+        });
+        dbContext.AuthRoles.Add(role);
+        dbContext.AuthUsers.Add(user);
+        await dbContext.SaveChangesAsync();
+        var oldHash = user.PasswordHash;
+        var service = new IdentityAdminPasswordRecoveryMaintenanceService(dbContext, passwordHasher);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.ResetPasswordAsync(CancellationToken.None));
+
+        dbContext.ChangeTracker.Clear();
+        var unchangedUser = await dbContext.AuthUsers.SingleAsync();
+
+        Assert.Equal(
+            $"Active group node '{IdentityAdminPasswordRecoveryMaintenanceService.RootGroupNodeCode}' was not found. Password was not changed.",
+            exception.Message);
+        Assert.Equal(oldHash, unchangedUser.PasswordHash);
+        Assert.Equal(2, await dbContext.AuditRecords.CountAsync());
+    }
+
+    private static async Task<(AuthRole Role, GroupNode RootNode, AuthUser User)> SeedInteractiveRootAdminAsync(
+        PlatformDbContext dbContext,
+        PasswordHasher<AuthUser> passwordHasher,
+        string login,
+        string password)
+    {
+        var role = new AuthRole
+        {
+            Id = Guid.NewGuid(),
+            Code = IdentityAdminPasswordRecoveryMaintenanceService.PlatformOwnerRoleCode,
+            Name = "Platform Owner"
+        };
+        var rootNode = new GroupNode
+        {
+            Id = Guid.NewGuid(),
+            Code = IdentityAdminPasswordRecoveryMaintenanceService.RootGroupNodeCode,
+            Name = "Root",
+            Depth = 0,
+            IsActive = true
+        };
+        var user = new AuthUser
+        {
+            Id = Guid.NewGuid(),
+            Login = login,
+            NormalizedLogin = login.Trim().ToUpperInvariant(),
+            DisplayName = login,
+            IsActive = true,
+            CurrentGroupNodeId = rootNode.Id,
+            CreatedAtUtc = DateTimeOffset.UtcNow.AddDays(-1)
+        };
+
+        user.PasswordHash = passwordHasher.HashPassword(user, password);
+        user.UserRoles.Add(new AuthUserRole
+        {
+            UserId = user.Id,
+            RoleId = role.Id
+        });
+
+        dbContext.AuthRoles.Add(role);
+        dbContext.GroupNodes.Add(rootNode);
+        dbContext.AuthUsers.Add(user);
+        dbContext.GroupAdminAssignments.Add(new GroupAdminAssignment
+        {
+            GroupNodeId = rootNode.Id,
+            UserId = user.Id,
+            AssignedAtUtc = DateTimeOffset.UtcNow.AddDays(-1)
+        });
+        await dbContext.SaveChangesAsync();
+
+        return (role, rootNode, user);
+    }
+
+    private static async Task SeedRoleAndRootAsync(PlatformDbContext dbContext)
+    {
+        dbContext.AuthRoles.Add(new AuthRole
+        {
+            Id = Guid.NewGuid(),
+            Code = IdentityAdminPasswordRecoveryMaintenanceService.PlatformOwnerRoleCode,
+            Name = "Platform Owner"
+        });
+        dbContext.GroupNodes.Add(new GroupNode
+        {
+            Id = Guid.NewGuid(),
+            Code = IdentityAdminPasswordRecoveryMaintenanceService.RootGroupNodeCode,
+            Name = "Root",
+            Depth = 0,
+            IsActive = true
+        });
+
+        await dbContext.SaveChangesAsync();
+    }
+
+    private static PlatformDbContext CreateDbContext()
+    {
+        return CreateDbContext(
+            $"identity-admin-password-recovery-tests-{Guid.NewGuid():N}",
+            new InMemoryDatabaseRoot());
+    }
+
+    private static PlatformDbContext CreateDbContext(
+        string databaseName,
+        InMemoryDatabaseRoot databaseRoot)
+    {
+        var options = new DbContextOptionsBuilder<PlatformDbContext>()
+            .UseInMemoryDatabase(databaseName, databaseRoot)
+            .Options;
+
+        return new PlatformDbContext(options);
+    }
+
+    private static string CreateEphemeralSecret()
+    {
+        return $"{Guid.NewGuid():N}{Guid.NewGuid():N}";
+    }
+
+    private static void AssertAuditRecordsAreSecretSafe(
+        IEnumerable<AuditRecord> auditRecords,
+        params string[] secrets)
+    {
+        foreach (var auditRecord in auditRecords)
+        {
+            var payload = auditRecord.PayloadJson ?? string.Empty;
+            Assert.DoesNotContain("accessToken", payload, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("refreshToken", payload, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("Authorization", payload, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("connection string", payload, StringComparison.OrdinalIgnoreCase);
+
+            foreach (var secret in secrets)
+            {
+                Assert.DoesNotContain(secret, payload, StringComparison.Ordinal);
+            }
+        }
+    }
+
+    private sealed class IdentityAdminPasswordRecoveryEnvironment : IDisposable
+    {
+        private readonly EnvironmentVariableScope enabled;
+        private readonly EnvironmentVariableScope login;
+        private readonly EnvironmentVariableScope password;
+
+        public IdentityAdminPasswordRecoveryEnvironment(
+            string? enabled,
+            string? login,
+            string? password)
+        {
+            this.enabled = new EnvironmentVariableScope(
+                IdentityAdminPasswordRecoveryMaintenanceService.EnabledEnvironmentVariableName,
+                enabled);
+            this.login = new EnvironmentVariableScope(
+                IdentityAdminPasswordRecoveryMaintenanceService.LoginEnvironmentVariableName,
+                login);
+            this.password = new EnvironmentVariableScope(
+                IdentityAdminPasswordRecoveryMaintenanceService.PasswordEnvironmentVariableName,
+                password);
+        }
+
+        public void Dispose()
+        {
+            password.Dispose();
+            login.Dispose();
+            enabled.Dispose();
+        }
+    }
+
+    private sealed class EnvironmentVariableScope : IDisposable
+    {
+        private readonly string name;
+        private readonly string? originalValue;
+
+        public EnvironmentVariableScope(string name, string? value)
+        {
+            this.name = name;
+            originalValue = Environment.GetEnvironmentVariable(name);
+            Environment.SetEnvironmentVariable(name, value);
+        }
+
+        public void Dispose()
+        {
+            Environment.SetEnvironmentVariable(name, originalValue);
+        }
+    }
+}

--- a/tools/App.Maintenance/IdentityAdmin/IdentityAdminPasswordRecoveryMaintenanceService.cs
+++ b/tools/App.Maintenance/IdentityAdmin/IdentityAdminPasswordRecoveryMaintenanceService.cs
@@ -180,6 +180,9 @@ public sealed class IdentityAdminPasswordRecoveryMaintenanceService(
                 $"Target account '{user.Login}' is not an active root/platform admin. Password was not changed.");
         }
 
+        var now = DateTimeOffset.UtcNow;
+        var sessionsRevoked = await RevokeActiveSessionsAsync(user.Id, now, cancellationToken);
+
         user.PasswordHash = passwordHasher.HashPassword(user, password);
 
         await WriteAuditRecordAsync(
@@ -192,7 +195,8 @@ public sealed class IdentityAdminPasswordRecoveryMaintenanceService(
             rootGroupNode.Code,
             hasPlatformOwnerRole,
             hasRootGroupAdminAssignment,
-            cancellationToken);
+            cancellationToken,
+            sessionsRevoked);
 
         await dbContext.SaveChangesAsync(cancellationToken);
         await CommitIfStartedAsync(transaction, cancellationToken);
@@ -202,6 +206,7 @@ public sealed class IdentityAdminPasswordRecoveryMaintenanceService(
             IdentityAdminPasswordRecoveryStatus.PasswordReset,
             role.Code,
             rootGroupNode.Code,
+            sessionsRevoked,
             "admin_password_recovery_succeeded");
     }
 
@@ -271,6 +276,25 @@ public sealed class IdentityAdminPasswordRecoveryMaintenanceService(
         await transaction.CommitAsync(cancellationToken);
     }
 
+    private async Task<int> RevokeActiveSessionsAsync(
+        Guid userId,
+        DateTimeOffset revokedAtUtc,
+        CancellationToken cancellationToken)
+    {
+        var activeSessions = await dbContext.AuthSessions
+            .Where(item => item.UserId == userId
+                && item.RevokedAtUtc == null
+                && (item.ExpiresAtUtc > revokedAtUtc || item.RefreshExpiresAtUtc > revokedAtUtc))
+            .ToArrayAsync(cancellationToken);
+
+        foreach (var session in activeSessions)
+        {
+            session.RevokedAtUtc = revokedAtUtc;
+        }
+
+        return activeSessions.Length;
+    }
+
     private Task WriteAuditRecordAsync(
         string action,
         Guid? subjectUserId,
@@ -281,7 +305,8 @@ public sealed class IdentityAdminPasswordRecoveryMaintenanceService(
         string? groupNodeCode,
         bool? hasPlatformOwnerRole,
         bool? hasRootGroupAdminAssignment,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        int? sessionsRevoked = null)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -294,7 +319,8 @@ public sealed class IdentityAdminPasswordRecoveryMaintenanceService(
             roleCode,
             groupNodeCode,
             hasPlatformOwnerRole,
-            hasRootGroupAdminAssignment
+            hasRootGroupAdminAssignment,
+            sessionsRevoked
         };
 
         dbContext.AuditRecords.Add(new AuditRecord
@@ -388,4 +414,5 @@ public sealed record IdentityAdminPasswordRecoveryResult(
     IdentityAdminPasswordRecoveryStatus Status,
     string AssignedRoleCode,
     string AssignedGroupNodeCode,
+    int SessionsRevoked,
     string AuditAction);

--- a/tools/App.Maintenance/IdentityAdmin/IdentityAdminPasswordRecoveryMaintenanceService.cs
+++ b/tools/App.Maintenance/IdentityAdmin/IdentityAdminPasswordRecoveryMaintenanceService.cs
@@ -1,0 +1,391 @@
+using System.Data;
+using System.Text.Json;
+
+using App.Maintenance.IntegrationAccounts;
+
+using BuildingBlocks.Infrastructure.Observability;
+using BuildingBlocks.Infrastructure.Persistence;
+using BuildingBlocks.Infrastructure.Persistence.Entities.Audit;
+using BuildingBlocks.Infrastructure.Persistence.Entities.Auth;
+
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace App.Maintenance.IdentityAdmin;
+
+public sealed class IdentityAdminPasswordRecoveryMaintenanceService(
+    PlatformDbContext dbContext,
+    IPasswordHasher<AuthUser> passwordHasher)
+{
+    public const string EnabledEnvironmentVariableName = "AA_ADMIN_PASSWORD_RECOVERY_ENABLED";
+    public const string LoginEnvironmentVariableName = "AA_ADMIN_PASSWORD_RECOVERY_LOGIN";
+    public const string PasswordEnvironmentVariableName = "AA_ADMIN_PASSWORD_RECOVERY_PASSWORD";
+    public const string PlatformOwnerRoleCode = "platform_owner";
+    public const string RootGroupNodeCode = "root";
+
+    private const string MaintenanceMode = "reset-password";
+    private const string MaintenanceRequestPath = "App.Maintenance identity-admin reset-password";
+
+    public async Task<IdentityAdminPasswordRecoveryResult> ResetPasswordAsync(
+        CancellationToken cancellationToken)
+    {
+        EnsureExplicitlyEnabled();
+
+        var login = ReadRequiredText(LoginEnvironmentVariableName, "Admin login", 128);
+        var password = ReadRequiredPassword();
+
+        await using var transaction = await BeginSerializableTransactionIfSupportedAsync(cancellationToken);
+
+        await WriteAuditRecordAsync(
+            "admin_password_recovery_attempted",
+            subjectUserId: null,
+            login,
+            outcome: "attempted",
+            reason: null,
+            roleCode: null,
+            groupNodeCode: null,
+            hasPlatformOwnerRole: null,
+            hasRootGroupAdminAssignment: null,
+            cancellationToken);
+
+        var role = await dbContext.AuthRoles
+            .SingleOrDefaultAsync(
+                item => item.Code == PlatformOwnerRoleCode,
+                cancellationToken);
+
+        if (role is null)
+        {
+            await FailWithAuditAsync(
+                login,
+                subjectUserId: null,
+                outcome: "failed",
+                reason: "platform_owner_role_missing",
+                roleCode: PlatformOwnerRoleCode,
+                groupNodeCode: null,
+                hasPlatformOwnerRole: false,
+                hasRootGroupAdminAssignment: null,
+                transaction,
+                cancellationToken);
+
+            throw new InvalidOperationException(
+                $"Role '{PlatformOwnerRoleCode}' was not found. Password was not changed.");
+        }
+
+        var rootGroupNode = await dbContext.GroupNodes
+            .SingleOrDefaultAsync(
+                item => item.Code == RootGroupNodeCode && item.IsActive,
+                cancellationToken);
+
+        if (rootGroupNode is null)
+        {
+            await FailWithAuditAsync(
+                login,
+                subjectUserId: null,
+                outcome: "failed",
+                reason: "active_root_group_missing",
+                role.Code,
+                groupNodeCode: RootGroupNodeCode,
+                hasPlatformOwnerRole: null,
+                hasRootGroupAdminAssignment: false,
+                transaction,
+                cancellationToken);
+
+            throw new InvalidOperationException(
+                $"Active group node '{RootGroupNodeCode}' was not found. Password was not changed.");
+        }
+
+        var normalizedLogin = NormalizeLogin(login);
+        var user = await dbContext.AuthUsers
+            .Include(item => item.UserRoles)
+            .SingleOrDefaultAsync(
+                item => item.NormalizedLogin == normalizedLogin,
+                cancellationToken);
+
+        if (user is null)
+        {
+            await FailWithAuditAsync(
+                login,
+                subjectUserId: null,
+                outcome: "not_found",
+                reason: "target_admin_not_found",
+                role.Code,
+                rootGroupNode.Code,
+                hasPlatformOwnerRole: null,
+                hasRootGroupAdminAssignment: null,
+                transaction,
+                cancellationToken);
+
+            throw new InvalidOperationException(
+                $"Interactive root/platform admin '{login}' was not found. Password was not changed.");
+        }
+
+        if (IsKnownNonInteractiveAccount(user))
+        {
+            await FailWithAuditAsync(
+                user.Login,
+                user.Id,
+                outcome: "rejected",
+                reason: "target_is_non_interactive_account",
+                role.Code,
+                rootGroupNode.Code,
+                hasPlatformOwnerRole: user.UserRoles.Any(item => item.RoleId == role.Id),
+                hasRootGroupAdminAssignment: await HasRootGroupAdminAssignmentAsync(user.Id, rootGroupNode.Id, cancellationToken),
+                transaction,
+                cancellationToken);
+
+            throw new InvalidOperationException(
+                $"Target account '{user.Login}' is not eligible for admin password recovery.");
+        }
+
+        if (!user.IsActive)
+        {
+            await FailWithAuditAsync(
+                user.Login,
+                user.Id,
+                outcome: "rejected",
+                reason: "target_admin_inactive",
+                role.Code,
+                rootGroupNode.Code,
+                hasPlatformOwnerRole: user.UserRoles.Any(item => item.RoleId == role.Id),
+                hasRootGroupAdminAssignment: await HasRootGroupAdminAssignmentAsync(user.Id, rootGroupNode.Id, cancellationToken),
+                transaction,
+                cancellationToken);
+
+            throw new InvalidOperationException(
+                $"Target account '{user.Login}' is not an active root/platform admin. Password was not changed.");
+        }
+
+        var hasPlatformOwnerRole = user.UserRoles.Any(item => item.RoleId == role.Id);
+        var hasRootGroupAdminAssignment = await HasRootGroupAdminAssignmentAsync(
+            user.Id,
+            rootGroupNode.Id,
+            cancellationToken);
+
+        if (!hasPlatformOwnerRole || !hasRootGroupAdminAssignment)
+        {
+            await FailWithAuditAsync(
+                user.Login,
+                user.Id,
+                outcome: "rejected",
+                reason: "target_not_root_platform_admin",
+                role.Code,
+                rootGroupNode.Code,
+                hasPlatformOwnerRole,
+                hasRootGroupAdminAssignment,
+                transaction,
+                cancellationToken);
+
+            throw new InvalidOperationException(
+                $"Target account '{user.Login}' is not an active root/platform admin. Password was not changed.");
+        }
+
+        user.PasswordHash = passwordHasher.HashPassword(user, password);
+
+        await WriteAuditRecordAsync(
+            "admin_password_recovery_succeeded",
+            user.Id,
+            user.Login,
+            outcome: "password_reset",
+            reason: null,
+            role.Code,
+            rootGroupNode.Code,
+            hasPlatformOwnerRole,
+            hasRootGroupAdminAssignment,
+            cancellationToken);
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+        await CommitIfStartedAsync(transaction, cancellationToken);
+
+        return new IdentityAdminPasswordRecoveryResult(
+            user.Login,
+            IdentityAdminPasswordRecoveryStatus.PasswordReset,
+            role.Code,
+            rootGroupNode.Code,
+            "admin_password_recovery_succeeded");
+    }
+
+    private async Task FailWithAuditAsync(
+        string login,
+        Guid? subjectUserId,
+        string outcome,
+        string reason,
+        string? roleCode,
+        string? groupNodeCode,
+        bool? hasPlatformOwnerRole,
+        bool? hasRootGroupAdminAssignment,
+        IDbContextTransaction? transaction,
+        CancellationToken cancellationToken)
+    {
+        await WriteAuditRecordAsync(
+            "admin_password_recovery_rejected",
+            subjectUserId,
+            login,
+            outcome,
+            reason,
+            roleCode,
+            groupNodeCode,
+            hasPlatformOwnerRole,
+            hasRootGroupAdminAssignment,
+            cancellationToken);
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+        await CommitIfStartedAsync(transaction, cancellationToken);
+    }
+
+    private async Task<bool> HasRootGroupAdminAssignmentAsync(
+        Guid userId,
+        Guid rootGroupNodeId,
+        CancellationToken cancellationToken)
+    {
+        return await dbContext.GroupAdminAssignments.AnyAsync(
+            item => item.GroupNodeId == rootGroupNodeId && item.UserId == userId,
+            cancellationToken);
+    }
+
+    private async Task<IDbContextTransaction?> BeginSerializableTransactionIfSupportedAsync(
+        CancellationToken cancellationToken)
+    {
+        if (string.Equals(
+            dbContext.Database.ProviderName,
+            "Microsoft.EntityFrameworkCore.InMemory",
+            StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        return await dbContext.Database.BeginTransactionAsync(
+            IsolationLevel.Serializable,
+            cancellationToken);
+    }
+
+    private static async Task CommitIfStartedAsync(
+        IDbContextTransaction? transaction,
+        CancellationToken cancellationToken)
+    {
+        if (transaction is null)
+        {
+            return;
+        }
+
+        await transaction.CommitAsync(cancellationToken);
+    }
+
+    private Task WriteAuditRecordAsync(
+        string action,
+        Guid? subjectUserId,
+        string login,
+        string outcome,
+        string? reason,
+        string? roleCode,
+        string? groupNodeCode,
+        bool? hasPlatformOwnerRole,
+        bool? hasRootGroupAdminAssignment,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var payload = new
+        {
+            mode = MaintenanceMode,
+            login,
+            outcome,
+            reason,
+            roleCode,
+            groupNodeCode,
+            hasPlatformOwnerRole,
+            hasRootGroupAdminAssignment
+        };
+
+        dbContext.AuditRecords.Add(new AuditRecord
+        {
+            Id = Guid.NewGuid(),
+            Category = AuditCategories.Authentication,
+            Action = action,
+            SubjectUserId = subjectUserId,
+            EntityType = "auth_user",
+            EntityId = subjectUserId?.ToString("D"),
+            RequestPath = MaintenanceRequestPath,
+            PayloadJson = JsonSerializer.Serialize(payload),
+            OccurredAtUtc = DateTimeOffset.UtcNow
+        });
+
+        return Task.CompletedTask;
+    }
+
+    private static void EnsureExplicitlyEnabled()
+    {
+        var value = Environment.GetEnvironmentVariable(EnabledEnvironmentVariableName);
+
+        if (!string.Equals(value, "true", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                $"Environment variable {EnabledEnvironmentVariableName} must be set to 'true' to run admin password recovery.");
+        }
+    }
+
+    private static string ReadRequiredPassword()
+    {
+        var password = Environment.GetEnvironmentVariable(PasswordEnvironmentVariableName);
+        if (string.IsNullOrWhiteSpace(password))
+        {
+            throw new InvalidOperationException(
+                $"Environment variable {PasswordEnvironmentVariableName} is required. The tool does not accept command-line passwords.");
+        }
+
+        return password;
+    }
+
+    private static string ReadRequiredText(
+        string environmentVariableName,
+        string valueName,
+        int maxLength)
+    {
+        var value = Environment.GetEnvironmentVariable(environmentVariableName);
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new InvalidOperationException(
+                $"Environment variable {environmentVariableName} is required for {valueName}.");
+        }
+
+        value = value.Trim();
+        if (value.Length > maxLength)
+        {
+            throw new InvalidOperationException(
+                $"Environment variable {environmentVariableName} must be {maxLength} characters or fewer.");
+        }
+
+        if (value.Any(char.IsControl))
+        {
+            throw new InvalidOperationException(
+                $"Environment variable {environmentVariableName} must not contain control characters.");
+        }
+
+        return value;
+    }
+
+    private static bool IsKnownNonInteractiveAccount(AuthUser user)
+    {
+        return string.Equals(
+            user.NormalizedLogin,
+            NormalizeLogin(IntegrationAccountMaintenanceService.IntegrationAccountLogin),
+            StringComparison.Ordinal);
+    }
+
+    private static string NormalizeLogin(string login)
+    {
+        return login.Trim().ToUpperInvariant();
+    }
+}
+
+public enum IdentityAdminPasswordRecoveryStatus
+{
+    PasswordReset
+}
+
+public sealed record IdentityAdminPasswordRecoveryResult(
+    string Login,
+    IdentityAdminPasswordRecoveryStatus Status,
+    string AssignedRoleCode,
+    string AssignedGroupNodeCode,
+    string AuditAction);

--- a/tools/App.Maintenance/Program.cs
+++ b/tools/App.Maintenance/Program.cs
@@ -1,4 +1,5 @@
 using App.Maintenance.Configuration;
+using App.Maintenance.IdentityAdmin;
 using App.Maintenance.IdentityBootstrap;
 using App.Maintenance.IncidentRoutingAdmins;
 using App.Maintenance.IntegrationAccounts;
@@ -72,18 +73,27 @@ internal static class AppMaintenanceProgram
                         return 0;
                     }
 
+                case MaintenanceCommand.IdentityAdminResetPassword:
+                    {
+                        var service = scope.ServiceProvider.GetRequiredService<IdentityAdminPasswordRecoveryMaintenanceService>();
+                        var result = await service.ResetPasswordAsync(cancellationToken);
+
+                        WriteIdentityAdminPasswordRecoveryResult(standardOutput, result);
+                        return 0;
+                    }
+
                 default:
                     throw new InvalidOperationException("Maintenance command is not supported.");
             }
         }
         catch (InvalidOperationException ex)
         {
-            errorOutput.WriteLine(ex.Message);
+            WriteSafeError(errorOutput, ex.Message);
             return 1;
         }
-        catch (Exception ex)
+        catch
         {
-            errorOutput.WriteLine($"Maintenance command failed: {ex.Message}");
+            errorOutput.WriteLine("Maintenance command failed.");
             return 1;
         }
     }
@@ -99,6 +109,7 @@ internal static class AppMaintenanceProgram
         builder.Services.AddSingleton<IPasswordHasher<AuthUser>, PasswordHasher<AuthUser>>();
         builder.Services.AddScoped<IncidentRoutingAdminMaintenanceService>();
         builder.Services.AddScoped<FirstAdminBootstrapMaintenanceService>();
+        builder.Services.AddScoped<IdentityAdminPasswordRecoveryMaintenanceService>();
         builder.Services.AddScoped<IntegrationAccountMaintenanceService>();
 
         return builder.Build();
@@ -127,6 +138,14 @@ internal static class AppMaintenanceProgram
             && string.Equals(args[1], "first-admin", StringComparison.OrdinalIgnoreCase))
         {
             command = MaintenanceCommand.IdentityBootstrapFirstAdmin;
+            return true;
+        }
+
+        if (args.Length == 2
+            && string.Equals(args[0], "identity-admin", StringComparison.OrdinalIgnoreCase)
+            && string.Equals(args[1], "reset-password", StringComparison.OrdinalIgnoreCase))
+        {
+            command = MaintenanceCommand.IdentityAdminResetPassword;
             return true;
         }
 
@@ -192,18 +211,96 @@ internal static class AppMaintenanceProgram
         return wasCreated ? "created" : "exists";
     }
 
+    private static void WriteIdentityAdminPasswordRecoveryResult(
+        TextWriter writer,
+        IdentityAdminPasswordRecoveryResult result)
+    {
+        writer.WriteLine($"login: {result.Login}");
+        writer.WriteLine($"mode: reset-password");
+        writer.WriteLine($"status: {FormatIdentityAdminPasswordRecoveryStatus(result.Status)}");
+        writer.WriteLine($"role: {result.AssignedRoleCode}");
+        writer.WriteLine($"group-node: {result.AssignedGroupNodeCode}");
+        writer.WriteLine($"audit: {result.AuditAction}");
+    }
+
+    private static string FormatIdentityAdminPasswordRecoveryStatus(
+        IdentityAdminPasswordRecoveryStatus status)
+    {
+        return status switch
+        {
+            IdentityAdminPasswordRecoveryStatus.PasswordReset => "password_reset",
+            _ => "unknown"
+        };
+    }
+
     private static void WriteUsage(TextWriter writer)
     {
         writer.WriteLine("Usage:");
         writer.WriteLine("  dotnet run --project tools\\App.Maintenance\\App.Maintenance.csproj -- integration-account upsert");
         writer.WriteLine("  dotnet run --project tools\\App.Maintenance\\App.Maintenance.csproj -- incident-routing-admin upsert");
         writer.WriteLine("  dotnet run --project tools\\App.Maintenance\\App.Maintenance.csproj -- identity-bootstrap first-admin");
+        writer.WriteLine("  dotnet run --project tools\\App.Maintenance\\App.Maintenance.csproj -- identity-admin reset-password");
+    }
+
+    private static void WriteSafeError(TextWriter writer, string message)
+    {
+        writer.WriteLine(RedactSecretLikeValues(message));
+    }
+
+    private static string RedactSecretLikeValues(string message)
+    {
+        var redacted = RedactKeyValue(message, "Password");
+        redacted = RedactKeyValue(redacted, "Pwd");
+        redacted = RedactKeyValue(redacted, "AccessToken");
+        redacted = RedactKeyValue(redacted, "RefreshToken");
+        redacted = RedactAuthorizationHeader(redacted);
+
+        return redacted;
+    }
+
+    private static string RedactKeyValue(string message, string key)
+    {
+        var marker = $"{key}=";
+        var start = message.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
+        if (start < 0)
+        {
+            return message;
+        }
+
+        var valueStart = start + marker.Length;
+        var valueEnd = message.IndexOfAny([';', ' ', '\r', '\n'], valueStart);
+        if (valueEnd < 0)
+        {
+            valueEnd = message.Length;
+        }
+
+        return message[..valueStart] + "<redacted>" + message[valueEnd..];
+    }
+
+    private static string RedactAuthorizationHeader(string message)
+    {
+        const string marker = "Authorization:";
+        var start = message.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
+        if (start < 0)
+        {
+            return message;
+        }
+
+        var valueStart = start + marker.Length;
+        var valueEnd = message.IndexOfAny(['\r', '\n'], valueStart);
+        if (valueEnd < 0)
+        {
+            valueEnd = message.Length;
+        }
+
+        return message[..valueStart] + " <redacted>" + message[valueEnd..];
     }
 
     private enum MaintenanceCommand
     {
         IntegrationAccountUpsert,
         IncidentRoutingAdminUpsert,
-        IdentityBootstrapFirstAdmin
+        IdentityBootstrapFirstAdmin,
+        IdentityAdminResetPassword
     }
 }

--- a/tools/App.Maintenance/Program.cs
+++ b/tools/App.Maintenance/Program.cs
@@ -220,6 +220,7 @@ internal static class AppMaintenanceProgram
         writer.WriteLine($"status: {FormatIdentityAdminPasswordRecoveryStatus(result.Status)}");
         writer.WriteLine($"role: {result.AssignedRoleCode}");
         writer.WriteLine($"group-node: {result.AssignedGroupNodeCode}");
+        writer.WriteLine($"sessions-revoked: {result.SessionsRevoked}");
         writer.WriteLine($"audit: {result.AuditAction}");
     }
 


### PR DESCRIPTION
﻿Coder: Coder 1 acting as Coder 2 / Desktop Client
Task ID: S2-53
Module: App.Maintenance / Identity admin password recovery
Scope: Runtime maintenance command for operator-controlled admin password reset.
Changed areas:
- tools/App.Maintenance/Program.cs
- tools/App.Maintenance/IdentityAdmin/IdentityAdminPasswordRecoveryMaintenanceService.cs
- tests/Integration/App.Maintenance/AppMaintenanceProgramTests.cs
- tests/Integration/App.Maintenance/IdentityAdminPasswordRecoveryMaintenanceServiceTests.cs
Base main SHA: 18031d72b817323489a28541a7ff23505ecabf32
Coordination log entries reviewed: TEAM COORDINATION LOG issue #89.
Handoff/task cards reviewed: docs/task-cards/S2-53_operator-admin-password-recovery-task-card.txt and docs/handoffs/S2_53_OPERATOR_ADMIN_PASSWORD_RECOVERY_PROMPT.md.
Contracts: No shared DTO/contracts changes.
Migrations: None.
Feature flags / gates: Operator-local environment gate AA_ADMIN_PASSWORD_RECOVERY_ENABLED=true.
API impact: No App.Api routes or public API changes.
Web impact: No App.Web changes.
Android impact: No App.Mobile.Android changes.
Offline behavior: Not applicable; operator maintenance command only.
Rollback: Revert this PR to remove the command/tests. Any password reset already performed requires a separate approved operator action.
Validation:
- git diff --check
- dotnet restore AnalyticsAutomation-Core.sln -nologo
- dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore
- dotnet build tools/App.Maintenance/App.Maintenance.csproj -nologo -v minimal
- dotnet test tests/Integration/App.Maintenance/App.Maintenance.Tests.csproj -nologo -v minimal
Handoff docs: S2-53 task card/handoff already merged in PR #121.
Next step: Review/merge, then separate manual Korobochka deploy, then operator-local reset-password smoke with secrets entered out of band.
NO-GO / Deferred:
- No open registration.
- No desktop user creation UI.
- No manual DB edit.
- No App.Api changes.
- No migrations.
- No deploy in this PR.
