### PR TITLE
[codex] S2-57 Desktop SignIn Input Binding Fix

### DIFF
--- a/docs/task-cards/S2-57_desktop-signin-input-binding-fix-task-card.txt
+++ b/docs/task-cards/S2-57_desktop-signin-input-binding-fix-task-card.txt
@@ -1,0 +1,99 @@
+Title:
+S2-57 Desktop SignIn Input Binding Fix Task Card
+
+Owner:
+Codex / Desktop Client
+
+Module:
+App.Desktop / SignIn UI usability
+
+Client form:
+desktop standalone
+
+Type:
+runtime desktop-only input binding bugfix
+
+Status:
+Runtime bugfix created after S2-56 manual smoke found the SignIn button stayed disabled after typing credentials.
+
+Goal:
+Make the current App.Desktop SignIn surface update its submit-enabled state immediately as the operator types non-whitespace login and password values.
+
+Context:
+S2-51 enabled the minimal desktop SignIn runtime slice.
+S2-54 added safe visible SignIn feedback.
+S2-55 localized the SignIn surface and clarified disabled/progress/result states.
+S2-56 routed button click and keyboard submit to the same safe ViewModel submit path.
+
+Manual evidence after S2-56:
+The desktop window launched and the Russian UI appeared, but the SignIn button remained disabled after credentials were typed.
+
+Scope:
+Allowed:
+- docs/task-cards/S2-57_desktop-signin-input-binding-fix-task-card.txt
+- src/App.Desktop/Components/DesktopShell.razor
+- src/App.Desktop/Services/Auth/DesktopSignInViewModel.cs
+- src/App.Desktop/Boundaries/DesktopSignInBoundary.cs only for a small text constant update if needed
+- src/App.Desktop/wwwroot/app.css only for visible validation/help state if needed
+- tests/Unit/App.Desktop.Tests/DesktopSignInServiceTests.cs
+- new desktop SignIn-specific tests under tests/Unit/App.Desktop.Tests/ if needed
+
+Forbidden:
+- App.Api changes
+- App.Worker changes
+- App.Web changes
+- App.Mobile.Android changes
+- App.UI.Shared changes
+- BuildingBlocks.Contracts/shared DTO changes
+- Modules changes
+- DB migrations
+- GitHub workflows
+- deploy scripts
+- token persistence changes
+
+Implementation summary:
+- Replace implicit Razor input binding for the SignIn login/password fields with explicit live oninput handlers.
+- Update the DesktopSignInViewModel with the current typed values before the submit button disabled state is recalculated.
+- Keep the existing ViewModel CanSubmit, busy guard, submit handler, Enter-submit form behavior, and password clearing.
+
+Security guardrails:
+- Do not log or display passwords.
+- Do not display access tokens, refresh tokens, Authorization headers, raw response bodies, raw exception text, or token-like values.
+- Keep safe Russian UI result text.
+
+Contracts:
+No App.Api or shared DTO contract changes.
+
+Migrations:
+None.
+
+Feature flags:
+None.
+
+Events/audit:
+No client-side event or audit changes. Server auth audit behavior is unchanged.
+
+Offline behavior:
+Unchanged. Desktop SignIn remains online-only for this slice.
+
+Rollback:
+Revert the S2-57 PR. This returns App.Desktop SignIn input handling to the S2-56 behavior.
+
+Validation:
+- git diff --check
+- dotnet restore AnalyticsAutomation-Core.sln -nologo
+- dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore
+- dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal
+- dotnet build AnalyticsAutomation-Core.sln -nologo -v minimal
+- dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal
+- hidden/control Unicode scan over changed text files
+- launch App.Desktop only enough to verify the window starts; manual button validation remains owner/user-driven
+
+Definition of done:
+- The SignIn button becomes enabled as soon as login and password have non-whitespace text and sign-in is idle.
+- The current typed login/password values are used for the SignIn attempt.
+- Empty, whitespace, or busy submit stays disabled/ignored.
+- Button click and keyboard Enter submit continue to target the same safe submit path.
+- Password is cleared after an attempted SignIn.
+- Safe visible Russian result text is preserved.
+- App.Api/contracts/migrations/deploy/App.Web/App.Mobile.Android are unchanged.

--- a/docs/task-cards/S2-57_desktop-signin-input-binding-fix-task-card.txt
+++ b/docs/task-cards/S2-57_desktop-signin-input-binding-fix-task-card.txt
@@ -52,9 +52,10 @@ Forbidden:
 - token persistence changes
 
 Implementation summary:
