### PR TITLE
S2-54 show desktop signin result feedback

### DIFF
--- a/docs/task-cards/S2-54_desktop-signin-feedback-fix-task-card.txt
+++ b/docs/task-cards/S2-54_desktop-signin-feedback-fix-task-card.txt
@@ -1,0 +1,89 @@
+Title:
+S2-54 Desktop SignIn Feedback Fix Task Card
+
+Owner:
+Coder 1 acting as Coder 2 / Desktop Client
+
+Module:
+App.Desktop / SignIn feedback
+
+Client form:
+desktop standalone
+
+Type:
+narrow runtime UX bugfix for the existing S2-51 desktop SignIn surface
+
+Status:
+Runtime bugfix task card created before code changes.
+
+Goal:
+Make the existing desktop SignIn surface visibly communicate sign-in state and results after manual smoke found no visible feedback for rejected or successful credentials.
+
+Context:
+S2-51 desktop SignIn runtime is already approved and merged. The desktop window opens and fields are visible, but the user needs explicit visible feedback for progress, rejected credentials, unavailable control plane, and successful sign-in.
+
+Scope:
+- Add explicit UI-facing SignIn status/result feedback inside App.Desktop.
+- Keep result text safe and sanitized.
+- Prevent duplicate concurrent submit from the ViewModel/UI.
+- Keep password clearing after attempted sign-in reliable.
+- Add focused App.Desktop unit tests for visible result behavior and secret-safe messages.
+
+Contracts:
+No App.Api or shared DTO contract changes.
+
+Migrations:
+None.
+
+Feature flag:
+Not needed. This is a UI bugfix for the existing desktop SignIn surface.
+
+Events / audit:
+None client-side. Server auth audit behavior is unchanged.
+
+Offline behavior:
+Unchanged.
+
+Session storage:
+Preserve the current disabled/no-op token persistence. Do not add plaintext token storage or real Windows secure storage.
+
+Security guardrails:
+- Do not expose raw server response bodies.
+- Do not expose raw exception text.
+- Do not expose passwords, access tokens, refresh tokens, Authorization headers, or token-like values in UI result text.
+- Do not persist passwords.
+- Do not add credentials or secrets to repo files, tests, reports, PR body, or logs.
+
+Explicitly out of scope:
+- App.Api changes.
+- Shared contract changes.
+- DB migrations.
+- Deploy or workflow changes.
+- App.Web changes.
+- App.Mobile.Android changes.
+- Upload flow.
+- GroupTree.
+- PreUploadCheck.
+- Direct site upload.
+- UploadReceipt.
+- Offline queue.
+- Duplicate/fraud/admin review UI.
+- Real secure token storage.
+
+Allowed changed areas:
+- docs/task-cards/S2-54_desktop-signin-feedback-fix-task-card.txt
+- src/App.Desktop/**
+- tests/Unit/App.Desktop.Tests/**
+
+Validation:
+- git diff --check
+- dotnet restore AnalyticsAutomation-Core.sln -nologo
+- dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore
+- dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal
+- dotnet build AnalyticsAutomation-Core.sln -nologo -v minimal
+- dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal
+- hidden Unicode scan for changed text files
+- App.Desktop launch smoke if UI composition/startup impact justifies it
+
+Rollback:
+Revert the S2-54 PR. No contracts, migrations, deploy, or storage schema rollback is required.

--- a/src/App.Desktop/Boundaries/DesktopSignInBoundary.cs
+++ b/src/App.Desktop/Boundaries/DesktopSignInBoundary.cs
@@ -37,7 +37,13 @@ public sealed class DesktopSignInResult
         DesktopSignInStatus.NotStarted,
         session: null,
         error: null,
-        "Sign-in has not been attempted.");
+        "Enter login and password to sign in.");
+
+    public static DesktopSignInResult InProgress { get; } = new(
+        DesktopSignInStatus.InProgress,
+        session: null,
+        error: null,
+        "Signing in...");
 
     public static DesktopSignInResult Succeeded(DesktopSessionSnapshot session)
     {
@@ -47,7 +53,7 @@ public sealed class DesktopSignInResult
             DesktopSignInStatus.Succeeded,
             session,
             error: null,
-            "Signed in.");
+            CreateSuccessMessage(session));
     }
 
     public static DesktopSignInResult Rejected(string? code)
@@ -56,7 +62,10 @@ public sealed class DesktopSignInResult
             DesktopSignInStatus.Rejected,
             code,
             fallbackCode: "sign_in_rejected",
-            message: "Sign-in was rejected.");
+            message: CreateErrorMessage(
+                DesktopSignInStatus.Rejected,
+                code,
+                "sign_in_rejected"));
     }
 
     public static DesktopSignInResult Failed(string? code)
@@ -65,7 +74,10 @@ public sealed class DesktopSignInResult
             DesktopSignInStatus.Failed,
             code,
             fallbackCode: "sign_in_failed",
-            message: "Sign-in failed.");
+            message: CreateErrorMessage(
+                DesktopSignInStatus.Failed,
+                code,
+                "sign_in_failed"));
     }
 
     public static DesktopSignInResult Unavailable(string? code)
@@ -74,7 +86,10 @@ public sealed class DesktopSignInResult
             DesktopSignInStatus.Unavailable,
             code,
             fallbackCode: "sign_in_unavailable",
-            message: "Desktop sign-in is unavailable.");
+            message: CreateErrorMessage(
+                DesktopSignInStatus.Unavailable,
+                code,
+                "sign_in_unavailable"));
     }
 
     public override string ToString()
@@ -119,6 +134,82 @@ public sealed class DesktopSignInResult
 
         return trimmed;
     }
+
+    private static string CreateSuccessMessage(DesktopSessionSnapshot session)
+    {
+        if (TryCreateSafeDisplayName(session.DisplayName, out string? displayName))
+        {
+            return $"Signed in as {displayName}.";
+        }
+
+        return "Signed in.";
+    }
+
+    private static bool TryCreateSafeDisplayName(string? value, out string? displayName)
+    {
+        displayName = null;
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        string trimmed = value.Trim();
+        if (trimmed.Length > 80)
+        {
+            return false;
+        }
+
+        foreach (char character in trimmed)
+        {
+            if (char.IsControl(character))
+            {
+                return false;
+            }
+        }
+
+        string lower = trimmed.ToLowerInvariant();
+        string[] blockedFragments =
+        [
+            "authorization",
+            "bearer",
+            "password",
+            "accesstoken",
+            "access_token",
+            "refresh_token",
+            "refreshtoken"
+        ];
+
+        foreach (string blockedFragment in blockedFragments)
+        {
+            if (lower.Contains(blockedFragment, StringComparison.Ordinal))
+            {
+                return false;
+            }
+        }
+
+        displayName = trimmed;
+        return true;
+    }
+
+    private static string CreateErrorMessage(
+        DesktopSignInStatus status,
+        string? code,
+        string fallbackCode)
+    {
+        string normalizedCode = NormalizeCode(code, fallbackCode);
+        if (string.Equals(normalizedCode, "missing_credentials", StringComparison.Ordinal))
+        {
+            return "Enter login and password to sign in.";
+        }
+
+        return status switch
+        {
+            DesktopSignInStatus.Rejected => "Login or password was not accepted.",
+            DesktopSignInStatus.Unavailable => "Sign-in service is unavailable. Check connection or configuration.",
+            _ => "Sign-in could not be completed. Try again."
+        };
+    }
 }
 
 public sealed record DesktopSignInError(
@@ -128,6 +219,7 @@ public sealed record DesktopSignInError(
 public enum DesktopSignInStatus
 {
     NotStarted,
+    InProgress,
     Succeeded,
     Rejected,
     Failed,

--- a/src/App.Desktop/Components/DesktopShell.razor
+++ b/src/App.Desktop/Components/DesktopShell.razor
@@ -14,10 +14,9 @@
         <section class="desktop-signin" aria-labelledby="desktop-signin-title">
             <div class="desktop-signin__heading">
                 <h2 id="desktop-signin-title">Sign in</h2>
-                @if (SignInViewModel.LastResult.Status != DesktopSignInStatus.NotStarted)
-                {
-                    <p class="@GetSignInStatusClass()">@SignInViewModel.LastResult.Message</p>
-                }
+                <p class="@GetSignInStatusClass()" role="status" aria-live="polite">
+                    @SignInViewModel.LastResult.Message
+                </p>
             </div>
 
             <form class="desktop-signin__form" @onsubmit="SignInAsync" @onsubmit:preventDefault="true">
@@ -27,7 +26,8 @@
                         id="desktop-signin-login"
                         name="login"
                         autocomplete="username"
-                        @bind="SignInViewModel.Login" />
+                        @bind="SignInViewModel.Login"
+                        @bind:event="oninput" />
                 </label>
 
                 <label class="desktop-signin__field" for="desktop-signin-password">
@@ -37,11 +37,12 @@
                         name="password"
                         type="password"
                         autocomplete="current-password"
-                        @bind="SignInViewModel.Password" />
+                        @bind="SignInViewModel.Password"
+                        @bind:event="oninput" />
                 </label>
 
-                <button class="desktop-signin__submit" type="submit" disabled="@SignInViewModel.IsBusy">
-                    @(SignInViewModel.IsBusy ? "Signing in" : "Sign in")
+                <button class="desktop-signin__submit" type="submit" disabled="@(!SignInViewModel.CanSubmit)">
+                    @(SignInViewModel.IsBusy ? "Signing in..." : "Sign in")
                 </button>
             </form>
         </section>
@@ -58,8 +59,13 @@
 
     private string GetSignInStatusClass()
     {
-        return SignInViewModel.LastResult.Status == DesktopSignInStatus.Succeeded
-            ? "desktop-signin__message desktop-signin__message--success"
-            : "desktop-signin__message desktop-signin__message--neutral";
+        return SignInViewModel.LastResult.Status switch
+        {
+            DesktopSignInStatus.Succeeded => "desktop-signin__message desktop-signin__message--success",
+            DesktopSignInStatus.InProgress => "desktop-signin__message desktop-signin__message--progress",
+            DesktopSignInStatus.Rejected or DesktopSignInStatus.Failed or DesktopSignInStatus.Unavailable =>
+                "desktop-signin__message desktop-signin__message--error",
+            _ => "desktop-signin__message desktop-signin__message--neutral"
+        };
     }
 }

--- a/src/App.Desktop/Services/Auth/DesktopSignInViewModel.cs
+++ b/src/App.Desktop/Services/Auth/DesktopSignInViewModel.cs
@@ -4,13 +4,20 @@ namespace App.Desktop.Services.Auth;
 
 public sealed class DesktopSignInViewModel(IDesktopSignInService signInService)
 {
+    private int _isBusy;
+
     public string Login { get; set; } = string.Empty;
 
     public string Password { get; set; } = string.Empty;
 
     public Guid? DeviceId { get; set; }
 
-    public bool IsBusy { get; private set; }
+    public bool IsBusy => Volatile.Read(ref _isBusy) == 1;
+
+    public bool CanSubmit =>
+        !IsBusy
+        && !string.IsNullOrWhiteSpace(Login)
+        && !string.IsNullOrWhiteSpace(Password);
 
     public DesktopSignInResult LastResult { get; private set; } = DesktopSignInResult.NotStarted;
 
@@ -18,9 +25,22 @@ public sealed class DesktopSignInViewModel(IDesktopSignInService signInService)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        IsBusy = true;
+        if (Interlocked.Exchange(ref _isBusy, 1) == 1)
+        {
+            LastResult = DesktopSignInResult.InProgress;
+            return LastResult;
+        }
+
         try
         {
+            if (string.IsNullOrWhiteSpace(Login) || string.IsNullOrWhiteSpace(Password))
+            {
+                LastResult = DesktopSignInResult.Rejected("missing_credentials");
+                return LastResult;
+            }
+
+            LastResult = DesktopSignInResult.InProgress;
+
             LastResult = await signInService.SignInAsync(
                 Login,
                 Password,
@@ -32,7 +52,7 @@ public sealed class DesktopSignInViewModel(IDesktopSignInService signInService)
         finally
         {
             Password = string.Empty;
-            IsBusy = false;
+            Volatile.Write(ref _isBusy, 0);
         }
     }
 }

--- a/src/App.Desktop/wwwroot/app.css
+++ b/src/App.Desktop/wwwroot/app.css
@@ -89,8 +89,16 @@ body {
     color: #17643c;
 }
 
+.desktop-signin__message--progress {
+    color: #18406b;
+}
+
+.desktop-signin__message--error {
+    color: #9b1c1c;
+}
+
 .desktop-signin__message--neutral {
-    color: #6b4b00;
+    color: #52616f;
 }
 
 .desktop-signin__form {

--- a/tests/Unit/App.Desktop.Tests/DesktopSignInServiceTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopSignInServiceTests.cs
@@ -30,6 +30,103 @@ public sealed class DesktopSignInServiceTests
         Assert.DoesNotContain(session.RefreshToken!, result.ToString(), StringComparison.Ordinal);
     }
 
+    [Fact]
+    public async Task ViewModelSuccessfulSignInSetsVisibleSignedInMessage()
+    {
+        var session = CreateAuthenticatedSession(displayName: "Desktop Operator");
+        var viewModel = new DesktopSignInViewModel(new DesktopSignInService(
+            new RecordingAuthClient(DesktopAuthResult.Succeeded(session)),
+            new DesktopSessionState(new DisabledDesktopSessionStore())))
+        {
+            Login = "desktop-operator",
+            Password = CreateSensitiveValue("password")
+        };
+
+        var result = await viewModel.SignInAsync(CancellationToken.None);
+
+        Assert.Equal(DesktopSignInStatus.Succeeded, result.Status);
+        Assert.Contains("Signed in", result.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Desktop Operator", result.Message, StringComparison.Ordinal);
+        Assert.Equal(result, viewModel.LastResult);
+        Assert.False(viewModel.IsBusy);
+    }
+
+    [Fact]
+    public async Task ViewModelRejectedCredentialsSetVisibleSafeErrorMessage()
+    {
+        var password = CreateSensitiveValue("password");
+        var accessToken = CreateSensitiveValue("access");
+        var rawServerMessage = $"invalid {password} {accessToken} Authorization: Bearer secret";
+        var viewModel = new DesktopSignInViewModel(new DesktopSignInService(
+            new RecordingAuthClient(DesktopAuthResult.Rejected("invalid_credentials", rawServerMessage)),
+            new DesktopSessionState(new DisabledDesktopSessionStore())))
+        {
+            Login = "desktop-operator",
+            Password = password
+        };
+
+        var result = await viewModel.SignInAsync(CancellationToken.None);
+
+        Assert.Equal(DesktopSignInStatus.Rejected, result.Status);
+        Assert.Contains("not accepted", result.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(password, result.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain(accessToken, result.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("Authorization", result.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(result, viewModel.LastResult);
+    }
+
+    [Fact]
+    public async Task ViewModelUnavailableResultSetsVisibleSafeUnavailableMessage()
+    {
+        var password = CreateSensitiveValue("password");
+        var viewModel = new DesktopSignInViewModel(new DesktopSignInService(
+            new ThrowingAuthClient(new HttpRequestException($"transport failed {password} Authorization: Bearer secret")),
+            new DesktopSessionState(new DisabledDesktopSessionStore())))
+        {
+            Login = "desktop-operator",
+            Password = password
+        };
+
+        var result = await viewModel.SignInAsync(CancellationToken.None);
+
+        Assert.Equal(DesktopSignInStatus.Unavailable, result.Status);
+        Assert.Contains("unavailable", result.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(password, result.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("Authorization", result.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(result, viewModel.LastResult);
+    }
+
+    [Fact]
+    public async Task ViewModelVisibleResultTextDoesNotExposePasswordTokensAuthorizationOrTokenLikeValues()
+    {
+        var password = CreateSensitiveValue("password");
+        var accessToken = CreateSensitiveValue("access");
+        var refreshToken = CreateSensitiveValue("refresh");
+        const string authorizationHeader = "Authorization: Bearer secret-token";
+        var session = CreateAuthenticatedSession(
+            accessToken: accessToken,
+            refreshToken: refreshToken,
+            displayName: $"{authorizationHeader} accessToken refreshToken password");
+        var viewModel = new DesktopSignInViewModel(new DesktopSignInService(
+            new RecordingAuthClient(DesktopAuthResult.Succeeded(session)),
+            new DesktopSessionState(new DisabledDesktopSessionStore())))
+        {
+            Login = "desktop-operator",
+            Password = password
+        };
+
+        var result = await viewModel.SignInAsync(CancellationToken.None);
+
+        Assert.Equal(DesktopSignInStatus.Succeeded, result.Status);
+        Assert.Equal("Signed in.", result.Message);
+        Assert.DoesNotContain(password, result.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain(accessToken, result.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain(refreshToken, result.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain(authorizationHeader, result.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("accessToken", result.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("refreshToken", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
     [Theory]
     [MemberData(nameof(FailedAuthResults))]
     public async Task FailedSignInDoesNotMutateExistingSignedInSession(DesktopAuthResult authResult)
@@ -114,6 +211,57 @@ public sealed class DesktopSignInServiceTests
     }
 
     [Fact]
+    public void ViewModelCanSubmitRequiresLoginPasswordAndIdleState()
+    {
+        var viewModel = new DesktopSignInViewModel(new RecordingSignInService(DesktopSignInResult.InProgress));
+
+        Assert.False(viewModel.CanSubmit);
+
+        viewModel.Login = "desktop-operator";
+
+        Assert.False(viewModel.CanSubmit);
+
+        viewModel.Password = CreateSensitiveValue("password");
+
+        Assert.True(viewModel.CanSubmit);
+    }
+
+    [Fact]
+    public async Task ViewModelConcurrentDoubleSubmitIsIgnoredSafely()
+    {
+        var completion = new TaskCompletionSource<DesktopSignInResult>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var signInService = new BlockingSignInService(completion.Task);
+        var password = CreateSensitiveValue("password");
+        var viewModel = new DesktopSignInViewModel(signInService)
+        {
+            Login = "desktop-operator",
+            Password = password
+        };
+
+        Task<DesktopSignInResult> firstAttempt = viewModel.SignInAsync(CancellationToken.None).AsTask();
+        await signInService.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.True(viewModel.IsBusy);
+        Assert.False(viewModel.CanSubmit);
+        Assert.Equal(DesktopSignInStatus.InProgress, viewModel.LastResult.Status);
+
+        DesktopSignInResult secondAttempt = await viewModel.SignInAsync(CancellationToken.None);
+
+        Assert.Equal(DesktopSignInStatus.InProgress, secondAttempt.Status);
+        Assert.Equal(1, signInService.CallCount);
+
+        completion.SetResult(DesktopSignInResult.Succeeded(
+            DesktopSessionSnapshot.FromSession(CreateAuthenticatedSession())));
+
+        DesktopSignInResult finalResult = await firstAttempt;
+
+        Assert.Equal(DesktopSignInStatus.Succeeded, finalResult.Status);
+        Assert.Equal(string.Empty, viewModel.Password);
+        Assert.False(viewModel.IsBusy);
+    }
+
+    [Fact]
     public async Task MissingCredentialsStayRejectedWithoutCallingAuthClient()
     {
         var authClient = new RecordingAuthClient(
@@ -139,15 +287,18 @@ public sealed class DesktopSignInServiceTests
         yield return [DesktopAuthResult.Unavailable("sign_in_unavailable", "Unavailable.")];
     }
 
-    private static DesktopAuthenticatedSession CreateAuthenticatedSession()
+    private static DesktopAuthenticatedSession CreateAuthenticatedSession(
+        string? accessToken = null,
+        string? refreshToken = null,
+        string? displayName = "Desktop Operator")
     {
         return DesktopAuthenticatedSession.Create(
             Guid.NewGuid(),
             Guid.NewGuid(),
             Guid.NewGuid(),
-            "Desktop Operator",
-            CreateSensitiveValue("access"),
-            CreateSensitiveValue("refresh"),
+            displayName,
+            accessToken ?? CreateSensitiveValue("access"),
+            refreshToken ?? CreateSensitiveValue("refresh"),
             DateTimeOffset.UtcNow,
             DateTimeOffset.UtcNow.AddMinutes(15),
             isOfflineRestricted: false);
@@ -174,6 +325,53 @@ public sealed class DesktopSignInServiceTests
             CallCount++;
             LastRequest = request;
             return ValueTask.FromResult(result);
+        }
+    }
+
+    private sealed class ThrowingAuthClient(Exception exception) : IDesktopAuthClient
+    {
+        public ValueTask<DesktopAuthResult> SignInAsync(
+            DesktopSignInRequest request,
+            CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(request);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            throw exception;
+        }
+    }
+
+    private sealed class RecordingSignInService(DesktopSignInResult result) : IDesktopSignInService
+    {
+        public ValueTask<DesktopSignInResult> SignInAsync(
+            string login,
+            string password,
+            Guid? deviceId,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            return ValueTask.FromResult(result);
+        }
+    }
+
+    private sealed class BlockingSignInService(Task<DesktopSignInResult> resultTask) : IDesktopSignInService
+    {
+        public TaskCompletionSource Started { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public int CallCount { get; private set; }
+
+        public ValueTask<DesktopSignInResult> SignInAsync(
+            string login,
+            string password,
+            Guid? deviceId,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            CallCount++;
+            Started.TrySetResult();
+            return new ValueTask<DesktopSignInResult>(resultTask);
         }
     }
 }


### PR DESCRIPTION
## Coder
Coder 1 acting as Coder 2 / Desktop Client

## Task ID
S2-54

## Module
App.Desktop / SignIn feedback

## Scope
Narrow desktop UX feedback bugfix for the already approved S2-51 SignIn runtime surface.

## Changed areas
- `docs/task-cards/S2-54_desktop-signin-feedback-fix-task-card.txt`
- `src/App.Desktop/Boundaries/DesktopSignInBoundary.cs`
- `src/App.Desktop/Components/DesktopShell.razor`
- `src/App.Desktop/Services/Auth/DesktopSignInViewModel.cs`
- `src/App.Desktop/wwwroot/app.css`
- `tests/Unit/App.Desktop.Tests/DesktopSignInServiceTests.cs`

## Base main SHA
`31c912c8aabe4ffccb1e0181e264ec02338be13b`

## Coordination log entries reviewed
TEAM COORDINATION LOG issue #89 with comments, including:
- PR #117 S2-51 Desktop SignIn Runtime Enablement Task Card
- PR #118 S2-51 desktop signin runtime enablement
- PR #121 S2-53 operator admin password recovery task card
- PR #122 S2-53 operator admin password recovery runtime

## Handoff/task cards reviewed
- `00_START_HERE_README.txt`
- `01_MASTER_PLAN_AND_ARCHITECTURE.txt`
- `02_SHARED_RULES_AND_PROTOCOLS.txt`
- `04_GITHUB_WORKFLOW_AND_INFRA_RULES.txt`
- `docs/task-cards/S2-51_desktop-signin-runtime-enablement-task-card.txt`
- `docs/handoffs/S2_51_DESKTOP_SIGNIN_RUNTIME_ENABLEMENT_PROMPT.md`
- `docs/task-cards/S2-53_operator-admin-password-recovery-task-card.txt`
- `docs/handoffs/S2_53_OPERATOR_ADMIN_PASSWORD_RECOVERY_PROMPT.md`
- `src/App.Desktop/**`
- `tests/Unit/App.Desktop.Tests/**`

## Contracts
No App.Api or shared DTO contract changes.

## Migrations
None.

## Feature flags
None. This is a UI bugfix for the existing desktop SignIn surface.

## API impact
No App.Api changes. Existing auth endpoint contract is unchanged.

## Web impact
No App.Web changes.

## Android impact
No App.Mobile.Android changes.

## Offline behavior
Unchanged.

## Rollback
Revert this PR. No contract, migration, deploy, or storage rollback is required.

## Validation
- `git diff --check` - passed
- `dotnet restore AnalyticsAutomation-Core.sln -nologo` - passed
- `dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore` - passed after running formatter once for final newline normalization
- `dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal` - passed, 0 warnings, 0 errors
- `dotnet build AnalyticsAutomation-Core.sln -nologo -v minimal` - passed, 0 errors, existing warnings outside this slice
- `dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal` - passed, 46/46
- Hidden Unicode scan of changed text files - passed
- Bounded App.Desktop launch smoke - passed, window handle detected; no credentials entered

## Handoff docs/task card
Created `docs/task-cards/S2-54_desktop-signin-feedback-fix-task-card.txt` before runtime code changes.

## Next step
Review the visible SignIn feedback behavior in the desktop app and merge if acceptable. Do not deploy from this PR.

## NO-GO / Deferred
No upload flow, GroupTree, PreUploadCheck, direct site upload, UploadReceipt, offline queue, duplicate/fraud/admin review UI, App.Api changes, contracts, migrations, deploy workflow, App.Web, App.Mobile.Android, App.UI.Shared, App.Worker, or real secure token storage.