### PR TITLE
[codex] S2-60 Desktop Upload Section File Selection Placeholder

### DIFF
--- a/docs/task-cards/S2-60_desktop-upload-section-file-selection-placeholder-task-card.txt
+++ b/docs/task-cards/S2-60_desktop-upload-section-file-selection-placeholder-task-card.txt
@@ -1,0 +1,146 @@
+Title:
+S2-60 Desktop Upload Section Entry / File Selection Placeholder
+
+Module:
+App.Desktop / upload section entry placeholder
+
+Owner:
+Coder 1 acting as Coder 2 / Desktop Client
+
+Client form:
+desktop standalone
+
+Type:
+narrow runtime desktop UI slice after signed-in shell placeholder
+
+Status:
+Runtime task card created with implementation.
+
+Goal:
+Make the signed-in "Загрузка видео" card an active desktop-only navigation entry, show a safe upload section placeholder, and support repeatable fake-auth visual-smoke screenshots with an optional fake file-selection state.
+
+Context:
+S2-58 added the debug-only fake-auth visual-smoke harness guarded by AA_DESKTOP_DEV_FAKE_AUTH_ENABLED=true and disabled whenever AA_DESKTOP_CONTROL_PLANE_BASE_ADDRESS is configured.
+S2-59 added the Russian signed-in shell, safe user context, "Выйти", and deferred placeholder cards for groups, upload, pre-upload check, and upload receipts.
+
+Scope:
+- Keep the current Russian SignIn UI before authentication.
+- After fake-auth SignIn, show the S2-59 signed-in shell.
+- Make the "Загрузка видео" card open the upload section.
+- Show the upload section title, approved-slice placeholder copy, step 1 file-selection block, "Выбрать видеофайл", and the safe placeholder result.
+- Add "Назад к рабочей области".
+- Keep "Выйти" working from the signed-in shell and upload section.
+- Do not implement the real upload flow.
+
+Allowed changed areas:
+- docs/task-cards/S2-60_desktop-upload-section-file-selection-placeholder-task-card.txt
+- src/App.Desktop/**
+- tests/Unit/App.Desktop.Tests/**
+
+Forbidden changed areas:
+- src/App.Api/**
+- src/App.Worker/**
+- src/App.Web/**
+- src/App.Mobile.Android/**
+- src/App.UI.Shared/**
+- src/BuildingBlocks.Contracts/**
+- src/Modules/**
+- DB migrations
+- .github/workflows/**
+- deploy scripts
+- docs/ops/**
+- committed screenshots or runtime artifacts
+
+Contracts:
+none
+
+Migrations:
+none
+
+Feature flags/env guard:
+- Uses the S2-58 fake auth visual-smoke guard:
+  AA_DESKTOP_DEV_FAKE_AUTH_ENABLED=true
+- Adds optional debug/dev-test fake file-selection guard for visual smoke only:
+  AA_DESKTOP_DEV_FAKE_UPLOAD_FILE_ENABLED=true
+- Fake auth still does not replace configured live auth. If AA_DESKTOP_CONTROL_PLANE_BASE_ADDRESS is configured, live HttpDesktopAuthClient remains selected.
+- Fake file selection is disabled by default and does not read disk.
+
+Fake file-selection visual-smoke data:
+- file name: visual-smoke-video.mp4
+- file size: 12345678
+- content type: video/mp4
+
+Events:
+none
+
+Offline behavior:
+none
+
+Security guardrails:
+- Do not display or log password.
+- Do not display or log accessToken, refreshToken, Authorization, raw session id, raw response body, or token-like values.
+- Do not persist tokens, passwords, selected files, file paths, or upload drafts.
+- Fake file selection does not read disk and does not call App.Api.
+- Use only non-secret fake-auth visual-smoke test data:
+  - login: visual-smoke-user
+  - password: visual-smoke-password
+- Screenshots and runtime artifacts stay under C:\CODEX\Temp and are not committed.
+
+Explicitly out of scope:
+- Real file picker.
+- Reading files from disk.
+- SHA-256.
+- businessObjectKey.
+- PreUploadCheck.
+- Direct site upload.
+- UploadReceipt.
+- Offline queue.
+- GroupTree runtime.
+- App.Api changes.
+- Shared contract changes.
+- DB migrations.
+- Deploy/workflow changes.
+- App.Web changes.
+- App.Mobile.Android changes.
+- App.UI.Shared changes.
+
+Rollback:
+revert S2-60 PR
+
+Validation:
+- git diff --check
+- dotnet restore AnalyticsAutomation-Core.sln -nologo
+- dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore
+- dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal
+- dotnet build AnalyticsAutomation-Core.sln -nologo -v minimal
+- dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal
+- hidden/control Unicode scan over changed text files
+- App.Desktop fake-auth visual smoke with fake upload file enabled
+
+Definition of done:
+- "Загрузка видео" is active after successful SignIn.
+- Upload section opens from the signed-in shell.
+- Upload section shows the required Russian title/copy, step 1 file-selection block, placeholder button, safe result message, and back button.
+- Optional fake selected file state appears only with AA_DESKTOP_DEV_FAKE_UPLOAD_FILE_ENABLED=true in debug/dev-test flow.
+- Fake selected file state contains no real path, no disk read, no SHA-256, no PreUploadCheck, no direct site upload, no UploadReceipt, and no App.Api call.
+- SignOut returns to SignIn and clears upload section state.
+- Visible strings do not expose password, accessToken, refreshToken, Authorization, raw session id, raw response body, or token-like values.
+- Required screenshots are saved under C:\CODEX\Temp and kept out of git.
+- App.Api/contracts/migrations/deploy/App.Web/App.Mobile.Android are unchanged.
+
+Visual-smoke definition of done:
+- Run App.Desktop with AA_DESKTOP_DEV_FAKE_AUTH_ENABLED=true and AA_DESKTOP_DEV_FAKE_UPLOAD_FILE_ENABLED=true.
+- Do not set AA_DESKTOP_CONTROL_PLANE_BASE_ADDRESS.
+- Use non-secret test data visual-smoke-user / visual-smoke-password.
+- Capture screenshots under C:\CODEX\Temp\S2-60_DESKTOP_UPLOAD_SECTION_VISUAL_SMOKE_<timestamp>\.
+- Required screenshots:
+  - 01_baseline_signin.png
+  - 02_signed_in_shell.png
+  - 03_upload_section_placeholder.png
+  - 04_fake_file_selection_placeholder.png
+  - 05_back_to_workspace.png
+  - 06_after_sign_out.png
+- Confirm signed-in shell shows the upload entry and safe display name.
+- Confirm upload section fake file state shows only visual-smoke-video.mp4, 12345678, and video/mp4.
+- Confirm no password, accessToken, refreshToken, Authorization, raw session id, raw response body, raw path, or real secret is visible.
+- Confirm screenshots and runtime artifacts are not committed.

--- a/src/App.Desktop/Boundaries/DesktopSignInBoundary.cs
+++ b/src/App.Desktop/Boundaries/DesktopSignInBoundary.cs
@@ -99,7 +99,7 @@ public static class DesktopSignedInShellText
     public static IReadOnlyList<DesktopNavigationPlaceholderCard> NavigationCards { get; } =
     [
         new("Группы", DeferredPlaceholderMessage),
-        new("Загрузка видео", DeferredPlaceholderMessage),
+        new("Загрузка видео", DesktopUploadSectionText.NavigationCardMessage, DesktopNavigationCardTarget.UploadSection),
         new("Проверка перед загрузкой", DeferredPlaceholderMessage),
         new("Квитанции загрузки", DeferredPlaceholderMessage)
     ];
@@ -114,7 +114,50 @@ public static class DesktopSignedInShellText
 
 public sealed record DesktopNavigationPlaceholderCard(
     string Title,
-    string Message);
+    string Message,
+    DesktopNavigationCardTarget Target = DesktopNavigationCardTarget.Deferred);
+
+public enum DesktopNavigationCardTarget
+{
+    Deferred,
+    UploadSection
+}
+
+public enum DesktopWorkspaceSection
+{
+    Workspace,
+    Upload
+}
+
+public static class DesktopUploadSectionText
+{
+    public const string Title = "Загрузка видео";
+    public const string Description =
+        "Этот раздел подготовлен. Реальная загрузка будет включена в следующем approved desktop slice.";
+    public const string NavigationCardMessage = "Открыть заготовку выбора видеофайла.";
+    public const string StepOneTitle = "Шаг 1. Выбор видеофайла";
+    public const string SelectVideoFileButton = "Выбрать видеофайл";
+    public const string PlaceholderResult = "Выбор файла пока работает в режиме заготовки.";
+    public const string BackToWorkspaceButton = "Назад к рабочей области";
+    public const string SelectedFileNameLabel = "Файл";
+    public const string SelectedFileSizeLabel = "Размер";
+    public const string SelectedFileContentTypeLabel = "Тип содержимого";
+}
+
+public sealed record DesktopUploadSelectedFile(
+    string FileName,
+    long SizeBytes,
+    string ContentType)
+{
+    public const string VisualSmokeFileName = "visual-smoke-video.mp4";
+    public const long VisualSmokeFileSizeBytes = 12345678;
+    public const string VisualSmokeContentType = "video/mp4";
+
+    public static DesktopUploadSelectedFile VisualSmokeFile { get; } = new(
+        VisualSmokeFileName,
+        VisualSmokeFileSizeBytes,
+        VisualSmokeContentType);
+}
 
 public sealed class DesktopSignInResult
 {

--- a/src/App.Desktop/Components/DesktopShell.razor
+++ b/src/App.Desktop/Components/DesktopShell.razor
@@ -1,5 +1,7 @@
 @inject IBlazorWebViewHostBoundary BlazorHostBoundary
 @inject DesktopSignInViewModel SignInViewModel
+@inject DesktopUploadSectionViewModel UploadSectionViewModel
+@using App.Desktop.Services.Upload
 @using Microsoft.AspNetCore.Components.Web
 
 <div class="desktop-shell">
@@ -32,19 +34,75 @@
                     </button>
                 </div>
 
-                <nav class="desktop-navigation" aria-label="Разделы рабочего места">
-                    @foreach (DesktopNavigationPlaceholderCard card in DesktopSignedInShellText.NavigationCards)
-                    {
-                        <button
-                            class="desktop-navigation-card"
-                            type="button"
-                            disabled="disabled"
-                            aria-disabled="true">
-                            <span class="desktop-navigation-card__title">@card.Title</span>
-                            <span class="desktop-navigation-card__message">@card.Message</span>
-                        </button>
-                    }
-                </nav>
+                @if (UploadSectionViewModel.IsUploadSectionOpen)
+                {
+                    <section class="desktop-upload" aria-labelledby="desktop-upload-title">
+                        <div class="desktop-upload__heading">
+                            <div>
+                                <h2 id="desktop-upload-title">@DesktopUploadSectionText.Title</h2>
+                                <p>@DesktopUploadSectionText.Description</p>
+                            </div>
+
+                            <button
+                                class="desktop-upload__back"
+                                type="button"
+                                disabled="@SignInViewModel.IsBusy"
+                                @onclick="BackToWorkspace">
+                                @DesktopUploadSectionText.BackToWorkspaceButton
+                            </button>
+                        </div>
+
+                        <div class="desktop-upload__step">
+                            <h3>@DesktopUploadSectionText.StepOneTitle</h3>
+                            <p class="desktop-upload__message" role="status" aria-live="polite">
+                                @UploadSectionViewModel.SelectionStatusMessage
+                            </p>
+
+                            <button
+                                class="desktop-upload__select"
+                                type="button"
+                                disabled="@SignInViewModel.IsBusy"
+                                @onclick="SelectVideoFilePlaceholder">
+                                @DesktopUploadSectionText.SelectVideoFileButton
+                            </button>
+
+                            @if (UploadSectionViewModel.SelectedFile is not null)
+                            {
+                                <dl class="desktop-upload__selection">
+                                    <div>
+                                        <dt>@DesktopUploadSectionText.SelectedFileNameLabel</dt>
+                                        <dd>@UploadSectionViewModel.SelectedFile.FileName</dd>
+                                    </div>
+                                    <div>
+                                        <dt>@DesktopUploadSectionText.SelectedFileSizeLabel</dt>
+                                        <dd>@UploadSectionViewModel.SelectedFile.SizeBytes</dd>
+                                    </div>
+                                    <div>
+                                        <dt>@DesktopUploadSectionText.SelectedFileContentTypeLabel</dt>
+                                        <dd>@UploadSectionViewModel.SelectedFile.ContentType</dd>
+                                    </div>
+                                </dl>
+                            }
+                        </div>
+                    </section>
+                }
+                else
+                {
+                    <nav class="desktop-navigation" aria-label="Разделы рабочего места">
+                        @foreach (DesktopNavigationPlaceholderCard card in DesktopSignedInShellText.NavigationCards)
+                        {
+                            <button
+                                class="@GetNavigationCardClass(card)"
+                                type="button"
+                                disabled="@IsNavigationCardDisabled(card)"
+                                aria-disabled="@IsNavigationCardDisabled(card)"
+                                @onclick="() => OpenNavigationCard(card)">
+                                <span class="desktop-navigation-card__title">@card.Title</span>
+                                <span class="desktop-navigation-card__message">@card.Message</span>
+                            </button>
+                        }
+                    </nav>
+                }
             </section>
         }
         else
@@ -138,8 +196,29 @@
         }
 
         await SignInViewModel.SignOutAsync(CancellationToken.None);
+        UploadSectionViewModel.ResetForSignedOutState();
 
         StateHasChanged();
+    }
+
+    private void OpenNavigationCard(DesktopNavigationPlaceholderCard card)
+    {
+        if (IsNavigationCardDisabled(card))
+        {
+            return;
+        }
+
+        UploadSectionViewModel.OpenUploadSection();
+    }
+
+    private void BackToWorkspace()
+    {
+        UploadSectionViewModel.BackToWorkspace();
+    }
+
+    private void SelectVideoFilePlaceholder()
+    {
+        UploadSectionViewModel.SelectVideoFilePlaceholder();
     }
 
     private string GetHeaderStatusText()
@@ -168,4 +247,15 @@
         };
     }
 
+    private static bool IsNavigationCardDisabled(DesktopNavigationPlaceholderCard card)
+    {
+        return card.Target != DesktopNavigationCardTarget.UploadSection;
+    }
+
+    private static string GetNavigationCardClass(DesktopNavigationPlaceholderCard card)
+    {
+        return IsNavigationCardDisabled(card)
+            ? "desktop-navigation-card"
+            : "desktop-navigation-card desktop-navigation-card--active";
+    }
 }

--- a/src/App.Desktop/Composition/DesktopCompositionRoot.cs
+++ b/src/App.Desktop/Composition/DesktopCompositionRoot.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using App.Desktop.Boundaries;
 using App.Desktop.Services.Auth;
 using App.Desktop.Services.Placeholders;
+using App.Desktop.Services.Upload;
 
 using Microsoft.Extensions.DependencyInjection;
 
@@ -17,12 +18,22 @@ public static class DesktopCompositionRoot
 
     public static ServiceProvider BuildServicesFromEnvironment()
     {
-        return BuildServices(DesktopAuthOptions.FromEnvironment());
+        return BuildServices(
+            DesktopAuthOptions.FromEnvironment(),
+            DesktopUploadSectionOptions.FromEnvironment());
     }
 
     public static ServiceProvider BuildServices(DesktopAuthOptions authOptions)
     {
+        return BuildServices(authOptions, DesktopUploadSectionOptions.Disabled);
+    }
+
+    public static ServiceProvider BuildServices(
+        DesktopAuthOptions authOptions,
+        DesktopUploadSectionOptions uploadSectionOptions)
+    {
         ArgumentNullException.ThrowIfNull(authOptions);
+        ArgumentNullException.ThrowIfNull(uploadSectionOptions);
 
         var services = new ServiceCollection();
 
@@ -32,6 +43,7 @@ public static class DesktopCompositionRoot
 #endif
 
         services.AddSingleton(authOptions);
+        services.AddSingleton(uploadSectionOptions);
         services.AddSingleton<IDesktopShellLifecycle, PlaceholderDesktopShellLifecycle>();
         services.AddSingleton<IDesktopSessionStore, DisabledDesktopSessionStore>();
         services.AddSingleton<DesktopSessionState>();
@@ -58,6 +70,7 @@ public static class DesktopCompositionRoot
 
         services.AddSingleton<IDesktopSignInService, DesktopSignInService>();
         services.AddTransient<DesktopSignInViewModel>();
+        services.AddTransient<DesktopUploadSectionViewModel>();
         services.AddSingleton<ISecureSessionStorage, PlaceholderSecureSessionStorage>();
         services.AddSingleton<IDesktopFilePicker, PlaceholderDesktopFilePicker>();
         services.AddSingleton<ILocalFileMetadataService, PlaceholderLocalFileMetadataService>();

--- a/src/App.Desktop/Services/Upload/DesktopUploadSectionOptions.cs
+++ b/src/App.Desktop/Services/Upload/DesktopUploadSectionOptions.cs
@@ -1,0 +1,52 @@
+namespace App.Desktop.Services.Upload;
+
+public sealed class DesktopUploadSectionOptions
+{
+    public const string DevFakeUploadFileEnabledEnvironmentVariable =
+        "AA_DESKTOP_DEV_FAKE_UPLOAD_FILE_ENABLED";
+
+    private DesktopUploadSectionOptions(bool isDevFakeUploadFileEnabled)
+    {
+        IsDevFakeUploadFileEnabled = isDevFakeUploadFileEnabled;
+    }
+
+    public static DesktopUploadSectionOptions Disabled { get; } = new(
+        isDevFakeUploadFileEnabled: false);
+
+#if DEBUG
+    public static DesktopUploadSectionOptions EnabledForDevFakeFileSelection { get; } = new(
+        isDevFakeUploadFileEnabled: true);
+#else
+    public static DesktopUploadSectionOptions EnabledForDevFakeFileSelection => Disabled;
+#endif
+
+    public bool IsDevFakeUploadFileEnabled { get; }
+
+    public static DesktopUploadSectionOptions FromEnvironment()
+    {
+        return FromEnvironmentValue(
+            Environment.GetEnvironmentVariable(DevFakeUploadFileEnabledEnvironmentVariable));
+    }
+
+    public static DesktopUploadSectionOptions FromEnvironmentValue(string? devFakeUploadFileEnabled)
+    {
+#if DEBUG
+        if (IsDevFakeUploadFileEnabledValue(devFakeUploadFileEnabled))
+        {
+            return EnabledForDevFakeFileSelection;
+        }
+#endif
+
+        return Disabled;
+    }
+
+    public override string ToString()
+    {
+        return $"{nameof(DesktopUploadSectionOptions)} {{ IsDevFakeUploadFileEnabled = {IsDevFakeUploadFileEnabled} }}";
+    }
+
+    private static bool IsDevFakeUploadFileEnabledValue(string? value)
+    {
+        return string.Equals(value?.Trim(), "true", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/App.Desktop/Services/Upload/DesktopUploadSectionViewModel.cs
+++ b/src/App.Desktop/Services/Upload/DesktopUploadSectionViewModel.cs
@@ -1,0 +1,49 @@
+using App.Desktop.Boundaries;
+
+namespace App.Desktop.Services.Upload;
+
+public sealed class DesktopUploadSectionViewModel(DesktopUploadSectionOptions options)
+{
+    private readonly DesktopUploadSectionOptions _options =
+        options ?? throw new ArgumentNullException(nameof(options));
+
+    public DesktopWorkspaceSection CurrentSection { get; private set; } = DesktopWorkspaceSection.Workspace;
+
+    public bool IsUploadSectionOpen => CurrentSection == DesktopWorkspaceSection.Upload;
+
+    public DesktopUploadSelectedFile? SelectedFile { get; private set; }
+
+    public string SelectionStatusMessage { get; private set; } =
+        DesktopUploadSectionText.PlaceholderResult;
+
+    public void OpenUploadSection()
+    {
+        CurrentSection = DesktopWorkspaceSection.Upload;
+    }
+
+    public void BackToWorkspace()
+    {
+        CurrentSection = DesktopWorkspaceSection.Workspace;
+    }
+
+    public void ResetForSignedOutState()
+    {
+        CurrentSection = DesktopWorkspaceSection.Workspace;
+        SelectedFile = null;
+        SelectionStatusMessage = DesktopUploadSectionText.PlaceholderResult;
+    }
+
+    public DesktopUploadSelectedFile? SelectVideoFilePlaceholder()
+    {
+        SelectionStatusMessage = DesktopUploadSectionText.PlaceholderResult;
+
+        if (!_options.IsDevFakeUploadFileEnabled)
+        {
+            SelectedFile = null;
+            return SelectedFile;
+        }
+
+        SelectedFile = DesktopUploadSelectedFile.VisualSmokeFile;
+        return SelectedFile;
+    }
+}

--- a/src/App.Desktop/wwwroot/app.css
+++ b/src/App.Desktop/wwwroot/app.css
@@ -223,6 +223,17 @@ body {
     cursor: default;
 }
 
+.desktop-navigation-card--active {
+    border-color: #2f6f9f;
+    background: #f8fbff;
+    cursor: pointer;
+}
+
+.desktop-navigation-card--active:hover {
+    border-color: #18406b;
+    background: #eef6ff;
+}
+
 .desktop-navigation-card__title {
     color: #18212f;
     font-size: 1rem;
@@ -234,6 +245,122 @@ body {
     font-size: 0.88rem;
     font-weight: 500;
     line-height: 1.4;
+}
+
+.desktop-upload {
+    display: grid;
+    gap: 18px;
+    box-sizing: border-box;
+    padding: 22px;
+    border: 1px solid #d7dde5;
+    border-radius: 8px;
+    background: #ffffff;
+}
+
+.desktop-upload__heading {
+    display: flex;
+    align-items: start;
+    justify-content: space-between;
+    gap: 18px;
+}
+
+.desktop-upload__heading h2 {
+    margin: 0;
+    font-size: 1.15rem;
+    font-weight: 650;
+}
+
+.desktop-upload__heading p {
+    max-width: 680px;
+    margin: 10px 0 0;
+    color: #52616f;
+    font-size: 0.94rem;
+    line-height: 1.45;
+}
+
+.desktop-upload__back,
+.desktop-upload__select {
+    min-height: 38px;
+    padding: 0 16px;
+    border-radius: 6px;
+    font: inherit;
+    font-size: 0.9rem;
+    font-weight: 650;
+    white-space: nowrap;
+}
+
+.desktop-upload__back {
+    border: 1px solid #394756;
+    background: #ffffff;
+    color: #253241;
+}
+
+.desktop-upload__select {
+    width: fit-content;
+    border: 1px solid #18406b;
+    background: #18406b;
+    color: #ffffff;
+}
+
+.desktop-upload__back:disabled,
+.desktop-upload__select:disabled {
+    color: #687789;
+    border-color: #b9c3cf;
+    background: #eef1f5;
+}
+
+.desktop-upload__step {
+    display: grid;
+    gap: 12px;
+    padding: 18px;
+    border: 1px solid #d1d8e1;
+    border-radius: 8px;
+    background: #fbfcfe;
+}
+
+.desktop-upload__step h3 {
+    margin: 0;
+    color: #18212f;
+    font-size: 1rem;
+    font-weight: 700;
+}
+
+.desktop-upload__message {
+    margin: 0;
+    color: #52616f;
+    font-size: 0.9rem;
+    font-weight: 600;
+    line-height: 1.4;
+}
+
+.desktop-upload__selection {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 12px;
+    margin: 4px 0 0;
+}
+
+.desktop-upload__selection div {
+    min-width: 0;
+    padding: 12px;
+    border: 1px solid #d7dde5;
+    border-radius: 6px;
+    background: #ffffff;
+}
+
+.desktop-upload__selection dt {
+    margin: 0 0 4px;
+    color: #52616f;
+    font-size: 0.78rem;
+    font-weight: 700;
+}
+
+.desktop-upload__selection dd {
+    margin: 0;
+    color: #18212f;
+    font-size: 0.9rem;
+    font-weight: 650;
+    overflow-wrap: anywhere;
 }
 
 @media (max-width: 860px) {
@@ -249,5 +376,19 @@ body {
 
     .desktop-workspace__signout {
         width: 100%;
+    }
+
+    .desktop-upload__heading {
+        align-items: stretch;
+        flex-direction: column;
+    }
+
+    .desktop-upload__back,
+    .desktop-upload__select {
+        width: 100%;
+    }
+
+    .desktop-upload__selection {
+        grid-template-columns: 1fr;
     }
 }

--- a/tests/Unit/App.Desktop.Tests/DesktopCompositionRootTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopCompositionRootTests.cs
@@ -1,6 +1,7 @@
 using App.Desktop.Boundaries;
 using App.Desktop.Composition;
 using App.Desktop.Services.Auth;
+using App.Desktop.Services.Upload;
 
 using Microsoft.Extensions.DependencyInjection;
 
@@ -18,6 +19,8 @@ public sealed class DesktopCompositionRootTests
         Assert.IsType<DisabledDesktopSessionStore>(services.GetRequiredService<IDesktopSessionStore>());
         Assert.IsType<UnavailableDesktopAuthClient>(services.GetRequiredService<IDesktopAuthClient>());
         Assert.IsType<DesktopSignInService>(services.GetRequiredService<IDesktopSignInService>());
+        Assert.IsType<DesktopUploadSectionViewModel>(services.GetRequiredService<DesktopUploadSectionViewModel>());
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
     }
 
     [Fact]
@@ -25,12 +28,31 @@ public sealed class DesktopCompositionRootTests
     {
         using var environment = new EnvironmentVariableScope()
             .Set(DesktopAuthOptions.ControlPlaneBaseAddressEnvironmentVariable, null)
-            .Set(DesktopAuthOptions.DevFakeAuthEnabledEnvironmentVariable, null);
+            .Set(DesktopAuthOptions.DevFakeAuthEnabledEnvironmentVariable, null)
+            .Set(DesktopUploadSectionOptions.DevFakeUploadFileEnabledEnvironmentVariable, null);
 
         using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
 
         Assert.False(services.GetRequiredService<DesktopAuthOptions>().IsDevFakeAuthEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
         Assert.IsType<UnavailableDesktopAuthClient>(services.GetRequiredService<IDesktopAuthClient>());
+    }
+
+    [Fact]
+    public void EnvironmentOptionsEnableFakeUploadFileOnlyWhenExplicitlyRequested()
+    {
+        using var environment = new EnvironmentVariableScope()
+            .Set(DesktopAuthOptions.ControlPlaneBaseAddressEnvironmentVariable, null)
+            .Set(DesktopAuthOptions.DevFakeAuthEnabledEnvironmentVariable, null)
+            .Set(DesktopUploadSectionOptions.DevFakeUploadFileEnabledEnvironmentVariable, "true");
+
+        using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
+
+#if DEBUG
+        Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
+#else
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
+#endif
     }
 
     [Fact]
@@ -98,6 +120,10 @@ public sealed class DesktopCompositionRootTests
         Assert.Equal(DesktopSignInStatus.Succeeded, result.Status);
         Assert.True(viewModel.IsSignedIn);
         Assert.Equal("Вход выполнен: Visual Smoke User.", viewModel.SignedInUserContextMessage);
+        Assert.Contains(
+            DesktopSignedInShellText.NavigationCards,
+            card => card.Target == DesktopNavigationCardTarget.UploadSection
+                && string.Equals(card.Title, DesktopUploadSectionText.Title, StringComparison.Ordinal));
         Assert.DoesNotContain(FakeDesktopAuthClient.VisualSmokePassword, result.ToString(), StringComparison.Ordinal);
         Assert.DoesNotContain("dev-fake-auth-access", result.ToString(), StringComparison.Ordinal);
 #else

--- a/tests/Unit/App.Desktop.Tests/DesktopSignInServiceTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopSignInServiceTests.cs
@@ -252,8 +252,13 @@ public sealed class DesktopSignInServiceTests
         Assert.Contains("@DesktopSignedInShellText.SignOutButton", markup, StringComparison.Ordinal);
         Assert.Contains("@onclick=\"SignOutAsync\"", markup, StringComparison.Ordinal);
         Assert.Contains("DesktopSignedInShellText.NavigationCards", markup, StringComparison.Ordinal);
-        Assert.Contains("disabled=\"disabled\"", markup, StringComparison.Ordinal);
-        Assert.Contains("aria-disabled=\"true\"", markup, StringComparison.Ordinal);
+        Assert.Contains("@onclick=\"() => OpenNavigationCard(card)\"", markup, StringComparison.Ordinal);
+        Assert.Contains("UploadSectionViewModel.OpenUploadSection()", markup, StringComparison.Ordinal);
+        Assert.Contains("UploadSectionViewModel.ResetForSignedOutState()", markup, StringComparison.Ordinal);
+        Assert.Contains("DesktopUploadSectionText.Title", markup, StringComparison.Ordinal);
+        Assert.Contains("DesktopUploadSectionText.SelectVideoFileButton", markup, StringComparison.Ordinal);
+        Assert.Contains("DesktopUploadSectionText.BackToWorkspaceButton", markup, StringComparison.Ordinal);
+        Assert.Contains("UploadSectionViewModel.SelectVideoFilePlaceholder()", markup, StringComparison.Ordinal);
         Assert.DoesNotContain("<UploadPlaceholder", markup, StringComparison.Ordinal);
         Assert.DoesNotContain("IDesktopUploadOrchestrator", markup, StringComparison.Ordinal);
         Assert.DoesNotContain("IControlPlaneApiClient", markup, StringComparison.Ordinal);
@@ -273,7 +278,7 @@ public sealed class DesktopSignInServiceTests
         Assert.Collection(
             DesktopSignedInShellText.NavigationCards,
             card => AssertPlaceholderCard(card, "Группы"),
-            card => AssertPlaceholderCard(card, "Загрузка видео"),
+            card => AssertUploadNavigationCard(card),
             card => AssertPlaceholderCard(card, "Проверка перед загрузкой"),
             card => AssertPlaceholderCard(card, "Квитанции загрузки"));
     }
@@ -683,6 +688,14 @@ public sealed class DesktopSignInServiceTests
     {
         Assert.Equal(expectedTitle, card.Title);
         Assert.Equal(DesktopSignedInShellText.DeferredPlaceholderMessage, card.Message);
+        Assert.Equal(DesktopNavigationCardTarget.Deferred, card.Target);
+    }
+
+    private static void AssertUploadNavigationCard(DesktopNavigationPlaceholderCard card)
+    {
+        Assert.Equal("Загрузка видео", card.Title);
+        Assert.Equal(DesktopUploadSectionText.NavigationCardMessage, card.Message);
+        Assert.Equal(DesktopNavigationCardTarget.UploadSection, card.Target);
     }
 
     private sealed class RecordingAuthClient(DesktopAuthResult result) : IDesktopAuthClient

--- a/tests/Unit/App.Desktop.Tests/DesktopUploadSectionTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopUploadSectionTests.cs
@@ -1,0 +1,190 @@
+using App.Desktop.Boundaries;
+using App.Desktop.Services.Upload;
+
+namespace App.Desktop.Tests;
+
+public sealed class DesktopUploadSectionTests
+{
+    [Fact]
+    public void UploadCardIsActiveNavigationEntryAfterSignedInShell()
+    {
+        DesktopNavigationPlaceholderCard uploadCard = Assert.Single(
+            DesktopSignedInShellText.NavigationCards,
+            card => string.Equals(card.Title, DesktopUploadSectionText.Title, StringComparison.Ordinal));
+
+        Assert.Equal(DesktopNavigationCardTarget.UploadSection, uploadCard.Target);
+        Assert.Equal("Открыть заготовку выбора видеофайла.", uploadCard.Message);
+    }
+
+    [Fact]
+    public void UploadCardNavigationOpensUploadSection()
+    {
+        var viewModel = new DesktopUploadSectionViewModel(DesktopUploadSectionOptions.Disabled);
+
+        Assert.Equal(DesktopWorkspaceSection.Workspace, viewModel.CurrentSection);
+        Assert.False(viewModel.IsUploadSectionOpen);
+
+        viewModel.OpenUploadSection();
+
+        Assert.Equal(DesktopWorkspaceSection.Upload, viewModel.CurrentSection);
+        Assert.True(viewModel.IsUploadSectionOpen);
+    }
+
+    [Fact]
+    public void UploadSectionHasRequiredRussianPlaceholderText()
+    {
+        Assert.Equal("Загрузка видео", DesktopUploadSectionText.Title);
+        Assert.Equal(
+            "Этот раздел подготовлен. Реальная загрузка будет включена в следующем approved desktop slice.",
+            DesktopUploadSectionText.Description);
+        Assert.Equal("Шаг 1. Выбор видеофайла", DesktopUploadSectionText.StepOneTitle);
+        Assert.Equal("Выбрать видеофайл", DesktopUploadSectionText.SelectVideoFileButton);
+        Assert.Equal(
+            "Выбор файла пока работает в режиме заготовки.",
+            DesktopUploadSectionText.PlaceholderResult);
+        Assert.Equal("Назад к рабочей области", DesktopUploadSectionText.BackToWorkspaceButton);
+    }
+
+    [Fact]
+    public void UploadSectionDoesNotReferenceApiFilePickerHashingOrUploadFlowBoundaries()
+    {
+        string[] sourceFiles =
+        [
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Components", "DesktopShell.razor"),
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "DesktopUploadSectionViewModel.cs"),
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "DesktopUploadSectionOptions.cs"),
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Boundaries", "DesktopSignInBoundary.cs")
+        ];
+
+        foreach (string sourceFile in sourceFiles)
+        {
+            string source = File.ReadAllText(sourceFile);
+
+            Assert.DoesNotContain("App.Api", source, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("IControlPlaneApiClient", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("IDesktopUploadOrchestrator", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("IDesktopFilePicker", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("ReadSha256", source, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("SHA-256", source, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("businessObjectKey", source, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("PreUploadCheck", source, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("DirectSiteUpload", source, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("UploadReceipt", source, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("FilePath", source, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void FakeUploadFileSelectionIsDevOnlyAndDisabledByDefault()
+    {
+        Assert.False(DesktopUploadSectionOptions.Disabled.IsDevFakeUploadFileEnabled);
+        Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue(null).IsDevFakeUploadFileEnabled);
+        Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("false").IsDevFakeUploadFileEnabled);
+
+#if DEBUG
+        Assert.True(DesktopUploadSectionOptions.FromEnvironmentValue("true").IsDevFakeUploadFileEnabled);
+#else
+        Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("true").IsDevFakeUploadFileEnabled);
+#endif
+    }
+
+    [Fact]
+    public void FakeUploadFileSelectionDoesNothingWhenDisabled()
+    {
+        var viewModel = new DesktopUploadSectionViewModel(DesktopUploadSectionOptions.Disabled);
+
+        DesktopUploadSelectedFile? selectedFile = viewModel.SelectVideoFilePlaceholder();
+
+        Assert.Null(selectedFile);
+        Assert.Null(viewModel.SelectedFile);
+        Assert.Equal(DesktopUploadSectionText.PlaceholderResult, viewModel.SelectionStatusMessage);
+    }
+
+    [Fact]
+    public void FakeSelectedFileStateIsSafeAndContainsNoRealPathOrSecret()
+    {
+        var viewModel = new DesktopUploadSectionViewModel(
+            DesktopUploadSectionOptions.EnabledForDevFakeFileSelection);
+
+        DesktopUploadSelectedFile? selectedFile = viewModel.SelectVideoFilePlaceholder();
+
+        Assert.NotNull(selectedFile);
+        Assert.Equal("visual-smoke-video.mp4", selectedFile.FileName);
+        Assert.Equal(12345678, selectedFile.SizeBytes);
+        Assert.Equal("video/mp4", selectedFile.ContentType);
+        Assert.Equal(DesktopUploadSectionText.PlaceholderResult, viewModel.SelectionStatusMessage);
+
+        string visibleState = selectedFile.ToString() + " " + viewModel.SelectionStatusMessage;
+        Assert.DoesNotContain(@"\", visibleState, StringComparison.Ordinal);
+        Assert.DoesNotContain("/", selectedFile.FileName, StringComparison.Ordinal);
+        Assert.DoesNotContain(":", visibleState, StringComparison.Ordinal);
+        Assert.DoesNotContain("password", visibleState, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Authorization", visibleState, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("accessToken", visibleState, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("refreshToken", visibleState, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("session_id", visibleState, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void SignOutResetReturnsUploadStateToWorkspace()
+    {
+        var viewModel = new DesktopUploadSectionViewModel(
+            DesktopUploadSectionOptions.EnabledForDevFakeFileSelection);
+
+        viewModel.OpenUploadSection();
+        _ = viewModel.SelectVideoFilePlaceholder();
+
+        viewModel.ResetForSignedOutState();
+
+        Assert.Equal(DesktopWorkspaceSection.Workspace, viewModel.CurrentSection);
+        Assert.False(viewModel.IsUploadSectionOpen);
+        Assert.Null(viewModel.SelectedFile);
+        Assert.Equal(DesktopUploadSectionText.PlaceholderResult, viewModel.SelectionStatusMessage);
+    }
+
+    [Fact]
+    public void UploadVisualStringsDoNotExposeTokensPasswordAuthorizationOrRawSession()
+    {
+        string[] visibleStrings =
+        [
+            DesktopUploadSectionText.Title,
+            DesktopUploadSectionText.Description,
+            DesktopUploadSectionText.NavigationCardMessage,
+            DesktopUploadSectionText.StepOneTitle,
+            DesktopUploadSectionText.SelectVideoFileButton,
+            DesktopUploadSectionText.PlaceholderResult,
+            DesktopUploadSectionText.BackToWorkspaceButton,
+            DesktopUploadSectionText.SelectedFileNameLabel,
+            DesktopUploadSectionText.SelectedFileSizeLabel,
+            DesktopUploadSectionText.SelectedFileContentTypeLabel,
+            DesktopUploadSelectedFile.VisualSmokeFileName,
+            DesktopUploadSelectedFile.VisualSmokeContentType
+        ];
+
+        foreach (string visibleString in visibleStrings)
+        {
+            Assert.DoesNotContain("password", visibleString, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("Authorization", visibleString, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("accessToken", visibleString, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("refreshToken", visibleString, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("session_id", visibleString, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("raw response", visibleString, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "AnalyticsAutomation-Core.sln")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException("Repository root was not found.");
+    }
+}


### PR DESCRIPTION
## Coder
Coder 1 acting as Coder 2 / Desktop Client

## Task ID S2-60
Desktop Upload Section Entry / File Selection Placeholder

## Module
App.Desktop / upload section entry placeholder

## Scope
Narrow desktop-only UI slice: make the signed-in `Загрузка видео` card active, show the upload section placeholder, add safe fake file-selection state for visual smoke, and keep real upload deferred.

## Changed areas
- `docs/task-cards/S2-60_desktop-upload-section-file-selection-placeholder-task-card.txt`
- `src/App.Desktop/Boundaries/DesktopSignInBoundary.cs`
- `src/App.Desktop/Components/DesktopShell.razor`
- `src/App.Desktop/Composition/DesktopCompositionRoot.cs`
- `src/App.Desktop/Services/Upload/DesktopUploadSectionOptions.cs`
- `src/App.Desktop/Services/Upload/DesktopUploadSectionViewModel.cs`
- `src/App.Desktop/wwwroot/app.css`
- `tests/Unit/App.Desktop.Tests/DesktopCompositionRootTests.cs`
- `tests/Unit/App.Desktop.Tests/DesktopSignInServiceTests.cs`
- `tests/Unit/App.Desktop.Tests/DesktopUploadSectionTests.cs`

## Base main SHA
`79f611354348d5bcd566b6f13c8ebad216a76890`

## Coordination log entries reviewed
- GitHub issue #89 metadata/comments reviewed.
- Relevant merge entries reviewed: #127 S2-58 Desktop Visual Smoke Fake Auth Harness and #128 S2-59 Desktop Signed-in Shell Navigation Placeholder.

## Handoff/task cards reviewed
- `docs/task-cards/S2-58_desktop-visual-smoke-fake-auth-task-card.txt`
- `docs/task-cards/S2-59_desktop-signed-in-shell-navigation-task-card.txt`

## Contracts
None. No shared DTO or App.Api contract changes.

## Migrations
None.

## Feature flags/env guard
- Existing fake auth visual-smoke guard: `AA_DESKTOP_DEV_FAKE_AUTH_ENABLED=true`.
- New optional fake file-selection visual-smoke guard: `AA_DESKTOP_DEV_FAKE_UPLOAD_FILE_ENABLED=true`.
- Fake file selection is disabled by default and guarded behind DEBUG behavior.
- Fake-auth visual smoke was run without `AA_DESKTOP_CONTROL_PLANE_BASE_ADDRESS`.

## API impact
None. Upload section does not call App.Api, pre-upload, site upload, or receipt paths.

## Web impact
None. No App.Web changes.

## Android impact
None. No App.Mobile.Android changes.

## Offline behavior
None.

## Rollback
Revert S2-60 PR.

## Validation
- `git diff --check` passed.
- `dotnet restore AnalyticsAutomation-Core.sln -nologo` passed.
- `dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore` passed.
- `dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal` passed with 0 warnings / 0 errors.
- `dotnet build AnalyticsAutomation-Core.sln -nologo -v minimal` passed; existing analyzer warnings remain outside this slice.
- `dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal` passed: 87/87.
- Hidden/control Unicode scan passed for 10 changed text files.
- App.Desktop fake-auth/fake-file visual smoke passed.

## Visual smoke screenshot folder/files
Folder: `C:\CODEX\Temp\S2-60_DESKTOP_UPLOAD_SECTION_VISUAL_SMOKE_20260430_123447\`

Files:
- `01_baseline_signin.png`
- `02_signed_in_shell.png`
- `03_upload_section_placeholder.png`
- `04_fake_file_selection_placeholder.png`
- `05_back_to_workspace.png`
- `06_after_sign_out.png`

## Handoff docs/task card
`docs/task-cards/S2-60_desktop-upload-section-file-selection-placeholder-task-card.txt`

## Next step
Review the desktop-only placeholder flow and visual smoke evidence; merge only after approval.

## NO-GO / Deferred
Real file picker, disk reads, SHA-256, `businessObjectKey`, `PreUploadCheck`, direct site upload, `UploadReceipt`, offline queue, GroupTree runtime, App.Api changes, contracts changes, migrations, deploy, App.Web changes, and App.Mobile.Android changes are deferred.