### PR TITLE
[codex] S2-59 Desktop Signed-in Shell Navigation Placeholder

### DIFF
--- a/docs/task-cards/S2-59_desktop-signed-in-shell-navigation-task-card.txt
+++ b/docs/task-cards/S2-59_desktop-signed-in-shell-navigation-task-card.txt
@@ -1,0 +1,132 @@
+Title:
+S2-59 Desktop Signed-in Shell / Navigation Placeholder Task Card
+
+Module:
+App.Desktop / signed-in shell navigation placeholder
+
+Owner:
+Coder 1 acting as Coder 2 / Desktop Client
+
+Client form:
+desktop standalone
+
+Type:
+narrow runtime desktop UI slice after SignIn stabilization
+
+Status:
+Runtime task card created with implementation.
+
+Goal:
+After a successful desktop SignIn, show a safe Russian signed-in shell with user context, a SignOut action, and deferred navigation placeholder cards for future upload flow work.
+
+Context:
+S2-51 enabled the App.Desktop SignIn runtime boundary.
+S2-54 through S2-57 stabilized visible Russian SignIn feedback, live input binding, click submit, Enter submit, and password clearing.
+S2-58 added a debug-only fake-auth visual-smoke harness guarded by AA_DESKTOP_DEV_FAKE_AUTH_ENABLED=true and disabled whenever AA_DESKTOP_CONTROL_PLANE_BASE_ADDRESS is configured.
+
+Scope:
+- Keep the current Russian SignIn UI before authentication.
+- After successful SignIn, hide the SignIn form and show a signed-in workspace.
+- Show safe user context as "Вход выполнен: <DisplayName>." when the display name is safe.
+- Add "Выйти" to clear the in-memory desktop session state and return to SignIn.
+- Always clear password on SignIn attempts and SignOut.
+- Add deferred/no-op Russian navigation placeholder cards:
+  - "Группы"
+  - "Загрузка видео"
+  - "Проверка перед загрузкой"
+  - "Квитанции загрузки"
+- Each card must show "Будет доступно в следующем approved desktop slice."
+- Keep the cards disabled/no-op and free of App.Api calls.
+
+Allowed changed areas:
+- docs/task-cards/S2-59_desktop-signed-in-shell-navigation-task-card.txt
+- src/App.Desktop/**
+- tests/Unit/App.Desktop.Tests/**
+
+Forbidden changed areas:
+- src/App.Api/**
+- src/App.Worker/**
+- src/App.Web/**
+- src/App.Mobile.Android/**
+- src/App.UI.Shared/**
+- src/BuildingBlocks.Contracts/**
+- src/Modules/**
+- DB migrations
+- .github/workflows/**
+- deploy scripts
+- docs/ops/**
+- committed screenshots or runtime artifacts
+
+Contracts:
+none
+
+Migrations:
+none
+
+Feature flags/env guard:
+Uses the existing S2-58 fake auth env guard only for visual smoke:
+AA_DESKTOP_DEV_FAKE_AUTH_ENABLED=true.
+
+Fake auth remains debug/dev-test only and must not replace configured live auth. If AA_DESKTOP_CONTROL_PLANE_BASE_ADDRESS is configured, live HttpDesktopAuthClient remains selected.
+
+Events:
+none
+
+Offline behavior:
+no offline implementation
+
+Security guardrails:
+- Do not display or log password.
+- Do not display or log accessToken, refreshToken, Authorization, raw session id, raw response body, or token-like values.
+- Do not persist tokens or passwords.
+- Do not add secrets or real credentials to docs, tests, PR text, screenshots, logs, or reports.
+- Use only non-secret fake-auth visual-smoke test data:
+  - login: visual-smoke-user
+  - password: visual-smoke-password
+- Screenshots and runtime artifacts stay under C:\CODEX\Temp and are not committed.
+
+Explicitly out of scope:
+- GroupTree implementation.
+- File picker.
+- SHA-256.
+- PreUploadCheck.
+- Site upload.
+- UploadReceipt.
+- Full upload flow.
+- Offline queue.
+- App.Api changes.
+- Shared contract changes.
+- DB migrations.
+- Deploy/workflow changes.
+- App.Web changes.
+- App.Mobile.Android changes.
+- App.UI.Shared changes.
+- Live Korobochka path changes.
+
+Rollback:
+revert S2-59 PR
+
+Validation:
+- git diff --check
+- dotnet restore AnalyticsAutomation-Core.sln -nologo
+- dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore
+- dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal
+- dotnet build AnalyticsAutomation-Core.sln -nologo -v minimal
+- dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal
+- hidden/control Unicode scan over changed text files
+- App.Desktop visual smoke with fake auth enabled
+
+Visual-smoke definition of done:
+- Run App.Desktop with AA_DESKTOP_DEV_FAKE_AUTH_ENABLED=true.
+- Do not set AA_DESKTOP_CONTROL_PLANE_BASE_ADDRESS.
+- Use non-secret test data visual-smoke-user / visual-smoke-password.
+- Capture screenshots under C:\CODEX\Temp\S2-59_DESKTOP_SIGNED_IN_SHELL_VISUAL_SMOKE_<timestamp>\.
+- Required screenshots:
+  - 01_baseline_signin.png
+  - 02_filled_fake_credentials.png
+  - 03_signed_in_shell.png
+  - 04_after_sign_out.png
+- Confirm signed-in shell shows safe display name and placeholder cards.
+- Confirm SignOut returns to SignIn, clears password, and does not show signed-in user context.
+- Confirm no password, accessToken, refreshToken, Authorization, raw session id, raw response body, or real secret is visible.
+- Confirm screenshots and runtime artifacts are not committed.

--- a/src/App.Desktop/Boundaries/DesktopSignInBoundary.cs
+++ b/src/App.Desktop/Boundaries/DesktopSignInBoundary.cs
@@ -25,6 +25,7 @@ public static class DesktopSignInText
     public const string RejectedMessage = "Логин или пароль не приняты.";
     public const string UnavailableMessage = "Сервис входа недоступен. Проверьте подключение или настройку.";
     public const string FailedMessage = "Не удалось выполнить вход. Попробуйте еще раз.";
+    public const string SignedOutMessage = "Вы вышли из системы. Введите логин и пароль для входа.";
 
     public static string CreateSuccessMessage(DesktopSessionSnapshot session)
     {
@@ -66,7 +67,10 @@ public static class DesktopSignInText
         [
             "authorization",
             "bearer",
+            "sessionid",
+            "session_id",
             "password",
+            "token",
             "accesstoken",
             "access_token",
             "refresh_token",
@@ -85,6 +89,32 @@ public static class DesktopSignInText
         return true;
     }
 }
+
+public static class DesktopSignedInShellText
+{
+    public const string Title = "Рабочая область";
+    public const string SignOutButton = "Выйти";
+    public const string DeferredPlaceholderMessage = "Будет доступно в следующем approved desktop slice.";
+
+    public static IReadOnlyList<DesktopNavigationPlaceholderCard> NavigationCards { get; } =
+    [
+        new("Группы", DeferredPlaceholderMessage),
+        new("Загрузка видео", DeferredPlaceholderMessage),
+        new("Проверка перед загрузкой", DeferredPlaceholderMessage),
+        new("Квитанции загрузки", DeferredPlaceholderMessage)
+    ];
+
+    public static string CreateUserContextMessage(DesktopSessionSnapshot session)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+
+        return DesktopSignInText.CreateSuccessMessage(session);
+    }
+}
+
+public sealed record DesktopNavigationPlaceholderCard(
+    string Title,
+    string Message);
 
 public sealed class DesktopSignInResult
 {
@@ -115,6 +145,12 @@ public sealed class DesktopSignInResult
         session: null,
         error: null,
         DesktopSignInText.NotStartedMessage);
+
+    public static DesktopSignInResult SignedOut { get; } = new(
+        DesktopSignInStatus.NotStarted,
+        session: null,
+        error: null,
+        DesktopSignInText.SignedOutMessage);
 
     public static DesktopSignInResult InProgress { get; } = new(
         DesktopSignInStatus.InProgress,

--- a/src/App.Desktop/Components/DesktopShell.razor
+++ b/src/App.Desktop/Components/DesktopShell.razor
@@ -12,59 +12,95 @@
     </header>
 
     <main class="desktop-shell__main">
-        <section class="desktop-signin" aria-labelledby="desktop-signin-title">
-            <div class="desktop-signin__heading">
-                <h2 id="desktop-signin-title">@DesktopSignInText.Title</h2>
-                <p id="desktop-signin-result" class="@GetSignInStatusClass()" role="status" aria-live="polite">
-                    @SignInViewModel.LastResult.Message
-                </p>
-            </div>
+        @if (SignInViewModel.IsSignedIn)
+        {
+            <section class="desktop-workspace" aria-labelledby="desktop-workspace-title">
+                <div class="desktop-workspace__summary">
+                    <div>
+                        <h2 id="desktop-workspace-title">@DesktopSignedInShellText.Title</h2>
+                        <p id="desktop-session-status" class="desktop-workspace__message" role="status" aria-live="polite">
+                            @SignInViewModel.SignedInUserContextMessage
+                        </p>
+                    </div>
 
-            <div class="desktop-signin__form" role="group" aria-describedby="desktop-signin-result">
-                <label class="desktop-signin__field" for="desktop-signin-login">
-                    <span>@DesktopSignInText.LoginLabel</span>
-                    <input
-                        id="desktop-signin-login"
-                        name="login"
-                        autocomplete="username"
-                        placeholder="@DesktopSignInText.LoginPlaceholder"
-                        aria-describedby="desktop-signin-result"
-                        aria-required="true"
-                        spellcheck="false"
-                        autofocus
+                    <button
+                        class="desktop-workspace__signout"
+                        type="button"
                         disabled="@SignInViewModel.IsBusy"
-                        @bind-value="SignInViewModel.Login"
-                        @bind-value:event="oninput"
-                        @onkeyup="SubmitSignInOnEnterAsync" />
-                </label>
+                        @onclick="SignOutAsync">
+                        @DesktopSignedInShellText.SignOutButton
+                    </button>
+                </div>
 
-                <label class="desktop-signin__field" for="desktop-signin-password">
-                    <span>@DesktopSignInText.PasswordLabel</span>
-                    <input
-                        id="desktop-signin-password"
-                        name="password"
-                        type="password"
-                        autocomplete="current-password"
-                        placeholder="@DesktopSignInText.PasswordPlaceholder"
-                        aria-describedby="desktop-signin-result"
-                        aria-required="true"
+                <nav class="desktop-navigation" aria-label="Разделы рабочего места">
+                    @foreach (DesktopNavigationPlaceholderCard card in DesktopSignedInShellText.NavigationCards)
+                    {
+                        <button
+                            class="desktop-navigation-card"
+                            type="button"
+                            disabled="disabled"
+                            aria-disabled="true">
+                            <span class="desktop-navigation-card__title">@card.Title</span>
+                            <span class="desktop-navigation-card__message">@card.Message</span>
+                        </button>
+                    }
+                </nav>
+            </section>
+        }
+        else
+        {
+            <section class="desktop-signin" aria-labelledby="desktop-signin-title">
+                <div class="desktop-signin__heading">
+                    <h2 id="desktop-signin-title">@DesktopSignInText.Title</h2>
+                    <p id="desktop-signin-result" class="@GetSignInStatusClass()" role="status" aria-live="polite">
+                        @SignInViewModel.LastResult.Message
+                    </p>
+                </div>
+
+                <div class="desktop-signin__form" role="group" aria-describedby="desktop-signin-result">
+                    <label class="desktop-signin__field" for="desktop-signin-login">
+                        <span>@DesktopSignInText.LoginLabel</span>
+                        <input
+                            id="desktop-signin-login"
+                            name="login"
+                            autocomplete="username"
+                            placeholder="@DesktopSignInText.LoginPlaceholder"
+                            aria-describedby="desktop-signin-result"
+                            aria-required="true"
+                            spellcheck="false"
+                            autofocus
+                            disabled="@SignInViewModel.IsBusy"
+                            @bind-value="SignInViewModel.Login"
+                            @bind-value:event="oninput"
+                            @onkeyup="SubmitSignInOnEnterAsync" />
+                    </label>
+
+                    <label class="desktop-signin__field" for="desktop-signin-password">
+                        <span>@DesktopSignInText.PasswordLabel</span>
+                        <input
+                            id="desktop-signin-password"
+                            name="password"
+                            type="password"
+                            autocomplete="current-password"
+                            placeholder="@DesktopSignInText.PasswordPlaceholder"
+                            aria-describedby="desktop-signin-result"
+                            aria-required="true"
+                            disabled="@SignInViewModel.IsBusy"
+                            @bind-value="SignInViewModel.Password"
+                            @bind-value:event="oninput"
+                            @onkeyup="SubmitSignInOnEnterAsync" />
+                    </label>
+
+                    <button
+                        class="desktop-signin__submit"
+                        type="button"
                         disabled="@SignInViewModel.IsBusy"
-                        @bind-value="SignInViewModel.Password"
-                        @bind-value:event="oninput"
-                        @onkeyup="SubmitSignInOnEnterAsync" />
-                </label>
-
-                <button
-                    class="desktop-signin__submit"
-                    type="button"
-                    disabled="@SignInViewModel.IsBusy"
-                    @onclick="SubmitSignInAsync">
-                    @(SignInViewModel.IsBusy ? DesktopSignInText.SubmitButtonBusy : DesktopSignInText.SubmitButton)
-                </button>
-            </div>
-        </section>
-
-        <UploadPlaceholder />
+                        @onclick="SubmitSignInAsync">
+                        @(SignInViewModel.IsBusy ? DesktopSignInText.SubmitButtonBusy : DesktopSignInText.SubmitButton)
+                    </button>
+                </div>
+            </section>
+        }
     </main>
 </div>
 
@@ -94,11 +130,27 @@
         StateHasChanged();
     }
 
+    private async Task SignOutAsync()
+    {
+        if (SignInViewModel.IsBusy)
+        {
+            return;
+        }
+
+        await SignInViewModel.SignOutAsync(CancellationToken.None);
+
+        StateHasChanged();
+    }
+
     private string GetHeaderStatusText()
     {
+        if (SignInViewModel.IsSignedIn)
+        {
+            return DesktopSignInText.HeaderStatusSignedIn;
+        }
+
         return SignInViewModel.LastResult.Status switch
         {
-            DesktopSignInStatus.Succeeded => DesktopSignInText.HeaderStatusSignedIn,
             DesktopSignInStatus.InProgress => DesktopSignInText.HeaderStatusBusy,
             _ => DesktopSignInText.HeaderStatus
         };

--- a/src/App.Desktop/Services/Auth/DesktopSignInViewModel.cs
+++ b/src/App.Desktop/Services/Auth/DesktopSignInViewModel.cs
@@ -2,9 +2,16 @@ using App.Desktop.Boundaries;
 
 namespace App.Desktop.Services.Auth;
 
-public sealed class DesktopSignInViewModel(IDesktopSignInService signInService)
+public sealed class DesktopSignInViewModel(
+    IDesktopSignInService signInService,
+    IDesktopSessionState sessionState)
 {
     private int _isBusy;
+
+    public DesktopSignInViewModel(IDesktopSignInService signInService)
+        : this(signInService, new DesktopSessionState(new DisabledDesktopSessionStore()))
+    {
+    }
 
     public string Login { get; set; } = string.Empty;
 
@@ -18,6 +25,13 @@ public sealed class DesktopSignInViewModel(IDesktopSignInService signInService)
         !IsBusy
         && !string.IsNullOrWhiteSpace(Login)
         && !string.IsNullOrWhiteSpace(Password);
+
+    public bool IsSignedIn => CurrentSession.IsSignedIn;
+
+    public DesktopSessionSnapshot CurrentSession { get; private set; } = sessionState.Current;
+
+    public string SignedInUserContextMessage =>
+        DesktopSignedInShellText.CreateUserContextMessage(CurrentSession);
 
     public DesktopSignInResult LastResult { get; private set; } = DesktopSignInResult.NotStarted;
 
@@ -57,7 +71,38 @@ public sealed class DesktopSignInViewModel(IDesktopSignInService signInService)
                 DeviceId,
                 cancellationToken);
 
+            if (LastResult.IsSuccess && LastResult.Session is not null)
+            {
+                CurrentSession = LastResult.Session;
+            }
+
             return LastResult;
+        }
+        finally
+        {
+            Password = string.Empty;
+            Volatile.Write(ref _isBusy, 0);
+        }
+    }
+
+    public async ValueTask<DesktopSessionSnapshot> SignOutAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (Interlocked.Exchange(ref _isBusy, 1) == 1)
+        {
+            LastResult = DesktopSignInResult.InProgress;
+            return CurrentSession;
+        }
+
+        try
+        {
+            Password = string.Empty;
+
+            CurrentSession = await sessionState.SignOutAsync(cancellationToken);
+            LastResult = DesktopSignInResult.SignedOut;
+
+            return CurrentSession;
         }
         finally
         {

--- a/src/App.Desktop/wwwroot/app.css
+++ b/src/App.Desktop/wwwroot/app.css
@@ -50,7 +50,7 @@ body {
 .desktop-shell__main {
     flex: 1;
     width: 100%;
-    max-width: 960px;
+    max-width: 1040px;
     display: flex;
     flex-direction: column;
     align-items: stretch;
@@ -147,9 +147,107 @@ body {
     background: #8da3b8;
 }
 
+.desktop-workspace {
+    display: grid;
+    gap: 24px;
+    width: 100%;
+    box-sizing: border-box;
+}
+
+.desktop-workspace__summary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 20px;
+    padding: 22px;
+    background: #ffffff;
+    border: 1px solid #d7dde5;
+    border-radius: 8px;
+}
+
+.desktop-workspace__summary h2 {
+    margin: 0;
+    font-size: 1.15rem;
+    font-weight: 650;
+}
+
+.desktop-workspace__message {
+    margin: 10px 0 0;
+    color: #17643c;
+    font-size: 0.95rem;
+    font-weight: 650;
+    line-height: 1.35;
+}
+
+.desktop-workspace__signout {
+    min-height: 38px;
+    padding: 0 16px;
+    border: 1px solid #394756;
+    border-radius: 6px;
+    background: #ffffff;
+    color: #253241;
+    font: inherit;
+    font-size: 0.9rem;
+    font-weight: 650;
+    white-space: nowrap;
+}
+
+.desktop-workspace__signout:disabled {
+    color: #687789;
+    border-color: #b9c3cf;
+}
+
+.desktop-navigation {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 16px;
+}
+
+.desktop-navigation-card {
+    display: grid;
+    min-height: 128px;
+    align-content: start;
+    gap: 10px;
+    box-sizing: border-box;
+    padding: 18px;
+    border: 1px solid #d1d8e1;
+    border-radius: 8px;
+    background: #ffffff;
+    color: #253241;
+    font: inherit;
+    text-align: left;
+}
+
+.desktop-navigation-card:disabled {
+    color: #52616f;
+    cursor: default;
+}
+
+.desktop-navigation-card__title {
+    color: #18212f;
+    font-size: 1rem;
+    font-weight: 700;
+}
+
+.desktop-navigation-card__message {
+    color: #52616f;
+    font-size: 0.88rem;
+    font-weight: 500;
+    line-height: 1.4;
+}
+
 @media (max-width: 860px) {
     .desktop-signin,
     .desktop-signin__form {
         grid-template-columns: 1fr;
+    }
+
+    .desktop-workspace__summary {
+        align-items: stretch;
+        flex-direction: column;
+    }
+
+    .desktop-workspace__signout {
+        width: 100%;
     }
 }

--- a/tests/Unit/App.Desktop.Tests/DesktopCompositionRootTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopCompositionRootTests.cs
@@ -80,6 +80,32 @@ public sealed class DesktopCompositionRootTests
             services.GetRequiredService<HttpClient>().BaseAddress);
     }
 
+    [Fact]
+    public async Task FakeAuthVisualSmokeCredentialsRemainAvailableForSignedInShellState()
+    {
+        using var services = DesktopCompositionRoot.BuildServices(
+            DesktopAuthOptions.FromEnvironmentValues(
+                baseAddress: null,
+                devFakeAuthEnabled: "true"));
+        var viewModel = services.GetRequiredService<DesktopSignInViewModel>();
+
+        viewModel.Login = FakeDesktopAuthClient.VisualSmokeLogin;
+        viewModel.Password = FakeDesktopAuthClient.VisualSmokePassword;
+
+        DesktopSignInResult result = await viewModel.SignInAsync(CancellationToken.None);
+
+#if DEBUG
+        Assert.Equal(DesktopSignInStatus.Succeeded, result.Status);
+        Assert.True(viewModel.IsSignedIn);
+        Assert.Equal("Вход выполнен: Visual Smoke User.", viewModel.SignedInUserContextMessage);
+        Assert.DoesNotContain(FakeDesktopAuthClient.VisualSmokePassword, result.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("dev-fake-auth-access", result.ToString(), StringComparison.Ordinal);
+#else
+        Assert.Equal(DesktopSignInStatus.Unavailable, result.Status);
+        Assert.False(viewModel.IsSignedIn);
+#endif
+    }
+
     [Theory]
     [InlineData("https://control-plane.local")]
     [InlineData("https://control-plane.local/")]

--- a/tests/Unit/App.Desktop.Tests/DesktopSignInServiceTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopSignInServiceTests.cs
@@ -52,6 +52,112 @@ public sealed class DesktopSignInServiceTests
     }
 
     [Fact]
+    public async Task ViewModelSuccessfulSignInTransitionsToSignedInShellState()
+    {
+        var session = CreateAuthenticatedSession(displayName: "Desktop Operator");
+        var sessionState = new DesktopSessionState(new DisabledDesktopSessionStore());
+        var viewModel = new DesktopSignInViewModel(
+            new DesktopSignInService(
+                new RecordingAuthClient(DesktopAuthResult.Succeeded(session)),
+                sessionState),
+            sessionState)
+        {
+            Login = "desktop-operator",
+            Password = CreateSensitiveValue("password")
+        };
+
+        var result = await viewModel.SignInAsync(CancellationToken.None);
+
+        Assert.Equal(DesktopSignInStatus.Succeeded, result.Status);
+        Assert.True(viewModel.IsSignedIn);
+        Assert.Equal(DesktopSessionStatus.SignedIn, viewModel.CurrentSession.Status);
+        Assert.Equal(session.UserId, viewModel.CurrentSession.UserId);
+        Assert.Equal("Вход выполнен: Desktop Operator.", viewModel.SignedInUserContextMessage);
+    }
+
+    [Fact]
+    public async Task ViewModelSignedInUserContextShowsSafeDisplayNameOnly()
+    {
+        var password = CreateSensitiveValue("password");
+        var accessToken = CreateSensitiveValue("access");
+        var refreshToken = CreateSensitiveValue("refresh");
+        var session = CreateAuthenticatedSession(
+            accessToken: accessToken,
+            refreshToken: refreshToken,
+            displayName: "Desktop Operator");
+        var viewModel = new DesktopSignInViewModel(new DesktopSignInService(
+            new RecordingAuthClient(DesktopAuthResult.Succeeded(session)),
+            new DesktopSessionState(new DisabledDesktopSessionStore())))
+        {
+            Login = "desktop-operator",
+            Password = password
+        };
+
+        _ = await viewModel.SignInAsync(CancellationToken.None);
+
+        Assert.Equal("Вход выполнен: Desktop Operator.", viewModel.SignedInUserContextMessage);
+        Assert.DoesNotContain(password, viewModel.SignedInUserContextMessage, StringComparison.Ordinal);
+        Assert.DoesNotContain(accessToken, viewModel.SignedInUserContextMessage, StringComparison.Ordinal);
+        Assert.DoesNotContain(refreshToken, viewModel.SignedInUserContextMessage, StringComparison.Ordinal);
+        Assert.DoesNotContain("Authorization", viewModel.SignedInUserContextMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("Authorization: Bearer secret")]
+    [InlineData("accessToken")]
+    [InlineData("refresh_token")]
+    [InlineData("raw session_id")]
+    [InlineData("password")]
+    public async Task ViewModelSignedInUserContextHidesUnsafeDisplayName(string unsafeDisplayName)
+    {
+        var viewModel = new DesktopSignInViewModel(new DesktopSignInService(
+            new RecordingAuthClient(DesktopAuthResult.Succeeded(
+                CreateAuthenticatedSession(displayName: unsafeDisplayName))),
+            new DesktopSessionState(new DisabledDesktopSessionStore())))
+        {
+            Login = "desktop-operator",
+            Password = CreateSensitiveValue("password")
+        };
+
+        _ = await viewModel.SignInAsync(CancellationToken.None);
+
+        Assert.Equal("Вход выполнен.", viewModel.SignedInUserContextMessage);
+        Assert.DoesNotContain(unsafeDisplayName, viewModel.SignedInUserContextMessage, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ViewModelSignOutReturnsToSignInStateAndClearsSessionVisibleState()
+    {
+        var session = CreateAuthenticatedSession(displayName: "Desktop Operator");
+        var sessionState = new DesktopSessionState(new DisabledDesktopSessionStore());
+        var viewModel = new DesktopSignInViewModel(
+            new DesktopSignInService(
+                new RecordingAuthClient(DesktopAuthResult.Succeeded(session)),
+                sessionState),
+            sessionState)
+        {
+            Login = "desktop-operator",
+            Password = CreateSensitiveValue("password")
+        };
+
+        _ = await viewModel.SignInAsync(CancellationToken.None);
+        viewModel.Password = CreateSensitiveValue("password-after-signin");
+
+        DesktopSessionSnapshot signedOut = await viewModel.SignOutAsync(CancellationToken.None);
+
+        Assert.Equal(DesktopSessionStatus.SignedOut, signedOut.Status);
+        Assert.False(viewModel.IsSignedIn);
+        Assert.Equal(DesktopSessionStatus.SignedOut, viewModel.CurrentSession.Status);
+        Assert.Null(viewModel.CurrentSession.UserId);
+        Assert.Null(viewModel.CurrentSession.DisplayName);
+        Assert.False(viewModel.CurrentSession.HasAccessToken);
+        Assert.False(viewModel.CurrentSession.HasRefreshToken);
+        Assert.Equal(string.Empty, viewModel.Password);
+        Assert.Equal(DesktopSignInText.SignedOutMessage, viewModel.LastResult.Message);
+        Assert.DoesNotContain("Desktop Operator", viewModel.LastResult.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task ViewModelSubmitUsesCurrentBoundInputValues()
     {
         var password = CreateSensitiveValue("password");
@@ -128,6 +234,48 @@ public sealed class DesktopSignInServiceTests
         Assert.Equal(2, CountOccurrences(markup, "aria-required=\"true\""));
         Assert.Contains("if (SignInViewModel.IsBusy)", markup, StringComparison.Ordinal);
         Assert.DoesNotContain("if (!SignInViewModel.CanSubmit)", markup, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DesktopShellSwitchesToSignedInWorkspaceWithDisabledNavigationPlaceholders()
+    {
+        string markup = File.ReadAllText(Path.Combine(
+            FindRepositoryRoot(),
+            "src",
+            "App.Desktop",
+            "Components",
+            "DesktopShell.razor"));
+
+        Assert.Contains("@if (SignInViewModel.IsSignedIn)", markup, StringComparison.Ordinal);
+        Assert.Contains("@DesktopSignedInShellText.Title", markup, StringComparison.Ordinal);
+        Assert.Contains("@SignInViewModel.SignedInUserContextMessage", markup, StringComparison.Ordinal);
+        Assert.Contains("@DesktopSignedInShellText.SignOutButton", markup, StringComparison.Ordinal);
+        Assert.Contains("@onclick=\"SignOutAsync\"", markup, StringComparison.Ordinal);
+        Assert.Contains("DesktopSignedInShellText.NavigationCards", markup, StringComparison.Ordinal);
+        Assert.Contains("disabled=\"disabled\"", markup, StringComparison.Ordinal);
+        Assert.Contains("aria-disabled=\"true\"", markup, StringComparison.Ordinal);
+        Assert.DoesNotContain("<UploadPlaceholder", markup, StringComparison.Ordinal);
+        Assert.DoesNotContain("IDesktopUploadOrchestrator", markup, StringComparison.Ordinal);
+        Assert.DoesNotContain("IControlPlaneApiClient", markup, StringComparison.Ordinal);
+        Assert.DoesNotContain("IDesktopFilePicker", markup, StringComparison.Ordinal);
+        Assert.DoesNotContain("PreUploadCheck", markup, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void SignedInShellTextDefinesDeferredRussianNavigationCards()
+    {
+        Assert.Equal("Рабочая область", DesktopSignedInShellText.Title);
+        Assert.Equal("Выйти", DesktopSignedInShellText.SignOutButton);
+        Assert.Equal(
+            "Будет доступно в следующем approved desktop slice.",
+            DesktopSignedInShellText.DeferredPlaceholderMessage);
+
+        Assert.Collection(
+            DesktopSignedInShellText.NavigationCards,
+            card => AssertPlaceholderCard(card, "Группы"),
+            card => AssertPlaceholderCard(card, "Загрузка видео"),
+            card => AssertPlaceholderCard(card, "Проверка перед загрузкой"),
+            card => AssertPlaceholderCard(card, "Квитанции загрузки"));
     }
 
     [Fact]
@@ -437,6 +585,7 @@ public sealed class DesktopSignInServiceTests
         Assert.Equal("Введите пароль", DesktopSignInText.PasswordPlaceholder);
         Assert.Equal("Войти", DesktopSignInText.SubmitButton);
         Assert.Equal("Выполняется вход...", DesktopSignInText.SubmitButtonBusy);
+        Assert.Equal("Вы вышли из системы. Введите логин и пароль для входа.", DesktopSignInText.SignedOutMessage);
     }
 
     public static IEnumerable<object[]> FailedAuthResults()
@@ -526,6 +675,14 @@ public sealed class DesktopSignInServiceTests
         }
 
         return count;
+    }
+
+    private static void AssertPlaceholderCard(
+        DesktopNavigationPlaceholderCard card,
+        string expectedTitle)
+    {
+        Assert.Equal(expectedTitle, card.Title);
+        Assert.Equal(DesktopSignedInShellText.DeferredPlaceholderMessage, card.Message);
     }
 
     private sealed class RecordingAuthClient(DesktopAuthResult result) : IDesktopAuthClient


### PR DESCRIPTION
## Coder
Coder 1 acting as Coder 2 / Desktop Client

## Task ID S2-59
Desktop Signed-in Shell / Navigation Placeholder

## Module
App.Desktop / signed-in shell navigation placeholder

## Scope
- Preserve the current Russian SignIn UI before authentication.
- After successful sign-in, hide SignIn and show a Russian signed-in workspace.
- Show safe user context as `Вход выполнен: <DisplayName>.` when display name is safe.
- Add `Выйти` to clear desktop signed-in/session state and return to SignIn with password cleared.
- Add disabled/no-op placeholder navigation cards: `Группы`, `Загрузка видео`, `Проверка перед загрузкой`, `Квитанции загрузки`.
- No upload flow implementation.

## Changed areas
- `docs/task-cards/S2-59_desktop-signed-in-shell-navigation-task-card.txt`
- `src/App.Desktop/Boundaries/DesktopSignInBoundary.cs`
- `src/App.Desktop/Components/DesktopShell.razor`
- `src/App.Desktop/Services/Auth/DesktopSignInViewModel.cs`
- `src/App.Desktop/wwwroot/app.css`
- `tests/Unit/App.Desktop.Tests/DesktopCompositionRootTests.cs`
- `tests/Unit/App.Desktop.Tests/DesktopSignInServiceTests.cs`

## Base main SHA
`7aad38d5f277b456665ab667873ff5b39b090a6e`

## Coordination log entries reviewed
- Issue #89 metadata: `TEAM COORDINATION LOG — AnalyticsAutomation-Core`, open, updated 2026-04-30.
- #117 / #118 S2-51 Desktop SignIn runtime enablement.
- #119 / #120 S2-52 identity bootstrap first admin.
- #121 / #122 S2-53 operator admin password recovery.
- #123 S2-54 desktop SignIn feedback.
- #124 S2-55 desktop Russian SignIn usability.
- #125 S2-56 desktop SignIn submit binding fix.
- #126 S2-57 Desktop SignIn input binding fix.
- #127 S2-58 Desktop visual-smoke fake auth harness.

## Handoff/task cards reviewed
- `docs/task-cards/S2-51_desktop-signin-runtime-enablement-task-card.txt`
- `docs/task-cards/S2-52_identity-bootstrap-first-admin-task-card.txt`
- `docs/task-cards/S2-53_operator-admin-password-recovery-task-card.txt`
- `docs/task-cards/S2-54_desktop-signin-feedback-fix-task-card.txt`
- `docs/task-cards/S2-55_desktop-russian-localization-signin-usability-task-card.txt`
- `docs/task-cards/S2-56_desktop-signin-submit-binding-fix-task-card.txt`
- `docs/task-cards/S2-57_desktop-signin-input-binding-fix-task-card.txt`
- `docs/task-cards/S2-58_desktop-visual-smoke-fake-auth-task-card.txt`

## Contracts
None. No shared DTO or App.Api contract changes.

## Migrations
None.

## Feature flags/env guard
Uses only the existing S2-58 fake auth env guard for visual smoke: `AA_DESKTOP_DEV_FAKE_AUTH_ENABLED=true`.

Fake auth remains debug/dev-test only and is not selected when `AA_DESKTOP_CONTROL_PLANE_BASE_ADDRESS` is configured.

## API impact
No App.Api changes. Placeholder cards do not call App.Api.

## Web impact
No App.Web changes.

## Android impact
No App.Mobile.Android changes.

## Offline behavior
No offline implementation.

## Rollback
Revert this S2-59 PR.

## Validation
- PASS: `git diff --check`
- PASS: `dotnet restore AnalyticsAutomation-Core.sln -nologo`
- PASS after whitespace fix: `dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore`
- PASS: `dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal`
- PASS: `dotnet build AnalyticsAutomation-Core.sln -nologo -v minimal` (existing analyzer warnings outside this scope)
- PASS: `dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal` (77 passed)
- PASS: hidden/control Unicode scan over changed text files
- PASS: App.Desktop visual smoke with fake auth enabled

## Visual smoke screenshot folder/files
Folder: `C:\CODEX\Temp\S2-59_DESKTOP_SIGNED_IN_SHELL_VISUAL_SMOKE_20260430_112137\`

Files:
- `01_baseline_signin.png`
- `02_filled_fake_credentials.png`
- `03_signed_in_shell.png`
- `04_after_sign_out.png`

Notes:
- Ran with `AA_DESKTOP_DEV_FAKE_AUTH_ENABLED=true`.
- Did not set `AA_DESKTOP_CONTROL_PLANE_BASE_ADDRESS`.
- Used non-secret test data `visual-smoke-user` / `visual-smoke-password`.
- Screenshots/runtime artifacts are under `C:\CODEX\Temp` and not committed.

## Handoff docs/task card
- `docs/task-cards/S2-59_desktop-signed-in-shell-navigation-task-card.txt`

## Next step
Review the narrow desktop signed-in shell placeholder. A later approved desktop slice can implement real upload navigation/workflow.

## NO-GO / Deferred
- No GroupTree implementation.
- No file picker.
- No SHA-256.
- No PreUploadCheck.
- No site upload.
- No UploadReceipt.
- No offline queue.
- No App.Api/contracts/migrations/deploy/App.Web/App.Mobile.Android changes.
- No live Korobochka path changes.