-- Replace implicit Razor input binding for the SignIn login/password fields with explicit live oninput handlers.
-- Update the DesktopSignInViewModel with the current typed values before the submit button disabled state is recalculated.
-- Keep the existing ViewModel CanSubmit, busy guard, submit handler, Enter-submit form behavior, and password clearing.
+- Replace implicit Razor input binding for the SignIn login/password fields with live oninput binding.
+- Keep the submit button clickable whenever SignIn is idle, and let the ViewModel validate missing input safely.
+- Remove the native form submit dependency; route button click and Enter submit through explicit Blazor handlers.
+- Preserve login after attempted SignIn, clear password after attempted SignIn, and keep the visible Russian result message available.
 
 Security guardrails:
 - Do not log or display passwords.
@@ -87,7 +88,14 @@ Validation:
 - dotnet build AnalyticsAutomation-Core.sln -nologo -v minimal
 - dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal
 - hidden/control Unicode scan over changed text files
-- launch App.Desktop only enough to verify the window starts; manual button validation remains owner/user-driven
+- App.Desktop launch smoke
+- visual screenshots saved under C:\CODEX\Temp and not committed:
+  - baseline SignIn screen
+  - login/password entered before submit
+  - after rejected/unavailable submit
+  - after Enter-submit when practical
+  - after successful sign-in if safe credentials are available to the operator
+- report includes screenshot paths and confirms no password, accessToken, refreshToken, Authorization header, raw token-like value, or secret-bearing response is shown
 
 Definition of done:
 - The SignIn button becomes enabled as soon as login and password have non-whitespace text and sign-in is idle.
@@ -96,6 +104,10 @@ Definition of done:
 - Button click and keyboard Enter submit continue to target the same safe submit path.
 - Password is cleared after an attempted SignIn.
 - Safe visible Russian result text is preserved.
+- App.Desktop launch smoke is captured.
+- Visual smoke screenshots are captured under C:\CODEX\Temp and are not committed.
+- Visual smoke evidence includes baseline, filled login/password before submit, after rejected/unavailable submit, after Enter-submit when practical, and after successful sign-in if safe credentials are available to the operator.
+- Reports include screenshot paths without logging passwords, access tokens, refresh tokens, Authorization headers, raw token-like values, or secret-bearing responses.
 - App.Api/contracts/migrations/deploy/App.Web/App.Mobile.Android are unchanged.
 
 Review follow-up after PR #126 manual smoke:

--- a/docs/task-cards/S2-57_desktop-signin-input-binding-fix-task-card.txt
+++ b/docs/task-cards/S2-57_desktop-signin-input-binding-fix-task-card.txt
@@ -103,3 +103,8 @@ Review follow-up after PR #126 manual smoke:
 - Follow-up fix keeps the submit button clickable whenever SignIn is idle, disables it only while a request is in progress, and lets the ViewModel enforce missing-credentials validation with the existing safe Russian message.
 - Login/password inputs now use canonical live Blazor binding with oninput so typed values continue to flow into the ViewModel before click or Enter submit.
 - Native required attributes were replaced with aria-required so browser constraint validation cannot block the ViewModel validation path.
+
+Second review follow-up after PR #126 manual smoke:
+- Manual smoke against PR head ce45969f79ee2587300599768fc978152a33c9f3 confirmed the button is clickable, but clicking it cleared both login and password fields.
+- Follow-up fix removes the native form submit dependency from DesktopShell and uses an explicit button click plus explicit Enter key handler, preventing form reset/navigation behavior in WPF BlazorWebView.
+- The ViewModel contract is preserved: login remains after rejected, unavailable, failed, successful, and missing-credential attempts; password is cleared after each attempt; the visible Russian result message remains available.

--- a/docs/task-cards/S2-57_desktop-signin-input-binding-fix-task-card.txt
+++ b/docs/task-cards/S2-57_desktop-signin-input-binding-fix-task-card.txt
@@ -97,3 +97,9 @@ Definition of done:
 - Password is cleared after an attempted SignIn.
 - Safe visible Russian result text is preserved.
 - App.Api/contracts/migrations/deploy/App.Web/App.Mobile.Android are unchanged.
+
+Review follow-up after PR #126 manual smoke:
+- Manual smoke against PR head e6a3ba03512bb09c6dcfaca4b3cfa4e6f026c305 reported BUTTON_STILL_DISABLED after typing credentials.
+- Follow-up fix keeps the submit button clickable whenever SignIn is idle, disables it only while a request is in progress, and lets the ViewModel enforce missing-credentials validation with the existing safe Russian message.
+- Login/password inputs now use canonical live Blazor binding with oninput so typed values continue to flow into the ViewModel before click or Enter submit.
+- Native required attributes were replaced with aria-required so browser constraint validation cannot block the ViewModel validation path.

