### PR TITLE
S2-55 desktop Russian sign-in usability

### DIFF
--- a/docs/task-cards/S2-55_desktop-russian-localization-signin-usability-task-card.txt
+++ b/docs/task-cards/S2-55_desktop-russian-localization-signin-usability-task-card.txt
@@ -1,0 +1,86 @@
+Title:
+S2-55 Desktop Russian Localization and SignIn Usability Task Card
+
+Owner:
+Coder 1 acting as Coder 2 / Desktop Client
+
+Module:
+App.Desktop / SignIn UX and Russian localization
+
+Client form:
+desktop standalone
+
+Type:
+runtime usability fix task card
+
+Status:
+Runtime desktop-only usability/localization fix created after manual smoke found that the SignIn button could stay disabled without a visible reason.
+
+Goal:
+Make the current App.Desktop SignIn surface understandable for Russian-speaking operators and make SignIn state visible. The UI must clearly show when SignIn cannot be submitted, when a sign-in request is in progress, when credentials are rejected, when the server is unavailable, and when sign-in succeeds.
+
+Context:
+S2-51 introduced the minimal desktop SignIn runtime slice.
+S2-52 introduced operator-controlled first-admin bootstrap.
+S2-53 introduced operator-controlled admin password recovery.
+S2-54 added visible SignIn feedback; manual smoke then found that the SignIn button could remain disabled and the desktop surface still needed Russian localization.
+
+Upstream context / reviewed sources:
+- Base main SHA at task start: ccff4130b2593f4bfce00cce87cbc8a2b399c787
+- Coordination log entries reviewed: TEAM COORDINATION LOG issue #89 metadata re-read by setup/PR gates; implementation report states issue #89 context was reviewed.
+- Handoff/task cards reviewed: S2-51 desktop SignIn runtime context, S2-54 desktop SignIn feedback context, App.Desktop runtime/tests.
+
+Scope:
+Allowed:
+- docs/task-cards/S2-55_desktop-russian-localization-signin-usability-task-card.txt
+- src/App.Desktop/**
+- tests/Unit/App.Desktop.Tests/**
+
+Forbidden:
+- App.Api changes
+- App.Worker changes
+- App.Web changes
+- App.Mobile.Android changes
+- App.UI.Shared changes
+- BuildingBlocks.Contracts/shared DTO changes
+- Modules changes
+- DB migrations
+- GitHub workflows
+- deploy scripts
+- full upload flow
+- registration UI
+- password reset UI
+- token persistence changes
+
+What changes:
+- Centralize current desktop SignIn visible strings in App.Desktop.
+- Use Russian labels, help, status, rejected/unavailable/failed, and success messages for the current desktop SignIn surface.
+- Make disabled SignIn state explainable to the user.
+- Enable SignIn as soon as both login and password fields contain non-whitespace input and the app is not already signing in.
+- Keep progress state visible while signing in.
+- Keep safe success indication visible after a successful sign-in.
+- Clear password after sign-in attempt.
+- Do not display passwords, access tokens, refresh tokens, Authorization headers, raw exception messages, raw response bodies, or token-like values.
+
+Validation:
+- git diff --check
+- dotnet restore AnalyticsAutomation-Core.sln -nologo
+- dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore
+- dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal
+- dotnet build AnalyticsAutomation-Core.sln -nologo -v minimal
+- dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal
+- hidden/control Unicode scan over changed text files
+- manual launch smoke after merge before next feature step
+
+Rollback:
+Revert the S2-55 PR. This returns App.Desktop SignIn strings/usability behavior to the previous S2-54 state.
+
+Definition of done:
+- App.Desktop SignIn surface is Russian for current visible strings.
+- Disabled SignIn state is understandable.
+- Wrong credentials and server unavailable states have safe visible messages.
+- Successful sign-in has a safe visible indication.
+- Password is cleared after an attempt.
+- App.Api/contracts/migrations/deploy/App.Web/App.Mobile.Android are unchanged.
+- App.Desktop unit tests cover Russian visible messages and usability behavior.
+- No deploy is run for this desktop-only client change.

--- a/src/App.Desktop/Boundaries/DesktopSignInBoundary.cs
+++ b/src/App.Desktop/Boundaries/DesktopSignInBoundary.cs
@@ -9,6 +9,83 @@ public interface IDesktopSignInService
         CancellationToken cancellationToken);
 }
 
+public static class DesktopSignInText
+{
+    public const string HeaderStatus = "Вход";
+    public const string HeaderStatusBusy = "Выполняется вход";
+    public const string HeaderStatusSignedIn = "Вход выполнен";
+    public const string Title = "Вход в систему";
+    public const string LoginLabel = "Логин";
+    public const string LoginPlaceholder = "Введите логин";
+    public const string PasswordLabel = "Пароль";
+    public const string PasswordPlaceholder = "Введите пароль";
+    public const string SubmitButton = "Войти";
+    public const string SubmitButtonBusy = "Выполняется вход...";
+    public const string NotStartedMessage = "Введите логин и пароль для входа.";
+    public const string RejectedMessage = "Логин или пароль не приняты.";
+    public const string UnavailableMessage = "Сервис входа недоступен. Проверьте подключение или настройку.";
+    public const string FailedMessage = "Не удалось выполнить вход. Попробуйте еще раз.";
+
+    public static string CreateSuccessMessage(DesktopSessionSnapshot session)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+
+        if (TryCreateSafeDisplayName(session.DisplayName, out string? displayName))
+        {
+            return $"Вход выполнен: {displayName}.";
+        }
+
+        return "Вход выполнен.";
+    }
+
+    private static bool TryCreateSafeDisplayName(string? value, out string? displayName)
+    {
+        displayName = null;
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        string trimmed = value.Trim();
+        if (trimmed.Length > 80)
+        {
+            return false;
+        }
+
+        foreach (char character in trimmed)
+        {
+            if (char.IsControl(character))
+            {
+                return false;
+            }
+        }
+
+        string lower = trimmed.ToLowerInvariant();
+        string[] blockedFragments =
+        [
+            "authorization",
+            "bearer",
+            "password",
+            "accesstoken",
+            "access_token",
+            "refresh_token",
+            "refreshtoken"
+        ];
+
+        foreach (string blockedFragment in blockedFragments)
+        {
+            if (lower.Contains(blockedFragment, StringComparison.Ordinal))
+            {
+                return false;
+            }
+        }
+
+        displayName = trimmed;
+        return true;
+    }
+}
+
 public sealed class DesktopSignInResult
 {
     private DesktopSignInResult(
@@ -37,13 +114,13 @@ public sealed class DesktopSignInResult
         DesktopSignInStatus.NotStarted,
         session: null,
         error: null,
-        "Enter login and password to sign in.");
+        DesktopSignInText.NotStartedMessage);
 
     public static DesktopSignInResult InProgress { get; } = new(
         DesktopSignInStatus.InProgress,
         session: null,
         error: null,
-        "Signing in...");
+        DesktopSignInText.SubmitButtonBusy);
 
     public static DesktopSignInResult Succeeded(DesktopSessionSnapshot session)
     {
@@ -53,7 +130,7 @@ public sealed class DesktopSignInResult
             DesktopSignInStatus.Succeeded,
             session,
             error: null,
-            CreateSuccessMessage(session));
+            DesktopSignInText.CreateSuccessMessage(session));
     }
 
     public static DesktopSignInResult Rejected(string? code)
@@ -135,63 +212,6 @@ public sealed class DesktopSignInResult
         return trimmed;
     }
 
-    private static string CreateSuccessMessage(DesktopSessionSnapshot session)
-    {
-        if (TryCreateSafeDisplayName(session.DisplayName, out string? displayName))
-        {
-            return $"Signed in as {displayName}.";
-        }
-
-        return "Signed in.";
-    }
-
-    private static bool TryCreateSafeDisplayName(string? value, out string? displayName)
-    {
-        displayName = null;
-
-        if (string.IsNullOrWhiteSpace(value))
-        {
-            return false;
-        }
-
-        string trimmed = value.Trim();
-        if (trimmed.Length > 80)
-        {
-            return false;
-        }
-
-        foreach (char character in trimmed)
-        {
-            if (char.IsControl(character))
-            {
-                return false;
-            }
-        }
-
-        string lower = trimmed.ToLowerInvariant();
-        string[] blockedFragments =
-        [
-            "authorization",
-            "bearer",
-            "password",
-            "accesstoken",
-            "access_token",
-            "refresh_token",
-            "refreshtoken"
-        ];
-
-        foreach (string blockedFragment in blockedFragments)
-        {
-            if (lower.Contains(blockedFragment, StringComparison.Ordinal))
-            {
-                return false;
-            }
-        }
-
-        displayName = trimmed;
-        return true;
-    }
-
     private static string CreateErrorMessage(
         DesktopSignInStatus status,
         string? code,
@@ -200,14 +220,14 @@ public sealed class DesktopSignInResult
         string normalizedCode = NormalizeCode(code, fallbackCode);
         if (string.Equals(normalizedCode, "missing_credentials", StringComparison.Ordinal))
         {
-            return "Enter login and password to sign in.";
+            return DesktopSignInText.NotStartedMessage;
         }
 
         return status switch
         {
-            DesktopSignInStatus.Rejected => "Login or password was not accepted.",
-            DesktopSignInStatus.Unavailable => "Sign-in service is unavailable. Check connection or configuration.",
-            _ => "Sign-in could not be completed. Try again."
+            DesktopSignInStatus.Rejected => DesktopSignInText.RejectedMessage,
+            DesktopSignInStatus.Unavailable => DesktopSignInText.UnavailableMessage,
+            _ => DesktopSignInText.FailedMessage
         };
     }
 }

--- a/src/App.Desktop/Components/DesktopShell.razor
+++ b/src/App.Desktop/Components/DesktopShell.razor
@@ -7,42 +7,52 @@
             <p class="desktop-shell__eyebrow">@BlazorHostBoundary.SurfaceName</p>
             <h1>AnalyticsAutomation Desktop</h1>
         </div>
-        <span class="desktop-shell__status">SignIn</span>
+        <span class="desktop-shell__status">@GetHeaderStatusText()</span>
     </header>
 
     <main class="desktop-shell__main">
         <section class="desktop-signin" aria-labelledby="desktop-signin-title">
             <div class="desktop-signin__heading">
-                <h2 id="desktop-signin-title">Sign in</h2>
-                <p class="@GetSignInStatusClass()" role="status" aria-live="polite">
+                <h2 id="desktop-signin-title">@DesktopSignInText.Title</h2>
+                <p id="desktop-signin-result" class="@GetSignInStatusClass()" role="status" aria-live="polite">
                     @SignInViewModel.LastResult.Message
                 </p>
             </div>
 
             <form class="desktop-signin__form" @onsubmit="SignInAsync" @onsubmit:preventDefault="true">
                 <label class="desktop-signin__field" for="desktop-signin-login">
-                    <span>Login</span>
+                    <span>@DesktopSignInText.LoginLabel</span>
                     <input
                         id="desktop-signin-login"
                         name="login"
                         autocomplete="username"
+                        placeholder="@DesktopSignInText.LoginPlaceholder"
+                        aria-describedby="desktop-signin-result"
+                        spellcheck="false"
+                        autofocus
+                        required
+                        disabled="@SignInViewModel.IsBusy"
                         @bind="SignInViewModel.Login"
                         @bind:event="oninput" />
                 </label>
 
                 <label class="desktop-signin__field" for="desktop-signin-password">
-                    <span>Password</span>
+                    <span>@DesktopSignInText.PasswordLabel</span>
                     <input
                         id="desktop-signin-password"
                         name="password"
                         type="password"
                         autocomplete="current-password"
+                        placeholder="@DesktopSignInText.PasswordPlaceholder"
+                        aria-describedby="desktop-signin-result"
+                        required
+                        disabled="@SignInViewModel.IsBusy"
                         @bind="SignInViewModel.Password"
                         @bind:event="oninput" />
                 </label>
 
                 <button class="desktop-signin__submit" type="submit" disabled="@(!SignInViewModel.CanSubmit)">
-                    @(SignInViewModel.IsBusy ? "Signing in..." : "Sign in")
+                    @(SignInViewModel.IsBusy ? DesktopSignInText.SubmitButtonBusy : DesktopSignInText.SubmitButton)
                 </button>
             </form>
         </section>
@@ -55,6 +65,16 @@
     private async Task SignInAsync()
     {
         await SignInViewModel.SignInAsync(CancellationToken.None);
+    }
+
+    private string GetHeaderStatusText()
+    {
+        return SignInViewModel.LastResult.Status switch
+        {
+            DesktopSignInStatus.Succeeded => DesktopSignInText.HeaderStatusSignedIn,
+            DesktopSignInStatus.InProgress => DesktopSignInText.HeaderStatusBusy,
+            _ => DesktopSignInText.HeaderStatus
+        };
     }
 
     private string GetSignInStatusClass()

--- a/src/App.Desktop/wwwroot/app.css
+++ b/src/App.Desktop/wwwroot/app.css
@@ -83,6 +83,7 @@ body {
     margin: 10px 0 0;
     font-size: 0.9rem;
     font-weight: 600;
+    line-height: 1.35;
 }
 
 .desktop-signin__message--success {
@@ -103,7 +104,7 @@ body {
 
 .desktop-signin__form {
     display: grid;
-    grid-template-columns: 1fr 1fr auto;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(132px, auto);
     gap: 14px;
     align-items: end;
 }
@@ -138,6 +139,7 @@ body {
     font: inherit;
     font-size: 0.9rem;
     font-weight: 650;
+    white-space: nowrap;
 }
 
 .desktop-signin__submit:disabled {

--- a/tests/Unit/App.Desktop.Tests/DesktopSignInServiceTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopSignInServiceTests.cs
@@ -45,7 +45,7 @@ public sealed class DesktopSignInServiceTests
         var result = await viewModel.SignInAsync(CancellationToken.None);
 
         Assert.Equal(DesktopSignInStatus.Succeeded, result.Status);
-        Assert.Contains("Signed in", result.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Вход выполнен", result.Message, StringComparison.Ordinal);
         Assert.Contains("Desktop Operator", result.Message, StringComparison.Ordinal);
         Assert.Equal(result, viewModel.LastResult);
         Assert.False(viewModel.IsBusy);
@@ -68,7 +68,7 @@ public sealed class DesktopSignInServiceTests
         var result = await viewModel.SignInAsync(CancellationToken.None);
 
         Assert.Equal(DesktopSignInStatus.Rejected, result.Status);
-        Assert.Contains("not accepted", result.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Логин или пароль не приняты", result.Message, StringComparison.Ordinal);
         Assert.DoesNotContain(password, result.Message, StringComparison.Ordinal);
         Assert.DoesNotContain(accessToken, result.Message, StringComparison.Ordinal);
         Assert.DoesNotContain("Authorization", result.Message, StringComparison.OrdinalIgnoreCase);
@@ -90,7 +90,7 @@ public sealed class DesktopSignInServiceTests
         var result = await viewModel.SignInAsync(CancellationToken.None);
 
         Assert.Equal(DesktopSignInStatus.Unavailable, result.Status);
-        Assert.Contains("unavailable", result.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Сервис входа недоступен", result.Message, StringComparison.Ordinal);
         Assert.DoesNotContain(password, result.Message, StringComparison.Ordinal);
         Assert.DoesNotContain("Authorization", result.Message, StringComparison.OrdinalIgnoreCase);
         Assert.Equal(result, viewModel.LastResult);
@@ -118,7 +118,7 @@ public sealed class DesktopSignInServiceTests
         var result = await viewModel.SignInAsync(CancellationToken.None);
 
         Assert.Equal(DesktopSignInStatus.Succeeded, result.Status);
-        Assert.Equal("Signed in.", result.Message);
+        Assert.Equal("Вход выполнен.", result.Message);
         Assert.DoesNotContain(password, result.Message, StringComparison.Ordinal);
         Assert.DoesNotContain(accessToken, result.Message, StringComparison.Ordinal);
         Assert.DoesNotContain(refreshToken, result.Message, StringComparison.Ordinal);
@@ -278,6 +278,22 @@ public sealed class DesktopSignInServiceTests
 
         Assert.Equal(DesktopSignInStatus.Rejected, result.Status);
         Assert.Equal(0, authClient.CallCount);
+        Assert.Equal(DesktopSignInText.NotStartedMessage, result.Message);
+    }
+
+    [Fact]
+    public void VisibleSignInTextUsesRussianLabelsAndActions()
+    {
+        Assert.Equal("Вход", DesktopSignInText.HeaderStatus);
+        Assert.Equal("Выполняется вход", DesktopSignInText.HeaderStatusBusy);
+        Assert.Equal("Вход выполнен", DesktopSignInText.HeaderStatusSignedIn);
+        Assert.Equal("Вход в систему", DesktopSignInText.Title);
+        Assert.Equal("Логин", DesktopSignInText.LoginLabel);
+        Assert.Equal("Введите логин", DesktopSignInText.LoginPlaceholder);
+        Assert.Equal("Пароль", DesktopSignInText.PasswordLabel);
+        Assert.Equal("Введите пароль", DesktopSignInText.PasswordPlaceholder);
+        Assert.Equal("Войти", DesktopSignInText.SubmitButton);
+        Assert.Equal("Выполняется вход...", DesktopSignInText.SubmitButtonBusy);
     }
 
     public static IEnumerable<object[]> FailedAuthResults()


### PR DESCRIPTION
Coder: Coder 1 acting as Coder 2 / Desktop Client
Task ID: S2-55
Module: App.Desktop / SignIn UX and Russian localization
Scope: Desktop-only SignIn usability/localization fix and task card.

Changed areas:
- docs/task-cards/S2-55_desktop-russian-localization-signin-usability-task-card.txt
- src/App.Desktop/Boundaries/DesktopSignInBoundary.cs
- src/App.Desktop/Components/DesktopShell.razor
- src/App.Desktop/wwwroot/app.css
- tests/Unit/App.Desktop.Tests/DesktopSignInServiceTests.cs

Base main SHA: ccff4130b2593f4bfce00cce87cbc8a2b399c787
Coordination log entries reviewed: TEAM COORDINATION LOG issue #89 metadata re-read by PR create/task-card gates; implementation report states issue #89 context was reviewed.
Handoff/task cards reviewed: S2-51 desktop SignIn runtime context; S2-54 desktop SignIn feedback context; S2-55 task card added in this branch.

Contracts: no shared DTO/contracts changes.
Migrations: none.
Feature flags: none.
API impact: no App.Api changes.
Web impact: App.Web unchanged.
Android impact: App.Mobile.Android unchanged.
Offline behavior: unchanged; no new offline behavior.
Rollback: revert this PR.

Validation:
- git diff --check
- dotnet restore AnalyticsAutomation-Core.sln -nologo
- dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore
- dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal
- dotnet build AnalyticsAutomation-Core.sln -nologo -v minimal
- dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal
- local hidden Unicode scan

Handoff docs: none.
Next step: merge only after CI green and review gates pass; then rerun manual desktop smoke.
NO-GO / Deferred: no App.Api changes, no registration UI, no upload flow, no deploy in this PR.
