### PR TITLE
S2-56 desktop signin submit binding fix

### DIFF
--- a/docs/task-cards/S2-56_desktop-signin-submit-binding-fix-task-card.txt
+++ b/docs/task-cards/S2-56_desktop-signin-submit-binding-fix-task-card.txt
@@ -1,0 +1,91 @@
+Title:
+S2-56 Desktop SignIn Submit Binding Fix Task Card
+
+Owner:
+Coder 1 acting as Coder 2 / Desktop Client
+
+Module:
+App.Desktop / SignIn submit binding
+
+Client form:
+desktop standalone
+
+Type:
+runtime bugfix task card
+
+Status:
+Runtime desktop-only fix created after the S2-55 desktop SignIn usability pass.
+
+Goal:
+Make the current App.Desktop SignIn submit action robust when the operator clicks the SignIn button or submits the form from the keyboard.
+
+Context:
+S2-51 enabled the minimal desktop SignIn runtime slice.
+S2-54 added visible SignIn feedback.
+S2-55 localized the SignIn surface and clarified disabled/progress/result states.
+S2-56 keeps that approved surface but tightens the submit binding so the visible SignIn action invokes the existing ViewModel path directly.
+
+Scope:
+Allowed:
+- docs/task-cards/S2-56_desktop-signin-submit-binding-fix-task-card.txt
+- src/App.Desktop/**
+- tests/Unit/App.Desktop.Tests/**
+
+Forbidden:
+- App.Api changes
+- App.Worker changes
+- App.Web changes
+- App.Mobile.Android changes
+- App.UI.Shared changes
+- BuildingBlocks.Contracts/shared DTO changes
+- Modules changes
+- DB migrations
+- GitHub workflows
+- deploy scripts
+- full upload flow
+- registration UI
+- password reset UI
+- token persistence changes
+
+What changes:
+- Keep the existing form submit path for keyboard Enter submit.
+- Add an explicit SignIn button click binding to the same submit handler.
+- Guard the component handler with the existing ViewModel CanSubmit state.
+- Preserve ViewModel duplicate-submit protection.
+- Preserve password clearing and safe visible result messages.
+- Do not display passwords, access tokens, refresh tokens, Authorization headers, raw exception messages, raw response bodies, or token-like values.
+
+Contracts:
+No App.Api or shared DTO contract changes.
+
+Migrations:
+None.
+
+Feature flags:
+Not needed. This is a UI binding bugfix for the existing desktop SignIn surface.
+
+Events/audit:
+No client-side events or audit changes. Server auth audit behavior is unchanged.
+
+Offline behavior:
+Unchanged. Desktop SignIn remains online-only for this slice.
+
+Rollback:
+Revert the S2-56 PR. This returns App.Desktop SignIn submit binding to the S2-55 behavior.
+
+Validation:
+- git diff --check
+- dotnet restore AnalyticsAutomation-Core.sln -nologo
+- dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore
+- dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal
+- dotnet build AnalyticsAutomation-Core.sln -nologo -v minimal
+- dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal
+- hidden/control Unicode scan over changed text files
+- launch smoke if practical after App.Desktop build
+
+Definition of done:
+- App.Desktop SignIn button click and keyboard form submit both target the existing safe ViewModel SignIn path.
+- Empty or busy submit is ignored by the component before calling the ViewModel.
+- Existing safe status/result/password-clearing behavior is preserved.
+- App.Desktop unit tests cover the submit binding and ViewModel current input handoff.
+- App.Api/contracts/migrations/deploy/App.Web/App.Mobile.Android are unchanged.

--- a/src/App.Desktop/Components/DesktopShell.razor
+++ b/src/App.Desktop/Components/DesktopShell.razor
@@ -19,7 +19,7 @@
                 </p>
             </div>
 
-            <form class="desktop-signin__form" @onsubmit="SignInAsync" @onsubmit:preventDefault="true">
+            <form class="desktop-signin__form" @onsubmit="SubmitSignInAsync" @onsubmit:preventDefault="true">
                 <label class="desktop-signin__field" for="desktop-signin-login">
                     <span>@DesktopSignInText.LoginLabel</span>
                     <input
@@ -51,7 +51,12 @@
                         @bind:event="oninput" />
                 </label>
 
-                <button class="desktop-signin__submit" type="submit" disabled="@(!SignInViewModel.CanSubmit)">
+                <button
+                    class="desktop-signin__submit"
+                    type="submit"
+                    disabled="@(!SignInViewModel.CanSubmit)"
+                    @onclick="SubmitSignInAsync"
+                    @onclick:preventDefault="true">
                     @(SignInViewModel.IsBusy ? DesktopSignInText.SubmitButtonBusy : DesktopSignInText.SubmitButton)
                 </button>
             </form>
@@ -62,9 +67,17 @@
 </div>
 
 @code {
-    private async Task SignInAsync()
+    private async Task SubmitSignInAsync()
     {
-        await SignInViewModel.SignInAsync(CancellationToken.None);
+        if (!SignInViewModel.CanSubmit)
+        {
+            return;
+        }
+
+        ValueTask<DesktopSignInResult> signInAttempt = SignInViewModel.SignInAsync(CancellationToken.None);
+        StateHasChanged();
+
+        await signInAttempt;
     }
 
     private string GetHeaderStatusText()

--- a/tests/Unit/App.Desktop.Tests/DesktopSignInServiceTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopSignInServiceTests.cs
@@ -52,6 +52,43 @@ public sealed class DesktopSignInServiceTests
     }
 
     [Fact]
+    public async Task ViewModelSubmitUsesCurrentBoundInputValues()
+    {
+        var password = CreateSensitiveValue("password");
+        var deviceId = Guid.NewGuid();
+        var signInService = new RecordingSignInService(DesktopSignInResult.Rejected("invalid_credentials"));
+        var viewModel = new DesktopSignInViewModel(signInService)
+        {
+            Login = "desktop-operator",
+            Password = password,
+            DeviceId = deviceId
+        };
+
+        _ = await viewModel.SignInAsync(CancellationToken.None);
+
+        Assert.Equal(1, signInService.CallCount);
+        Assert.Equal("desktop-operator", signInService.LastLogin);
+        Assert.Equal(password, signInService.LastPassword);
+        Assert.Equal(deviceId, signInService.LastDeviceId);
+    }
+
+    [Fact]
+    public void DesktopShellBindsButtonClickAndFormSubmitToSameHandler()
+    {
+        string markup = File.ReadAllText(Path.Combine(
+            FindRepositoryRoot(),
+            "src",
+            "App.Desktop",
+            "Components",
+            "DesktopShell.razor"));
+
+        Assert.Contains("@onsubmit=\"SubmitSignInAsync\"", markup, StringComparison.Ordinal);
+        Assert.Contains("type=\"submit\"", markup, StringComparison.Ordinal);
+        Assert.Contains("@onclick=\"SubmitSignInAsync\"", markup, StringComparison.Ordinal);
+        Assert.Contains("@onclick:preventDefault=\"true\"", markup, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task ViewModelRejectedCredentialsSetVisibleSafeErrorMessage()
     {
         var password = CreateSensitiveValue("password");
@@ -325,6 +362,22 @@ public sealed class DesktopSignInServiceTests
         return $"{prefix}-{Guid.NewGuid():N}";
     }
 
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "AnalyticsAutomation-Core.sln")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException("Repository root was not found.");
+    }
+
     private sealed class RecordingAuthClient(DesktopAuthResult result) : IDesktopAuthClient
     {
         public int CallCount { get; private set; }
@@ -359,6 +412,14 @@ public sealed class DesktopSignInServiceTests
 
     private sealed class RecordingSignInService(DesktopSignInResult result) : IDesktopSignInService
     {
+        public int CallCount { get; private set; }
+
+        public string? LastLogin { get; private set; }
+
+        public string? LastPassword { get; private set; }
+
+        public Guid? LastDeviceId { get; private set; }
+
         public ValueTask<DesktopSignInResult> SignInAsync(
             string login,
             string password,
@@ -366,6 +427,11 @@ public sealed class DesktopSignInServiceTests
             CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
+
+            CallCount++;
+            LastLogin = login;
+            LastPassword = password;
+            LastDeviceId = deviceId;
 
             return ValueTask.FromResult(result);
         }


### PR DESCRIPTION
## Coder
Coder 1 acting as Coder 2 / Desktop Client

## Task ID
S2-56 Desktop SignIn Submit Binding Fix

## Module
App.Desktop / SignIn submit binding

## Scope
Narrow desktop-only UI binding fix for the existing SignIn surface.

## Changed areas
- `docs/task-cards/S2-56_desktop-signin-submit-binding-fix-task-card.txt`
- `src/App.Desktop/Components/DesktopShell.razor`
- `tests/Unit/App.Desktop.Tests/DesktopSignInServiceTests.cs`

## Base main SHA
`eac38a6f11765ffd897128a11d2998496ab6fde3`

## Coordination log entries reviewed
- TEAM COORDINATION LOG issue #89 metadata and latest merge entries through PR #124 / S2-55.
- Setup report: `C:\CODEX\Temp\S2-56_DESKTOP_SIGNIN_SUBMIT_BINDING_FIX_SETUP_v1_20260429-143148.md`.

Note: the setup report pointed to `C:\CODEX\Temp\S2-56_DESKTOP_SIGNIN_SUBMIT_BINDING_FIX_PROMPT_v1.md`, but that prompt file was absent from `C:\CODEX\Temp`. Scope was reconstructed from the S2-56 setup artifact, current branch name, issue #89, and the immediately preceding S2-54/S2-55 desktop SignIn task cards/prompts.

## Handoff/task cards reviewed
- `00_START_HERE_README.txt`
- `01_MASTER_PLAN_AND_ARCHITECTURE.txt`
- `02_SHARED_RULES_AND_PROTOCOLS.txt`
- `04_GITHUB_WORKFLOW_AND_INFRA_RULES.txt`
- `docs/task-cards/S2-51_desktop-signin-runtime-enablement-task-card.txt`
- `docs/handoffs/S2_51_DESKTOP_SIGNIN_RUNTIME_ENABLEMENT_PROMPT.md`
- `docs/task-cards/S2-55_desktop-russian-localization-signin-usability-task-card.txt`
- `src/App.Desktop/**`
- `tests/Unit/App.Desktop.Tests/**`

## What changed
- Kept the existing form `@onsubmit` path for keyboard submit.
- Added an explicit SignIn button `@onclick` binding to the same component submit handler.
- Prevented the button click default submit so mouse click does not rely only on form submit behavior.
- Guarded the component handler with `SignInViewModel.CanSubmit`.
- Triggered an immediate component refresh after starting the ViewModel sign-in attempt so busy/progress state can render while the request is in flight.
- Added focused tests for current ViewModel input handoff and Razor submit/click binding.

## Contracts
No App.Api or shared DTO contract changes.

## Migrations
None.

## Feature flags
None. This is a desktop UI binding bugfix for the existing SignIn surface.

## API impact
None.

## Web impact
None. `App.Web` was not changed.

## Android impact
None. `App.Mobile.Android` was not changed.

## Offline behavior
Unchanged. Desktop SignIn remains online-only for this slice.

## Security / secrets
- No credential, token, Authorization header, raw exception, raw response, or token persistence changes.
- Existing password clearing and safe result mapping are preserved.
- Disabled/no-op token persistence remains unchanged.

## Rollback
Revert this PR.

## Validation
- `git diff --check` -> passed.
- `dotnet restore AnalyticsAutomation-Core.sln -nologo` -> passed.
- `dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore` -> passed after applying formatting once to match existing final-newline policy.
- `dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal` -> passed, 0 warnings, 0 errors.
- `dotnet build AnalyticsAutomation-Core.sln -nologo -v minimal` -> passed, 0 errors, existing analyzer warnings outside this slice.
- `dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal` -> passed, 49/49.
- Hidden/control Unicode scan over changed text files -> passed.
- App.Desktop bounded launch smoke -> process stayed running for 10 seconds; stopped intentionally; no credentials entered.

## Handoff docs/task card
- Added `docs/task-cards/S2-56_desktop-signin-submit-binding-fix-task-card.txt`.

## NO-GO / Deferred
- No App.Api changes.
- No shared contract changes.
- No migrations.
- No deploy workflow or deploy scripts.
- No App.Web changes.
- No App.Mobile.Android changes.
- No upload flow, GroupTree, PreUploadCheck, direct site upload, UploadReceipt, offline queue, duplicate/fraud/admin UI, registration UI, or password reset UI.
- No token storage expansion.

## Next step
Review the App.Desktop SignIn submit behavior and merge if acceptable. Do not deploy from this PR.