--- a/src/App.Desktop/Components/DesktopShell.razor
+++ b/src/App.Desktop/Components/DesktopShell.razor
@@ -28,12 +28,12 @@
                         autocomplete="username"
                         placeholder="@DesktopSignInText.LoginPlaceholder"
                         aria-describedby="desktop-signin-result"
+                        aria-required="true"
                         spellcheck="false"
                         autofocus
-                        required
                         disabled="@SignInViewModel.IsBusy"
-                        value="@SignInViewModel.Login"
-                        @oninput="UpdateLogin" />
+                        @bind-value="SignInViewModel.Login"
+                        @bind-value:event="oninput" />
                 </label>
 
                 <label class="desktop-signin__field" for="desktop-signin-password">
@@ -45,16 +45,16 @@
                         autocomplete="current-password"
                         placeholder="@DesktopSignInText.PasswordPlaceholder"
                         aria-describedby="desktop-signin-result"
-                        required
+                        aria-required="true"
                         disabled="@SignInViewModel.IsBusy"
-                        value="@SignInViewModel.Password"
-                        @oninput="UpdatePassword" />
+                        @bind-value="SignInViewModel.Password"
+                        @bind-value:event="oninput" />
                 </label>
 
                 <button
                     class="desktop-signin__submit"
                     type="submit"
-                    disabled="@(!SignInViewModel.CanSubmit)"
+                    disabled="@SignInViewModel.IsBusy"
                     @onclick="SubmitSignInAsync"
                     @onclick:preventDefault="true">
                     @(SignInViewModel.IsBusy ? DesktopSignInText.SubmitButtonBusy : DesktopSignInText.SubmitButton)
@@ -67,21 +67,9 @@
 </div>
 
 @code {
-    private void UpdateLogin(ChangeEventArgs args)
-    {
-        SignInViewModel.SetLoginInput(ReadInputValue(args));
-        StateHasChanged();
-    }
-
-    private void UpdatePassword(ChangeEventArgs args)
-    {
-        SignInViewModel.SetPasswordInput(ReadInputValue(args));
-        StateHasChanged();
-    }
-
     private async Task SubmitSignInAsync()
     {
-        if (!SignInViewModel.CanSubmit)
+        if (SignInViewModel.IsBusy)
         {
             return;
         }
@@ -90,6 +78,8 @@
         StateHasChanged();
 
         await signInAttempt;
+
+        StateHasChanged();
     }
 
     private string GetHeaderStatusText()
@@ -114,8 +104,4 @@
         };
     }
 
-    private static string ReadInputValue(ChangeEventArgs args)
-    {
-        return args.Value?.ToString() ?? string.Empty;
-    }
 }

--- a/src/App.Desktop/Components/DesktopShell.razor
+++ b/src/App.Desktop/Components/DesktopShell.razor
@@ -32,8 +32,8 @@
                         autofocus
                         required
                         disabled="@SignInViewModel.IsBusy"
-                        @bind="SignInViewModel.Login"
-                        @bind:event="oninput" />
+                        value="@SignInViewModel.Login"
+                        @oninput="UpdateLogin" />
                 </label>
 
                 <label class="desktop-signin__field" for="desktop-signin-password">
@@ -47,8 +47,8 @@
                         aria-describedby="desktop-signin-result"
                         required
                         disabled="@SignInViewModel.IsBusy"
-                        @bind="SignInViewModel.Password"
-                        @bind:event="oninput" />
+                        value="@SignInViewModel.Password"
+                        @oninput="UpdatePassword" />
                 </label>
 
                 <button
@@ -67,6 +67,18 @@
 </div>
 
 @code {
+    private void UpdateLogin(ChangeEventArgs args)
+    {
+        SignInViewModel.SetLoginInput(ReadInputValue(args));
+        StateHasChanged();
+    }
+
+    private void UpdatePassword(ChangeEventArgs args)
+    {
+        SignInViewModel.SetPasswordInput(ReadInputValue(args));
+        StateHasChanged();
+    }
+
     private async Task SubmitSignInAsync()
     {
         if (!SignInViewModel.CanSubmit)
@@ -100,5 +112,10 @@
                 "desktop-signin__message desktop-signin__message--error",
             _ => "desktop-signin__message desktop-signin__message--neutral"
         };
+    }
+
+    private static string ReadInputValue(ChangeEventArgs args)
+    {
+        return args.Value?.ToString() ?? string.Empty;
     }
 }

--- a/src/App.Desktop/Components/DesktopShell.razor
+++ b/src/App.Desktop/Components/DesktopShell.razor
@@ -1,5 +1,6 @@
 @inject IBlazorWebViewHostBoundary BlazorHostBoundary
 @inject DesktopSignInViewModel SignInViewModel
