### PR TITLE
[codex] S2-58 Desktop Visual Smoke Fake Auth Harness

### DIFF
--- a/docs/task-cards/S2-58_desktop-visual-smoke-fake-auth-task-card.txt
+++ b/docs/task-cards/S2-58_desktop-visual-smoke-fake-auth-task-card.txt
@@ -1,0 +1,85 @@
+Title:
+S2-58 Desktop Visual Smoke Fake Auth Harness
+
+Owner:
+Codex / Desktop Client
+
+Module:
+App.Desktop / visual-smoke auth harness
+
+Client form:
+desktop standalone
+
+Type:
+runtime desktop-only dev/test harness
+
+Status:
+Implemented in this branch.
+
+Goal:
+Add a safe, repeatable App.Desktop visual-smoke authentication harness that lets Codex capture baseline, rejected, and successful SignIn screenshots without real Korobochka credentials.
+
+Context:
+S2-51 enabled the desktop SignIn runtime through the existing auth boundary and live HttpDesktopAuthClient.
+S2-54 through S2-57 made the SignIn UI visibly safe, Russian, clickable, and screenshot-worthy.
+S2-57 proved the value of desktop visual-smoke evidence but still lacked safe credentials for the successful sign-in state.
+
+Guard:
+Fake auth is enabled only by the explicit local dev/test variable:
+AA_DESKTOP_DEV_FAKE_AUTH_ENABLED=true
+
+The composition root registers the fake auth client only in Debug builds and only when no live control-plane base address is configured. If AA_DESKTOP_CONTROL_PLANE_BASE_ADDRESS is configured, the live HttpDesktopAuthClient path remains selected.
+
+Fake credentials:
+login: visual-smoke-user
+password: visual-smoke-password
+
+These are fixed non-secret test data for local visual smoke only.
+
+Security guardrails:
+- Fake auth never calls App.Api.
+- Fake auth does not create users or write persistence.
+- Fake auth does not work as a replacement for configured live/Korobochka auth.
+- Production/live sign-in continues to require operator-entered real credentials through HttpDesktopAuthClient.
+- Do not display or log password, accessToken, refreshToken, Authorization, raw token-like values, raw response bodies, or secret-bearing errors.
+- Screenshots and runtime artifacts stay under C:\CODEX\Temp and are not committed.
+
+Scope:
+Allowed:
+- docs/task-cards/S2-58_desktop-visual-smoke-fake-auth-task-card.txt
+- src/App.Desktop/**
+- tests/Unit/App.Desktop.Tests/**
+
+Forbidden:
+- src/App.Api/**
+- src/App.Worker/**
+- src/App.Web/**
+- src/App.Mobile.Android/**
+- src/App.UI.Shared/**
+- src/BuildingBlocks.Contracts/**
+- src/Modules/**
+- DB migrations
+- .github/workflows/**
+- deploy scripts
+- docs/ops/**
+- committed screenshots or runtime artifacts
+
+Validation:
+- git diff --check
+- dotnet restore AnalyticsAutomation-Core.sln -nologo
+- dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore
+- dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal
+- dotnet build AnalyticsAutomation-Core.sln -nologo -v minimal
+- dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal
+- hidden/control Unicode scan over changed text files
+- App.Desktop launch visual smoke with fake auth enabled
+
+Definition of done:
+- Fake auth is disabled by default.
+- Fake auth requires AA_DESKTOP_DEV_FAKE_AUTH_ENABLED=true and Debug build behavior.
+- Fake auth does not replace configured live auth.
+- Fake auth succeeds only for the fixed visual-smoke test credentials.
+- Wrong fake credentials produce a safe rejected state.
+- Fake-auth diagnostics and visible strings do not expose credentials or token values.
+- Required screenshots are saved under C:\CODEX\Temp and kept out of git.
+- App.Api/contracts/migrations/deploy/App.Web/App.Mobile.Android are unchanged.

--- a/src/App.Desktop/Composition/DesktopCompositionRoot.cs
+++ b/src/App.Desktop/Composition/DesktopCompositionRoot.cs
@@ -39,7 +39,11 @@ public static class DesktopCompositionRoot
             serviceProvider => serviceProvider.GetRequiredService<DesktopSessionState>());
         services.AddSingleton<IDesktopAuthSessionBoundary>(
             serviceProvider => serviceProvider.GetRequiredService<DesktopSessionState>());
-        if (authOptions.IsControlPlaneSignInConfigured)
+        if (authOptions.IsDevFakeAuthEnabled)
+        {
+            services.AddSingleton<IDesktopAuthClient, FakeDesktopAuthClient>();
+        }
+        else if (authOptions.IsControlPlaneSignInConfigured)
         {
             services.AddSingleton(_ => new HttpClient
             {

--- a/src/App.Desktop/Services/Auth/DesktopAuthOptions.cs
+++ b/src/App.Desktop/Services/Auth/DesktopAuthOptions.cs
@@ -5,21 +5,51 @@ public sealed class DesktopAuthOptions
     public const string ControlPlaneBaseAddressEnvironmentVariable =
         "AA_DESKTOP_CONTROL_PLANE_BASE_ADDRESS";
 
-    private DesktopAuthOptions(Uri? controlPlaneBaseAddress)
+    public const string DevFakeAuthEnabledEnvironmentVariable =
+        "AA_DESKTOP_DEV_FAKE_AUTH_ENABLED";
+
+    private DesktopAuthOptions(
+        Uri? controlPlaneBaseAddress,
+        bool isDevFakeAuthEnabled)
     {
         ControlPlaneBaseAddress = controlPlaneBaseAddress;
+        IsDevFakeAuthEnabled = isDevFakeAuthEnabled;
     }
 
-    public static DesktopAuthOptions Disabled { get; } = new(controlPlaneBaseAddress: null);
+    public static DesktopAuthOptions Disabled { get; } = new(
+        controlPlaneBaseAddress: null,
+        isDevFakeAuthEnabled: false);
 
     public Uri? ControlPlaneBaseAddress { get; }
 
     public bool IsControlPlaneSignInConfigured => ControlPlaneBaseAddress is not null;
 
+    public bool IsDevFakeAuthEnabled { get; }
+
     public static DesktopAuthOptions FromEnvironment()
     {
-        return FromControlPlaneBaseAddress(
-            Environment.GetEnvironmentVariable(ControlPlaneBaseAddressEnvironmentVariable));
+        return FromEnvironmentValues(
+            Environment.GetEnvironmentVariable(ControlPlaneBaseAddressEnvironmentVariable),
+            Environment.GetEnvironmentVariable(DevFakeAuthEnabledEnvironmentVariable));
+    }
+
+    public static DesktopAuthOptions FromEnvironmentValues(
+        string? baseAddress,
+        string? devFakeAuthEnabled)
+    {
+        DesktopAuthOptions liveOptions = FromControlPlaneBaseAddress(baseAddress);
+
+#if DEBUG
+        if (!liveOptions.IsControlPlaneSignInConfigured
+            && IsDevFakeAuthEnabledValue(devFakeAuthEnabled))
+        {
+            return new DesktopAuthOptions(
+                controlPlaneBaseAddress: null,
+                isDevFakeAuthEnabled: true);
+        }
+#endif
+
+        return liveOptions;
     }
 
     public static DesktopAuthOptions FromControlPlaneBaseAddress(string? baseAddress)
@@ -41,13 +71,21 @@ public sealed class DesktopAuthOptions
             return Disabled;
         }
 
-        return new DesktopAuthOptions(baseAddress);
+        return new DesktopAuthOptions(
+            baseAddress,
+            isDevFakeAuthEnabled: false);
     }
 
     public override string ToString()
     {
         return $"{nameof(DesktopAuthOptions)} {{ IsControlPlaneSignInConfigured = {IsControlPlaneSignInConfigured}, "
+            + $"IsDevFakeAuthEnabled = {IsDevFakeAuthEnabled}, "
             + $"Scheme = {ControlPlaneBaseAddress?.Scheme ?? "<none>"}, Host = {ControlPlaneBaseAddress?.Host ?? "<none>"} }}";
+    }
+
+    private static bool IsDevFakeAuthEnabledValue(string? value)
+    {
+        return string.Equals(value?.Trim(), "true", StringComparison.OrdinalIgnoreCase);
     }
 
     private static bool IsSafeControlPlaneBaseAddress(Uri baseAddress)

--- a/src/App.Desktop/Services/Auth/FakeDesktopAuthClient.cs
+++ b/src/App.Desktop/Services/Auth/FakeDesktopAuthClient.cs
@@ -1,0 +1,42 @@
+using App.Desktop.Boundaries;
+
+namespace App.Desktop.Services.Auth;
+
+public sealed class FakeDesktopAuthClient : IDesktopAuthClient
+{
+    public const string VisualSmokeLogin = "visual-smoke-user";
+    public const string VisualSmokePassword = "visual-smoke-password";
+
+    private static readonly Guid SessionId = Guid.Parse("9b64d538-751c-4d41-8423-2a66d60a475d");
+    private static readonly Guid UserId = Guid.Parse("1c9f60aa-f495-4ce0-b2e2-e00cc9d7fd1e");
+
+    public ValueTask<DesktopAuthResult> SignInAsync(
+        DesktopSignInRequest request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!string.Equals(request.Login, VisualSmokeLogin, StringComparison.Ordinal)
+            || !string.Equals(request.Password, VisualSmokePassword, StringComparison.Ordinal))
+        {
+            return ValueTask.FromResult(DesktopAuthResult.Rejected(
+                "fake_auth_invalid_credentials",
+                "Dev/test fake auth rejected the supplied credentials."));
+        }
+
+        DateTimeOffset issuedAtUtc = DateTimeOffset.UtcNow;
+        var session = DesktopAuthenticatedSession.Create(
+            SessionId,
+            UserId,
+            request.DeviceId,
+            "Visual Smoke User",
+            "dev-fake-auth-access",
+            refreshToken: null,
+            issuedAtUtc,
+            issuedAtUtc.AddMinutes(15),
+            isOfflineRestricted: true);
+
+        return ValueTask.FromResult(DesktopAuthResult.Succeeded(session));
+    }
+}

--- a/tests/Unit/App.Desktop.Tests/DesktopAuthClientBoundaryTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopAuthClientBoundaryTests.cs
@@ -224,6 +224,71 @@ public sealed class DesktopAuthClientBoundaryTests
         Assert.DoesNotContain(tokenLikeValue, result.Error.Message, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public async Task FakeAuthClientReturnsSuccessForVisualSmokeCredentials()
+    {
+        var client = new FakeDesktopAuthClient();
+        var deviceId = Guid.NewGuid();
+
+        var result = await client.SignInAsync(
+            new DesktopSignInRequest(
+                FakeDesktopAuthClient.VisualSmokeLogin,
+                FakeDesktopAuthClient.VisualSmokePassword,
+                deviceId),
+            CancellationToken.None);
+
+        Assert.Equal(DesktopAuthStatus.Succeeded, result.Status);
+        Assert.NotNull(result.Session);
+        Assert.Equal("Visual Smoke User", result.Session.DisplayName);
+        Assert.Equal(deviceId, result.Session.DeviceId);
+        Assert.True(result.Session.IsOfflineRestricted);
+        Assert.DoesNotContain(FakeDesktopAuthClient.VisualSmokePassword, result.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(result.Session.AccessToken, result.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(result.Session.AccessToken, result.Session.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("Authorization", result.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task FakeAuthClientRejectsWrongCredentialsWithoutExposingInputValues()
+    {
+        var client = new FakeDesktopAuthClient();
+        var login = $"visual-smoke-{Guid.NewGuid():N}";
+        var password = CreateSensitiveValue("password");
+
+        var result = await client.SignInAsync(
+            new DesktopSignInRequest(login, password, Guid.NewGuid()),
+            CancellationToken.None);
+
+        Assert.Equal(DesktopAuthStatus.Rejected, result.Status);
+        Assert.Null(result.Session);
+        Assert.NotNull(result.Error);
+        Assert.DoesNotContain(login, result.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(password, result.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(FakeDesktopAuthClient.VisualSmokePassword, result.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("Authorization", result.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task FakeAuthClientVisibleSignInResultDoesNotExposePasswordOrTokens()
+    {
+        var service = new DesktopSignInService(
+            new FakeDesktopAuthClient(),
+            new DesktopSessionState(new DisabledDesktopSessionStore()));
+
+        DesktopSignInResult result = await service.SignInAsync(
+            FakeDesktopAuthClient.VisualSmokeLogin,
+            FakeDesktopAuthClient.VisualSmokePassword,
+            Guid.NewGuid(),
+            CancellationToken.None);
+
+        Assert.Equal(DesktopSignInStatus.Succeeded, result.Status);
+        Assert.Contains("Visual Smoke User", result.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain(FakeDesktopAuthClient.VisualSmokePassword, result.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("dev-fake-auth-access", result.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("Authorization", result.ToString(), StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("refreshToken", result.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
     private static StringContent JsonContent<T>(T value)
     {
         return new StringContent(

--- a/tests/Unit/App.Desktop.Tests/DesktopCompositionRootTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopCompositionRootTests.cs
@@ -21,6 +21,19 @@ public sealed class DesktopCompositionRootTests
     }
 
     [Fact]
+    public void EnvironmentOptionsKeepFakeAuthDisabledByDefault()
+    {
+        using var environment = new EnvironmentVariableScope()
+            .Set(DesktopAuthOptions.ControlPlaneBaseAddressEnvironmentVariable, null)
+            .Set(DesktopAuthOptions.DevFakeAuthEnabledEnvironmentVariable, null);
+
+        using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
+
+        Assert.False(services.GetRequiredService<DesktopAuthOptions>().IsDevFakeAuthEnabled);
+        Assert.IsType<UnavailableDesktopAuthClient>(services.GetRequiredService<IDesktopAuthClient>());
+    }
+
+    [Fact]
     public void BuildServicesWithConfiguredBaseAddressResolvesHttpAuthClient()
     {
         using var services = DesktopCompositionRoot.BuildServices(
@@ -29,6 +42,39 @@ public sealed class DesktopCompositionRootTests
         Assert.IsType<HttpDesktopAuthClient>(services.GetRequiredService<IDesktopAuthClient>());
         Assert.IsType<DisabledDesktopSessionStore>(services.GetRequiredService<IDesktopSessionStore>());
         Assert.True(services.GetRequiredService<DesktopAuthOptions>().IsControlPlaneSignInConfigured);
+        Assert.Equal(
+            new Uri("https://control-plane.local"),
+            services.GetRequiredService<HttpClient>().BaseAddress);
+    }
+
+    [Fact]
+    public void ExplicitFakeAuthFlagResolvesFakeAuthClientOnlyWithoutLiveBaseAddress()
+    {
+        using var services = DesktopCompositionRoot.BuildServices(
+            DesktopAuthOptions.FromEnvironmentValues(
+                baseAddress: null,
+                devFakeAuthEnabled: "true"));
+
+#if DEBUG
+        Assert.True(services.GetRequiredService<DesktopAuthOptions>().IsDevFakeAuthEnabled);
+        Assert.IsType<FakeDesktopAuthClient>(services.GetRequiredService<IDesktopAuthClient>());
+        Assert.Null(services.GetService<HttpClient>());
+#else
+        Assert.False(services.GetRequiredService<DesktopAuthOptions>().IsDevFakeAuthEnabled);
+        Assert.IsType<UnavailableDesktopAuthClient>(services.GetRequiredService<IDesktopAuthClient>());
+#endif
+    }
+
+    [Fact]
+    public void ExplicitFakeAuthFlagDoesNotReplaceConfiguredLiveAuthClient()
+    {
+        using var services = DesktopCompositionRoot.BuildServices(
+            DesktopAuthOptions.FromEnvironmentValues(
+                "https://control-plane.local",
+                devFakeAuthEnabled: "true"));
+
+        Assert.False(services.GetRequiredService<DesktopAuthOptions>().IsDevFakeAuthEnabled);
+        Assert.IsType<HttpDesktopAuthClient>(services.GetRequiredService<IDesktopAuthClient>());
         Assert.Equal(
             new Uri("https://control-plane.local"),
             services.GetRequiredService<HttpClient>().BaseAddress);
@@ -64,5 +110,29 @@ public sealed class DesktopCompositionRootTests
 
         Assert.IsType<UnavailableDesktopAuthClient>(services.GetRequiredService<IDesktopAuthClient>());
         Assert.False(services.GetRequiredService<DesktopAuthOptions>().IsControlPlaneSignInConfigured);
+    }
+
+    private sealed class EnvironmentVariableScope : IDisposable
+    {
+        private readonly Dictionary<string, string?> _originalValues = [];
+
+        public EnvironmentVariableScope Set(string name, string? value)
+        {
+            if (!_originalValues.ContainsKey(name))
+            {
+                _originalValues.Add(name, Environment.GetEnvironmentVariable(name));
+            }
+
+            Environment.SetEnvironmentVariable(name, value);
+            return this;
+        }
+
+        public void Dispose()
+        {
+            foreach (KeyValuePair<string, string?> entry in _originalValues)
+            {
+                Environment.SetEnvironmentVariable(entry.Key, entry.Value);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Adds a dev/test-only App.Desktop fake auth client for repeatable desktop visual-smoke screenshots.
- Enables fake auth only when `AA_DESKTOP_DEV_FAKE_AUTH_ENABLED=true`, in Debug builds, and only when no live control-plane base address is configured.
- Keeps `HttpDesktopAuthClient` as the configured live auth path and adds focused desktop unit coverage plus the S2-58 task card.

## Safety
- Fake auth does not call App.Api and does not create users or persistence.
- A configured `AA_DESKTOP_CONTROL_PLANE_BASE_ADDRESS` keeps live auth selected, so the fake harness cannot replace Korobochka/live auth configuration.
- Visual-smoke stdout/stderr logs were empty and scanned for forbidden password/token/Authorization strings.
- Screenshots/runtime artifacts were saved under `C:\CODEX\Temp` and were not committed.

## Visual Smoke
Folder: `C:\CODEX\Temp\S2-58_VISUAL_SMOKE_20260430_093858`
- `01_baseline_signin.png`
- `02_filled_fake_credentials_before_submit.png`
- `03_rejected_fake_credentials.png`
- `04_successful_fake_signin.png`

## Validation
- `git diff --check` passed.
- `dotnet restore AnalyticsAutomation-Core.sln -nologo` passed.
- `dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore` passed after formatter normalized touched-file whitespace.
- `dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal` passed.
- `dotnet build AnalyticsAutomation-Core.sln -nologo -v minimal` passed with existing analyzer warnings outside this change.
- `dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal` passed: 66 tests.
- Hidden/control Unicode scan over changed text files passed.

No App.Api, contracts, migrations, deploy, App.Web, or App.Mobile.Android files changed.