+@using Microsoft.AspNetCore.Components.Web
 
 <div class="desktop-shell">
     <header class="desktop-shell__header">
@@ -19,7 +20,7 @@
                 </p>
             </div>
 
-            <form class="desktop-signin__form" @onsubmit="SubmitSignInAsync" @onsubmit:preventDefault="true">
+            <div class="desktop-signin__form" role="group" aria-describedby="desktop-signin-result">
                 <label class="desktop-signin__field" for="desktop-signin-login">
                     <span>@DesktopSignInText.LoginLabel</span>
                     <input
@@ -33,7 +34,8 @@
                         autofocus
                         disabled="@SignInViewModel.IsBusy"
                         @bind-value="SignInViewModel.Login"
-                        @bind-value:event="oninput" />
+                        @bind-value:event="oninput"
+                        @onkeyup="SubmitSignInOnEnterAsync" />
                 </label>
 
                 <label class="desktop-signin__field" for="desktop-signin-password">
@@ -48,18 +50,18 @@
                         aria-required="true"
                         disabled="@SignInViewModel.IsBusy"
                         @bind-value="SignInViewModel.Password"
-                        @bind-value:event="oninput" />
+                        @bind-value:event="oninput"
+                        @onkeyup="SubmitSignInOnEnterAsync" />
                 </label>
 
                 <button
                     class="desktop-signin__submit"
-                    type="submit"
+                    type="button"
                     disabled="@SignInViewModel.IsBusy"
-                    @onclick="SubmitSignInAsync"
-                    @onclick:preventDefault="true">
+                    @onclick="SubmitSignInAsync">
                     @(SignInViewModel.IsBusy ? DesktopSignInText.SubmitButtonBusy : DesktopSignInText.SubmitButton)
                 </button>
-            </form>
+            </div>
         </section>
 
         <UploadPlaceholder />
@@ -67,6 +69,16 @@
 </div>
 
 @code {
+    private async Task SubmitSignInOnEnterAsync(KeyboardEventArgs args)
+    {
+        if (!string.Equals(args.Key, "Enter", StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        await SubmitSignInAsync();
+    }
+
     private async Task SubmitSignInAsync()
     {
         if (SignInViewModel.IsBusy)

--- a/src/App.Desktop/Services/Auth/DesktopSignInViewModel.cs
+++ b/src/App.Desktop/Services/Auth/DesktopSignInViewModel.cs
@@ -21,6 +21,16 @@ public sealed class DesktopSignInViewModel(IDesktopSignInService signInService)
 
     public DesktopSignInResult LastResult { get; private set; } = DesktopSignInResult.NotStarted;
 
+    public void SetLoginInput(string? login)
+    {
+        Login = login ?? string.Empty;
+    }
+
+    public void SetPasswordInput(string? password)
+    {
+        Password = password ?? string.Empty;
+    }
+
     public async ValueTask<DesktopSignInResult> SignInAsync(CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();

--- a/tests/Unit/App.Desktop.Tests/DesktopSignInServiceTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopSignInServiceTests.cs
@@ -92,7 +92,7 @@ public sealed class DesktopSignInServiceTests
     }
 
     [Fact]
-    public void DesktopShellUpdatesViewModelFromLiveInputEvents()
+    public void DesktopShellBindsInputsWithLiveInputEvents()
     {
         string markup = File.ReadAllText(Path.Combine(
             FindRepositoryRoot(),
@@ -101,15 +101,29 @@ public sealed class DesktopSignInServiceTests
             "Components",
             "DesktopShell.razor"));
 
-        Assert.Contains("value=\"@SignInViewModel.Login\"", markup, StringComparison.Ordinal);
-        Assert.Contains("@oninput=\"UpdateLogin\"", markup, StringComparison.Ordinal);
-        Assert.Contains("SignInViewModel.SetLoginInput(ReadInputValue(args));", markup, StringComparison.Ordinal);
-        Assert.Contains("value=\"@SignInViewModel.Password\"", markup, StringComparison.Ordinal);
-        Assert.Contains("@oninput=\"UpdatePassword\"", markup, StringComparison.Ordinal);
-        Assert.Contains("SignInViewModel.SetPasswordInput(ReadInputValue(args));", markup, StringComparison.Ordinal);
-        Assert.Contains("StateHasChanged();", markup, StringComparison.Ordinal);
-        Assert.DoesNotContain("@bind=\"SignInViewModel.Login\"", markup, StringComparison.Ordinal);
-        Assert.DoesNotContain("@bind=\"SignInViewModel.Password\"", markup, StringComparison.Ordinal);
+        Assert.Contains("@bind-value=\"SignInViewModel.Login\"", markup, StringComparison.Ordinal);
+        Assert.Contains("@bind-value=\"SignInViewModel.Password\"", markup, StringComparison.Ordinal);
+        Assert.Equal(2, CountOccurrences(markup, "@bind-value:event=\"oninput\""));
+        Assert.DoesNotContain("@oninput=\"UpdateLogin\"", markup, StringComparison.Ordinal);
+        Assert.DoesNotContain("@oninput=\"UpdatePassword\"", markup, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DesktopShellKeepsSubmitClickableWhileIdleAndLetsViewModelValidate()
+    {
+        string markup = File.ReadAllText(Path.Combine(
+            FindRepositoryRoot(),
+            "src",
+            "App.Desktop",
+            "Components",
+            "DesktopShell.razor"));
+
+        Assert.Contains("disabled=\"@SignInViewModel.IsBusy\"", markup, StringComparison.Ordinal);
+        Assert.DoesNotContain("disabled=\"@(!SignInViewModel.CanSubmit)\"", markup, StringComparison.Ordinal);
+        Assert.DoesNotContain(" required", markup, StringComparison.Ordinal);
+        Assert.Equal(2, CountOccurrences(markup, "aria-required=\"true\""));
+        Assert.Contains("if (SignInViewModel.IsBusy)", markup, StringComparison.Ordinal);
+        Assert.DoesNotContain("if (!SignInViewModel.CanSubmit)", markup, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -287,6 +301,27 @@ public sealed class DesktopSignInServiceTests
         Assert.True(viewModel.CanSubmit);
     }
 
+    [Fact]
+    public async Task ViewModelMissingCredentialsRejectsWithoutCallingSignInService()
+    {
+        var signInService = new RecordingSignInService(DesktopSignInResult.Succeeded(
+            DesktopSessionSnapshot.FromSession(CreateAuthenticatedSession())));
+        var viewModel = new DesktopSignInViewModel(signInService)
+        {
+            Login = " ",
+            Password = CreateSensitiveValue("password")
+        };
+
+        DesktopSignInResult result = await viewModel.SignInAsync(CancellationToken.None);
+
+        Assert.Equal(DesktopSignInStatus.Rejected, result.Status);
+        Assert.Equal(DesktopSignInText.NotStartedMessage, result.Message);
+        Assert.Equal(result, viewModel.LastResult);
+        Assert.Equal(0, signInService.CallCount);
+        Assert.Equal(string.Empty, viewModel.Password);
+        Assert.False(viewModel.IsBusy);
+    }
+
     [Theory]
     [InlineData("", "password")]
     [InlineData(" ", "password")]
@@ -415,6 +450,20 @@ public sealed class DesktopSignInServiceTests
         }
 
         throw new InvalidOperationException("Repository root was not found.");
+    }
+
+    private static int CountOccurrences(string value, string match)
+    {
+        int count = 0;
+        int startIndex = 0;
+
+        while ((startIndex = value.IndexOf(match, startIndex, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            startIndex += match.Length;
+        }
+
+        return count;
     }
 
     private sealed class RecordingAuthClient(DesktopAuthResult result) : IDesktopAuthClient

--- a/tests/Unit/App.Desktop.Tests/DesktopSignInServiceTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopSignInServiceTests.cs
@@ -76,7 +76,7 @@ public sealed class DesktopSignInServiceTests
     }
 
     [Fact]
-    public void DesktopShellBindsButtonClickAndFormSubmitToSameHandler()
+    public void DesktopShellUsesExplicitClickAndEnterSubmitWithoutNativeFormSubmit()
     {
         string markup = File.ReadAllText(Path.Combine(
             FindRepositoryRoot(),
@@ -85,10 +85,14 @@ public sealed class DesktopSignInServiceTests
             "Components",
             "DesktopShell.razor"));
 
-        Assert.Contains("@onsubmit=\"SubmitSignInAsync\"", markup, StringComparison.Ordinal);
-        Assert.Contains("type=\"submit\"", markup, StringComparison.Ordinal);
+        Assert.DoesNotContain("<form", markup, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("@onsubmit", markup, StringComparison.Ordinal);
+        Assert.DoesNotContain("type=\"submit\"", markup, StringComparison.Ordinal);
+        Assert.DoesNotContain("@onclick:preventDefault", markup, StringComparison.Ordinal);
+        Assert.Contains("type=\"button\"", markup, StringComparison.Ordinal);
         Assert.Contains("@onclick=\"SubmitSignInAsync\"", markup, StringComparison.Ordinal);
-        Assert.Contains("@onclick:preventDefault=\"true\"", markup, StringComparison.Ordinal);
+        Assert.Equal(2, CountOccurrences(markup, "@onkeyup=\"SubmitSignInOnEnterAsync\""));
+        Assert.Contains("if (!string.Equals(args.Key, \"Enter\", StringComparison.Ordinal))", markup, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -285,6 +289,32 @@ public sealed class DesktopSignInServiceTests
         Assert.DoesNotContain(password, viewModel.LastResult.ToString(), StringComparison.Ordinal);
     }
 
+    [Theory]
+    [MemberData(nameof(ViewModelAttemptResults))]
+    public async Task ViewModelPreservesLoginClearsPasswordAndKeepsVisibleResultAfterAttempt(
+        DesktopSignInResult signInResult,
+        DesktopSignInStatus expectedStatus,
+        string expectedMessage)
+    {
+        const string login = "desktop-operator";
+        var password = CreateSensitiveValue("password");
+        var viewModel = new DesktopSignInViewModel(new RecordingSignInService(signInResult))
+        {
+            Login = login,
+            Password = password
+        };
+
+        DesktopSignInResult result = await viewModel.SignInAsync(CancellationToken.None);
+
+        Assert.Equal(expectedStatus, result.Status);
+        Assert.Equal(expectedMessage, result.Message);
+        Assert.Equal(result, viewModel.LastResult);
+        Assert.Equal(login, viewModel.Login);
+        Assert.Equal(string.Empty, viewModel.Password);
+        Assert.False(string.IsNullOrWhiteSpace(viewModel.LastResult.Message));
+        Assert.DoesNotContain(password, viewModel.LastResult.ToString(), StringComparison.Ordinal);
+    }
+
     [Fact]
     public void ViewModelCanSubmitRequiresLoginPasswordAndIdleState()
     {
@@ -302,14 +332,15 @@ public sealed class DesktopSignInServiceTests
     }
 
     [Fact]
-    public async Task ViewModelMissingCredentialsRejectsWithoutCallingSignInService()
+    public async Task ViewModelMissingCredentialsRejectsWithoutCallingSignInServiceAndPreservesLogin()
     {
         var signInService = new RecordingSignInService(DesktopSignInResult.Succeeded(
             DesktopSessionSnapshot.FromSession(CreateAuthenticatedSession())));
+        const string login = "desktop-operator";
         var viewModel = new DesktopSignInViewModel(signInService)
         {
-            Login = " ",
-            Password = CreateSensitiveValue("password")
+            Login = login,
+            Password = " "
         };
 
         DesktopSignInResult result = await viewModel.SignInAsync(CancellationToken.None);
@@ -318,6 +349,7 @@ public sealed class DesktopSignInServiceTests
         Assert.Equal(DesktopSignInText.NotStartedMessage, result.Message);
         Assert.Equal(result, viewModel.LastResult);
         Assert.Equal(0, signInService.CallCount);
+        Assert.Equal(login, viewModel.Login);
         Assert.Equal(string.Empty, viewModel.Password);
         Assert.False(viewModel.IsBusy);
     }
@@ -412,6 +444,36 @@ public sealed class DesktopSignInServiceTests
         yield return [DesktopAuthResult.Rejected("invalid_credentials", "Rejected.")];
         yield return [DesktopAuthResult.Failed("sign_in_failed", "Failed.")];
         yield return [DesktopAuthResult.Unavailable("sign_in_unavailable", "Unavailable.")];
+    }
+
+    public static IEnumerable<object[]> ViewModelAttemptResults()
+    {
+        yield return
+        [
+            DesktopSignInResult.Rejected("invalid_credentials"),
+            DesktopSignInStatus.Rejected,
+            DesktopSignInText.RejectedMessage
+        ];
+        yield return
+        [
+            DesktopSignInResult.Unavailable("sign_in_unavailable"),
+            DesktopSignInStatus.Unavailable,
+            DesktopSignInText.UnavailableMessage
+        ];
+        yield return
+        [
+            DesktopSignInResult.Failed("sign_in_failed"),
+            DesktopSignInStatus.Failed,
+            DesktopSignInText.FailedMessage
+        ];
+
+        var session = CreateAuthenticatedSession(displayName: "Desktop Operator");
+        yield return
+        [
+            DesktopSignInResult.Succeeded(DesktopSessionSnapshot.FromSession(session)),
+            DesktopSignInStatus.Succeeded,
+            DesktopSignInText.CreateSuccessMessage(DesktopSessionSnapshot.FromSession(session))
+        ];
     }
 
     private static DesktopAuthenticatedSession CreateAuthenticatedSession(

--- a/tests/Unit/App.Desktop.Tests/DesktopSignInServiceTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopSignInServiceTests.cs
@@ -59,10 +59,13 @@ public sealed class DesktopSignInServiceTests
         var signInService = new RecordingSignInService(DesktopSignInResult.Rejected("invalid_credentials"));
         var viewModel = new DesktopSignInViewModel(signInService)
         {
-            Login = "desktop-operator",
-            Password = password,
+            Login = "stale-login",
+            Password = CreateSensitiveValue("stale-password"),
             DeviceId = deviceId
         };
+
+        viewModel.SetLoginInput("desktop-operator");
+        viewModel.SetPasswordInput(password);
 
         _ = await viewModel.SignInAsync(CancellationToken.None);
 
@@ -86,6 +89,27 @@ public sealed class DesktopSignInServiceTests
         Assert.Contains("type=\"submit\"", markup, StringComparison.Ordinal);
         Assert.Contains("@onclick=\"SubmitSignInAsync\"", markup, StringComparison.Ordinal);
         Assert.Contains("@onclick:preventDefault=\"true\"", markup, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DesktopShellUpdatesViewModelFromLiveInputEvents()
+    {
+        string markup = File.ReadAllText(Path.Combine(
+            FindRepositoryRoot(),
+            "src",
+            "App.Desktop",
+            "Components",
+            "DesktopShell.razor"));
+
+        Assert.Contains("value=\"@SignInViewModel.Login\"", markup, StringComparison.Ordinal);
+        Assert.Contains("@oninput=\"UpdateLogin\"", markup, StringComparison.Ordinal);
+        Assert.Contains("SignInViewModel.SetLoginInput(ReadInputValue(args));", markup, StringComparison.Ordinal);
+        Assert.Contains("value=\"@SignInViewModel.Password\"", markup, StringComparison.Ordinal);
+        Assert.Contains("@oninput=\"UpdatePassword\"", markup, StringComparison.Ordinal);
+        Assert.Contains("SignInViewModel.SetPasswordInput(ReadInputValue(args));", markup, StringComparison.Ordinal);
+        Assert.Contains("StateHasChanged();", markup, StringComparison.Ordinal);
+        Assert.DoesNotContain("@bind=\"SignInViewModel.Login\"", markup, StringComparison.Ordinal);
+        Assert.DoesNotContain("@bind=\"SignInViewModel.Password\"", markup, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -254,13 +278,28 @@ public sealed class DesktopSignInServiceTests
 
         Assert.False(viewModel.CanSubmit);
 
-        viewModel.Login = "desktop-operator";
+        viewModel.SetLoginInput("desktop-operator");
 
         Assert.False(viewModel.CanSubmit);
 
-        viewModel.Password = CreateSensitiveValue("password");
+        viewModel.SetPasswordInput(CreateSensitiveValue("password"));
 
         Assert.True(viewModel.CanSubmit);
+    }
+
+    [Theory]
+    [InlineData("", "password")]
+    [InlineData(" ", "password")]
+    [InlineData("desktop-operator", "")]
+    [InlineData("desktop-operator", " ")]
+    public void ViewModelCanSubmitRejectsMissingOrWhitespaceInput(string login, string password)
+    {
+        var viewModel = new DesktopSignInViewModel(new RecordingSignInService(DesktopSignInResult.InProgress));
+
+        viewModel.SetLoginInput(login);
+        viewModel.SetPasswordInput(password);
+
+        Assert.False(viewModel.CanSubmit);
     }
 
     [Fact]


### PR DESCRIPTION
## Coder
Codex

## Task ID
S2-57

## Module
App.Desktop / SignIn UI usability

## Scope
Fix the standalone desktop SignIn input/submit path so the `Войти` button is clickable while SignIn is idle, does not trigger native form reset/navigation behavior in WPF BlazorWebView, preserves login after attempts, clears only password, and keeps safe Russian result messages visible.

## Latest visual smoke evidence update
Follow-up commit `5411c2b3d39b821744b0fab35c99a19ac1141b86` updates the S2-57 task card so desktop UI tasks require visual smoke screenshots as validation artifacts.

Visual smoke was run from this PR branch with `AA_DESKTOP_CONTROL_PLANE_BASE_ADDRESS=http://192.168.1.66/`.

Screenshots were captured automatically and saved outside the repository under:

`C:\CODEX\Temp\S2-57_PR126_VISUAL_SMOKE_20260429_213625`

Screenshot files:

- `01_baseline_signin.png`
- `02_filled_before_submit.png`
- `03_after_invalid_or_unavailable_button_submit.png`
- `04_after_enter_submit.png`

Observed result: baseline screen rendered; filled state showed login and masked password; button submit kept login, cleared password, and showed safe Russian rejected/unavailable result; Enter-submit also kept login, cleared password, and kept the visible Russian result message. Successful sign-in screenshot was not captured because no safe known credentials were entered by an operator.

No screenshots or runtime artifacts were committed.

## Manual smoke blockers addressed
Manual smoke against PR head `e6a3ba03512bb09c6dcfaca4b3cfa4e6f026c305` reported:

- `MANUAL_RESULT=BUTTON_STILL_DISABLED`
- `STATUS=APP_DESKTOP_MANUAL_RUN_COMPLETED`

Follow-up head `ce45969f79ee2587300599768fc978152a33c9f3` made the button clickable, but manual smoke then found that clicking `Войти` cleared both login and password.

The form-reset follow-up commit `9e233f05b9b37d5be620b44ee5377e694a3d8e72` removed the native form submit dependency.

## Changed areas
- `docs/task-cards/S2-57_desktop-signin-input-binding-fix-task-card.txt`
- `src/App.Desktop/Components/DesktopShell.razor`
- `tests/Unit/App.Desktop.Tests/DesktopSignInServiceTests.cs`

Latest commit changes only the S2-57 task card; screenshots remain outside git.

## Root cause
The desktop shell previously relied on native `<form>` submit semantics plus a submit button and Blazor click handler. In WPF BlazorWebView, that reset-prone native submit path could clear/recreate form state after clicking `Войти`, wiping the login field along with the password and threatening the visible result state.

## Fix summary
- Removed the native `<form>` wrapper from `DesktopShell.razor`.
- Changed the SignIn button to explicit `type="button"` with the existing Blazor click handler.
- Added explicit Enter-key handling on login/password inputs, routed to the same `SubmitSignInAsync` path.
- Kept live `@bind-value:event="oninput"` input binding.
- Kept the button disabled only while `SignInViewModel.IsBusy`, not because of `CanSubmit` while idle.
- Kept ViewModel validation as the source of truth for missing/whitespace credentials.
- Required future S2-57 desktop UI validation to include visual screenshots saved under `C:\CODEX\Temp` and not committed.

## Behavior implemented
- `Войти` remains clickable while SignIn is idle.
- Typing non-empty login/password supports immediate click or Enter submit.
- Click and Enter no longer depend on native form submit/reset/navigation behavior.
- After any sign-in attempt: password is cleared, login is preserved, and the visible Russian result message remains in `LastResult`.
- Wrong credentials show the safe Russian rejected message.
- Unavailable server shows the safe Russian unavailable message.
- Successful sign-in shows a visible Russian success indication when safe credentials are available.
- Empty/whitespace credentials do not call auth, preserve typed login if present, clear password, and show safe Russian guidance.
- No password, accessToken, refreshToken, Authorization header, raw response body, raw exception text, token-like values, or connection strings are printed in UI, tests, diagnostics, reports, or PR notes.

## Base main SHA
`52388f1f9448f89f409e0a1310299fb1bd374c50`

## New PR head SHA
`5411c2b3d39b821744b0fab35c99a19ac1141b86`

## Validation
Latest visual smoke evidence update:

- `git diff --check` passed; Git emitted Windows CRLF working-copy warning only
- `dotnet restore AnalyticsAutomation-Core.sln -nologo` passed
- `dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore` passed
- `dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal` passed with 0 warnings / 0 errors
- `dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal` passed: 60/60
- hidden/control Unicode scan over changed text files passed
- visual smoke screenshots captured automatically under `C:\CODEX\Temp\S2-57_PR126_VISUAL_SMOKE_20260429_213625`

Previous form-reset validation also included full solution build passing with existing analyzer warnings outside S2-57 scope / 0 errors.

## Handoff docs / task card
Updated `docs/task-cards/S2-57_desktop-signin-input-binding-fix-task-card.txt` so Definition of Done explicitly requires App.Desktop launch smoke, visual screenshots, screenshot paths in reports, Temp-only storage, and no secrets/tokens/passwords in evidence.

## Forbidden scope confirmation
No changes to App.Api, contracts, migrations, App.Web, App.Mobile.Android, App.Worker, Modules, `.github/workflows`, deploy scripts, or runtime/deploy assets.

## NO-GO / Deferred
- No merge
- No deploy
- No automated successful credential entry
- No direct push to main

## Next step
Operator can review the Temp screenshots and, if safe credentials are available, manually capture the optional successful sign-in screenshot under the same Temp evidence discipline before marking PR #126 ready.