### PR TITLE
[codex] S2-61 Desktop Upload File Picker Boundary

### DIFF
--- a/docs/task-cards/S2-61_desktop-upload-file-picker-boundary-task-card.txt
+++ b/docs/task-cards/S2-61_desktop-upload-file-picker-boundary-task-card.txt
@@ -1,0 +1,131 @@
+Title:
+S2-61 Desktop Upload Real File Picker Boundary / Safe Metadata Preview
+
+Module:
+App.Desktop / upload file picker boundary
+
+Owner:
+Coder 1 acting as Coder 2 / Desktop Client
+
+Client form:
+desktop standalone
+
+Type:
+narrow runtime desktop UI slice after S2-60 upload section placeholder
+
+Status:
+Runtime task card created with implementation.
+
+Goal:
+Replace the S2-60 fake file-selection placeholder with an App.Desktop-local video file picker boundary that previews safe file metadata only.
+
+Context:
+S2-58 added debug-only fake auth visual smoke guarded by AA_DESKTOP_DEV_FAKE_AUTH_ENABLED=true.
+S2-59 added the Russian signed-in shell.
+S2-60 added the active "Загрузка видео" entry, upload section placeholder, and optional fake selected metadata for visual smoke.
+
+Scope:
+- Keep the current Russian SignIn UI before authentication.
+- After fake-auth SignIn, show the signed-in shell.
+- Open the upload section from "Загрузка видео".
+- Let "Выбрать видеофайл" call an App.Desktop-local video file picker boundary.
+- Show "Выбор файла отменён." when the operator cancels selection.
+- When a file is selected, show only safe metadata:
+  - file name without the local path;
+  - size in bytes;
+  - content type only when determined safely.
+- Keep "Назад к рабочей области" and "Выйти" working, with upload selection state cleared on reset/sign-out.
+
+Allowed changed areas:
+- docs/task-cards/S2-61_desktop-upload-file-picker-boundary-task-card.txt
+- src/App.Desktop/**
+- tests/Unit/App.Desktop.Tests/**
+
+Forbidden changed areas:
+- src/App.Api/**
+- src/App.Worker/**
+- src/App.Web/**
+- src/App.Mobile.Android/**
+- src/App.UI.Shared/**
+- src/BuildingBlocks.Contracts/**
+- src/Modules/**
+- DB migrations
+- .github/workflows/**
+- deploy scripts
+- docs/ops/**
+- committed screenshots or runtime artifacts
+
+Contracts:
+none
+
+Migrations:
+none
+
+Feature flags/env guard:
+- Uses the existing S2-58 fake auth visual-smoke guard:
+  AA_DESKTOP_DEV_FAKE_AUTH_ENABLED=true
+- Uses AA_DESKTOP_DEV_FAKE_UPLOAD_FILE_ENABLED=true for visual smoke fake picker only.
+- Fake picker is disabled by default and does not replace the native picker unless explicitly enabled in the debug/dev-test flow.
+
+Fake file picker visual-smoke data:
+- file name: visual-smoke-video.mp4
+- file size: 12345678
+- content type: video/mp4
+
+Events:
+none
+
+Offline behavior:
+none
+
+Security guardrails:
+- Do not read file contents.
+- Do not compute SHA-256.
+- Do not introduce businessObjectKey, PreUploadCheck, direct site upload, UploadReceipt, offline queue, GroupTree runtime, or App.Api calls from the upload section.
+- Do not display the full local path.
+- Do not display or log password, accessToken, refreshToken, Authorization, raw session id, raw response body, or token-like values.
+- Fake auth uses only non-secret visual-smoke data:
+  - login: visual-smoke-user
+  - password: visual-smoke-password
+- Screenshots and runtime artifacts stay under C:\CODEX\Temp and are not committed.
+
+Explicitly out of scope:
+- Reading file contents.
+- SHA-256.
+- businessObjectKey.
+- PreUploadCheck.
+- Direct site upload.
+- UploadReceipt.
+- Offline queue.
+- GroupTree runtime.
+- App.Api changes.
+- Shared contract changes.
+- DB migrations.
+- Deploy/workflow changes.
+- App.Web changes.
+- App.Mobile.Android changes.
+- App.UI.Shared changes.
+
+Rollback:
+revert S2-61 PR
+
+Validation:
+- git diff --check
+- dotnet restore AnalyticsAutomation-Core.sln -nologo
+- dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore
+- dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal
+- dotnet build AnalyticsAutomation-Core.sln -nologo -v minimal
+- dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal
+- hidden/control Unicode scan over changed text files
+- App.Desktop fake-auth/fake-picker visual smoke with screenshots
+
+Definition of done:
+- App.Desktop has an IDesktopVideoFilePicker boundary.
+- The default picker is a native WPF desktop picker behind the boundary.
+- The debug/dev-test fake picker is enabled only by AA_DESKTOP_DEV_FAKE_UPLOAD_FILE_ENABLED=true.
+- Fake picker returns visual-smoke-video.mp4 / 12345678 / video/mp4 without disk reads or App.Api calls.
+- Upload section preview shows only safe metadata and never the full local path.
+- Cancel selection shows "Выбор файла отменён.".
+- Back/sign-out reset the selected file state.
+- Automated App.Desktop unit tests cover default fake-disabled behavior, env guard behavior, fake metadata, path hiding, cancel messaging, reset behavior, forbidden upload-chain calls, and visible-string safety.
+- Required visual-smoke screenshots are saved under C:\CODEX\Temp and kept out of git.

--- a/src/App.Desktop/Boundaries/DesktopSignInBoundary.cs
+++ b/src/App.Desktop/Boundaries/DesktopSignInBoundary.cs
@@ -1,3 +1,5 @@
+using System.IO;
+
 namespace App.Desktop.Boundaries;
 
 public interface IDesktopSignInService
@@ -133,15 +135,20 @@ public static class DesktopUploadSectionText
 {
     public const string Title = "Загрузка видео";
     public const string Description =
-        "Этот раздел подготовлен. Реальная загрузка будет включена в следующем approved desktop slice.";
+        "Этот раздел показывает безопасные сведения о выбранном видеофайле. Реальная загрузка будет включена в следующем approved desktop slice.";
     public const string NavigationCardMessage = "Открыть заготовку выбора видеофайла.";
     public const string StepOneTitle = "Шаг 1. Выбор видеофайла";
     public const string SelectVideoFileButton = "Выбрать видеофайл";
-    public const string PlaceholderResult = "Выбор файла пока работает в режиме заготовки.";
+    public const string PlaceholderResult = "Выберите видеофайл для безопасного предпросмотра.";
+    public const string SelectingFileMessage = "Открывается выбор видеофайла.";
+    public const string SelectionCanceledMessage = "Выбор файла отменён.";
+    public const string SelectedFilePreviewMessage = "Файл выбран. Показаны только безопасные сведения.";
+    public const string SelectionUnavailableMessage = "Не удалось получить безопасные сведения о файле.";
     public const string BackToWorkspaceButton = "Назад к рабочей области";
     public const string SelectedFileNameLabel = "Файл";
     public const string SelectedFileSizeLabel = "Размер";
     public const string SelectedFileContentTypeLabel = "Тип содержимого";
+    public const string UnknownContentTypeValue = "Не определён";
 }
 
 public sealed record DesktopUploadSelectedFile(
@@ -157,6 +164,99 @@ public sealed record DesktopUploadSelectedFile(
         VisualSmokeFileName,
         VisualSmokeFileSizeBytes,
         VisualSmokeContentType);
+
+    public static DesktopUploadSelectedFile FromSafeMetadata(
+        string fileNameOrPath,
+        long sizeBytes,
+        string? contentType)
+    {
+        return new DesktopUploadSelectedFile(
+            CreateSafeFileName(fileNameOrPath),
+            Math.Max(0, sizeBytes),
+            CreateSafeContentType(contentType));
+    }
+
+    private static string CreateSafeFileName(string? fileNameOrPath)
+    {
+        string? fileName = Path.GetFileName(fileNameOrPath?.Trim());
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            return "selected-video-file";
+        }
+
+        var safeCharacters = new char[fileName.Length];
+        var safeLength = 0;
+
+        foreach (char character in fileName)
+        {
+            if (safeLength >= 160)
+            {
+                break;
+            }
+
+            if (char.IsControl(character)
+                || character == Path.DirectorySeparatorChar
+                || character == Path.AltDirectorySeparatorChar
+                || character == Path.PathSeparator
+                || character == Path.VolumeSeparatorChar)
+            {
+                continue;
+            }
+
+            safeCharacters[safeLength] = character;
+            safeLength++;
+        }
+
+        string safeFileName = new string(safeCharacters, 0, safeLength).Trim();
+        return string.IsNullOrWhiteSpace(safeFileName)
+            ? "selected-video-file"
+            : safeFileName;
+    }
+
+    private static string CreateSafeContentType(string? contentType)
+    {
+        if (string.IsNullOrWhiteSpace(contentType))
+        {
+            return DesktopUploadSectionText.UnknownContentTypeValue;
+        }
+
+        string trimmed = contentType.Trim().ToLowerInvariant();
+        if (trimmed.Length > 80 || trimmed.Count(value => value == '/') != 1)
+        {
+            return DesktopUploadSectionText.UnknownContentTypeValue;
+        }
+
+        string[] blockedFragments =
+        [
+            "authorization",
+            "bearer",
+            "password",
+            "token",
+            "sessionid",
+            "session_id",
+            "access_token",
+            "refreshtoken",
+            "refresh_token"
+        ];
+
+        foreach (string blockedFragment in blockedFragments)
+        {
+            if (trimmed.Contains(blockedFragment, StringComparison.Ordinal))
+            {
+                return DesktopUploadSectionText.UnknownContentTypeValue;
+            }
+        }
+
+        foreach (char character in trimmed)
+        {
+            if (!char.IsAsciiLetterOrDigit(character) && character is not '/' and not '+' and not '-' and not '.')
+            {
+                return DesktopUploadSectionText.UnknownContentTypeValue;
+            }
+        }
+
+        return trimmed;
+    }
 }
 
 public sealed class DesktopSignInResult

--- a/src/App.Desktop/Boundaries/DesktopVideoFilePickerBoundary.cs
+++ b/src/App.Desktop/Boundaries/DesktopVideoFilePickerBoundary.cs
@@ -1,0 +1,49 @@
+namespace App.Desktop.Boundaries;
+
+public interface IDesktopVideoFilePicker
+{
+    ValueTask<DesktopVideoFilePickerResult> PickVideoFileAsync(CancellationToken cancellationToken);
+}
+
+public sealed class DesktopVideoFilePickerResult
+{
+    private DesktopVideoFilePickerResult(
+        DesktopVideoFilePickerStatus status,
+        DesktopUploadSelectedFile? selectedFile)
+    {
+        Status = status;
+        SelectedFile = selectedFile;
+    }
+
+    public DesktopVideoFilePickerStatus Status { get; }
+
+    public DesktopUploadSelectedFile? SelectedFile { get; }
+
+    public static DesktopVideoFilePickerResult Canceled { get; } = new(
+        DesktopVideoFilePickerStatus.Canceled,
+        selectedFile: null);
+
+    public static DesktopVideoFilePickerResult Unavailable { get; } = new(
+        DesktopVideoFilePickerStatus.Unavailable,
+        selectedFile: null);
+
+    public static DesktopVideoFilePickerResult Selected(
+        string fileNameOrPath,
+        long sizeBytes,
+        string? contentType)
+    {
+        return new DesktopVideoFilePickerResult(
+            DesktopVideoFilePickerStatus.Selected,
+            DesktopUploadSelectedFile.FromSafeMetadata(
+                fileNameOrPath,
+                sizeBytes,
+                contentType));
+    }
+}
+
+public enum DesktopVideoFilePickerStatus
+{
+    Canceled,
+    Selected,
+    Unavailable
+}

--- a/src/App.Desktop/Components/DesktopShell.razor
+++ b/src/App.Desktop/Components/DesktopShell.razor
@@ -61,8 +61,8 @@
                             <button
                                 class="desktop-upload__select"
                                 type="button"
-                                disabled="@SignInViewModel.IsBusy"
-                                @onclick="SelectVideoFilePlaceholder">
+                                disabled="@(SignInViewModel.IsBusy || UploadSectionViewModel.IsSelectingFile)"
+                                @onclick="SelectVideoFileAsync">
                                 @DesktopUploadSectionText.SelectVideoFileButton
                             </button>
 
@@ -216,9 +216,9 @@
         UploadSectionViewModel.BackToWorkspace();
     }
 
-    private void SelectVideoFilePlaceholder()
+    private async Task SelectVideoFileAsync()
     {
-        UploadSectionViewModel.SelectVideoFilePlaceholder();
+        await UploadSectionViewModel.SelectVideoFileAsync(CancellationToken.None);
     }
 
     private string GetHeaderStatusText()

--- a/src/App.Desktop/Composition/DesktopCompositionRoot.cs
+++ b/src/App.Desktop/Composition/DesktopCompositionRoot.cs
@@ -72,6 +72,15 @@ public static class DesktopCompositionRoot
         services.AddTransient<DesktopSignInViewModel>();
         services.AddTransient<DesktopUploadSectionViewModel>();
         services.AddSingleton<ISecureSessionStorage, PlaceholderSecureSessionStorage>();
+        if (uploadSectionOptions.IsDevFakeUploadFileEnabled)
+        {
+            services.AddSingleton<IDesktopVideoFilePicker, FakeDesktopVideoFilePicker>();
+        }
+        else
+        {
+            services.AddSingleton<IDesktopVideoFilePicker, WpfDesktopVideoFilePicker>();
+        }
+
         services.AddSingleton<IDesktopFilePicker, PlaceholderDesktopFilePicker>();
         services.AddSingleton<ILocalFileMetadataService, PlaceholderLocalFileMetadataService>();
         services.AddSingleton<IControlPlaneApiClient, PlaceholderControlPlaneApiClient>();

--- a/src/App.Desktop/Services/Upload/DesktopUploadSectionViewModel.cs
+++ b/src/App.Desktop/Services/Upload/DesktopUploadSectionViewModel.cs
@@ -2,14 +2,16 @@ using App.Desktop.Boundaries;
 
 namespace App.Desktop.Services.Upload;
 
-public sealed class DesktopUploadSectionViewModel(DesktopUploadSectionOptions options)
+public sealed class DesktopUploadSectionViewModel(IDesktopVideoFilePicker videoFilePicker)
 {
-    private readonly DesktopUploadSectionOptions _options =
-        options ?? throw new ArgumentNullException(nameof(options));
+    private readonly IDesktopVideoFilePicker _videoFilePicker =
+        videoFilePicker ?? throw new ArgumentNullException(nameof(videoFilePicker));
 
     public DesktopWorkspaceSection CurrentSection { get; private set; } = DesktopWorkspaceSection.Workspace;
 
     public bool IsUploadSectionOpen => CurrentSection == DesktopWorkspaceSection.Upload;
+
+    public bool IsSelectingFile { get; private set; }
 
     public DesktopUploadSelectedFile? SelectedFile { get; private set; }
 
@@ -24,26 +26,51 @@ public sealed class DesktopUploadSectionViewModel(DesktopUploadSectionOptions op
     public void BackToWorkspace()
     {
         CurrentSection = DesktopWorkspaceSection.Workspace;
+        ResetSelection();
     }
 
     public void ResetForSignedOutState()
     {
         CurrentSection = DesktopWorkspaceSection.Workspace;
-        SelectedFile = null;
-        SelectionStatusMessage = DesktopUploadSectionText.PlaceholderResult;
+        ResetSelection();
     }
 
-    public DesktopUploadSelectedFile? SelectVideoFilePlaceholder()
+    public async ValueTask<DesktopUploadSelectedFile?> SelectVideoFileAsync(CancellationToken cancellationToken)
     {
-        SelectionStatusMessage = DesktopUploadSectionText.PlaceholderResult;
-
-        if (!_options.IsDevFakeUploadFileEnabled)
+        if (IsSelectingFile)
         {
-            SelectedFile = null;
             return SelectedFile;
         }
 
-        SelectedFile = DesktopUploadSelectedFile.VisualSmokeFile;
-        return SelectedFile;
+        IsSelectingFile = true;
+        SelectionStatusMessage = DesktopUploadSectionText.SelectingFileMessage;
+
+        try
+        {
+            DesktopVideoFilePickerResult result = await _videoFilePicker.PickVideoFileAsync(cancellationToken);
+
+            if (result.Status == DesktopVideoFilePickerStatus.Selected && result.SelectedFile is not null)
+            {
+                SelectedFile = result.SelectedFile;
+                SelectionStatusMessage = DesktopUploadSectionText.SelectedFilePreviewMessage;
+                return SelectedFile;
+            }
+
+            SelectedFile = null;
+            SelectionStatusMessage = result.Status == DesktopVideoFilePickerStatus.Unavailable
+                ? DesktopUploadSectionText.SelectionUnavailableMessage
+                : DesktopUploadSectionText.SelectionCanceledMessage;
+            return null;
+        }
+        finally
+        {
+            IsSelectingFile = false;
+        }
+    }
+
+    private void ResetSelection()
+    {
+        SelectedFile = null;
+        SelectionStatusMessage = DesktopUploadSectionText.PlaceholderResult;
     }
 }

--- a/src/App.Desktop/Services/Upload/FakeDesktopVideoFilePicker.cs
+++ b/src/App.Desktop/Services/Upload/FakeDesktopVideoFilePicker.cs
@@ -1,0 +1,16 @@
+using App.Desktop.Boundaries;
+
+namespace App.Desktop.Services.Upload;
+
+public sealed class FakeDesktopVideoFilePicker : IDesktopVideoFilePicker
+{
+    public ValueTask<DesktopVideoFilePickerResult> PickVideoFileAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return ValueTask.FromResult(DesktopVideoFilePickerResult.Selected(
+            DesktopUploadSelectedFile.VisualSmokeFileName,
+            DesktopUploadSelectedFile.VisualSmokeFileSizeBytes,
+            DesktopUploadSelectedFile.VisualSmokeContentType));
+    }
+}

--- a/src/App.Desktop/Services/Upload/WpfDesktopVideoFilePicker.cs
+++ b/src/App.Desktop/Services/Upload/WpfDesktopVideoFilePicker.cs
@@ -1,0 +1,77 @@
+using System.IO;
+
+using App.Desktop.Boundaries;
+
+using Microsoft.Win32;
+
+namespace App.Desktop.Services.Upload;
+
+public sealed class WpfDesktopVideoFilePicker : IDesktopVideoFilePicker
+{
+    private const string VideoFilter =
+        "Video files (*.mp4;*.mov;*.m4v;*.avi;*.mkv;*.webm)|*.mp4;*.mov;*.m4v;*.avi;*.mkv;*.webm|All files (*.*)|*.*";
+
+    public ValueTask<DesktopVideoFilePickerResult> PickVideoFileAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var dialog = new OpenFileDialog
+        {
+            Title = DesktopUploadSectionText.SelectVideoFileButton,
+            Filter = VideoFilter,
+            Multiselect = false,
+            CheckFileExists = true,
+            CheckPathExists = true,
+            AddExtension = false
+        };
+
+        bool? accepted = dialog.ShowDialog();
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (accepted != true || string.IsNullOrWhiteSpace(dialog.FileName))
+        {
+            return ValueTask.FromResult(DesktopVideoFilePickerResult.Canceled);
+        }
+
+        return ValueTask.FromResult(CreateSafeSelection(dialog.FileName));
+    }
+
+    private static DesktopVideoFilePickerResult CreateSafeSelection(string filePath)
+    {
+        try
+        {
+            var fileInfo = new FileInfo(filePath);
+            return DesktopVideoFilePickerResult.Selected(
+                fileInfo.Name,
+                fileInfo.Length,
+                ResolveContentType(fileInfo.Extension));
+        }
+        catch (Exception exception) when (IsSafeMetadataFailure(exception))
+        {
+            return DesktopVideoFilePickerResult.Unavailable;
+        }
+    }
+
+    private static string? ResolveContentType(string? extension)
+    {
+        return extension?.ToLowerInvariant() switch
+        {
+            ".mp4" => "video/mp4",
+            ".m4v" => "video/x-m4v",
+            ".mov" => "video/quicktime",
+            ".avi" => "video/x-msvideo",
+            ".mkv" => "video/x-matroska",
+            ".webm" => "video/webm",
+            _ => null
+        };
+    }
+
+    private static bool IsSafeMetadataFailure(Exception exception)
+    {
+        return exception is IOException
+            or UnauthorizedAccessException
+            or NotSupportedException
+            or ArgumentException;
+    }
+}

--- a/tests/Unit/App.Desktop.Tests/DesktopCompositionRootTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopCompositionRootTests.cs
@@ -21,6 +21,7 @@ public sealed class DesktopCompositionRootTests
         Assert.IsType<DesktopSignInService>(services.GetRequiredService<IDesktopSignInService>());
         Assert.IsType<DesktopUploadSectionViewModel>(services.GetRequiredService<DesktopUploadSectionViewModel>());
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
+        Assert.IsType<WpfDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
     }
 
     [Fact]
@@ -36,6 +37,7 @@ public sealed class DesktopCompositionRootTests
         Assert.False(services.GetRequiredService<DesktopAuthOptions>().IsDevFakeAuthEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
         Assert.IsType<UnavailableDesktopAuthClient>(services.GetRequiredService<IDesktopAuthClient>());
+        Assert.IsType<WpfDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
     }
 
     [Fact]
@@ -50,8 +52,10 @@ public sealed class DesktopCompositionRootTests
 
 #if DEBUG
         Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
+        Assert.IsType<FakeDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
 #else
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
+        Assert.IsType<WpfDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
 #endif
     }
 

--- a/tests/Unit/App.Desktop.Tests/DesktopSignInServiceTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopSignInServiceTests.cs
@@ -258,7 +258,7 @@ public sealed class DesktopSignInServiceTests
         Assert.Contains("DesktopUploadSectionText.Title", markup, StringComparison.Ordinal);
         Assert.Contains("DesktopUploadSectionText.SelectVideoFileButton", markup, StringComparison.Ordinal);
         Assert.Contains("DesktopUploadSectionText.BackToWorkspaceButton", markup, StringComparison.Ordinal);
-        Assert.Contains("UploadSectionViewModel.SelectVideoFilePlaceholder()", markup, StringComparison.Ordinal);
+        Assert.Contains("UploadSectionViewModel.SelectVideoFileAsync(CancellationToken.None)", markup, StringComparison.Ordinal);
         Assert.DoesNotContain("<UploadPlaceholder", markup, StringComparison.Ordinal);
         Assert.DoesNotContain("IDesktopUploadOrchestrator", markup, StringComparison.Ordinal);
         Assert.DoesNotContain("IControlPlaneApiClient", markup, StringComparison.Ordinal);

--- a/tests/Unit/App.Desktop.Tests/DesktopUploadSectionTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopUploadSectionTests.cs
@@ -19,7 +19,7 @@ public sealed class DesktopUploadSectionTests
     [Fact]
     public void UploadCardNavigationOpensUploadSection()
     {
-        var viewModel = new DesktopUploadSectionViewModel(DesktopUploadSectionOptions.Disabled);
+        var viewModel = new DesktopUploadSectionViewModel(new CancelingDesktopVideoFilePicker());
 
         Assert.Equal(DesktopWorkspaceSection.Workspace, viewModel.CurrentSection);
         Assert.False(viewModel.IsUploadSectionOpen);
@@ -35,25 +35,35 @@ public sealed class DesktopUploadSectionTests
     {
         Assert.Equal("Загрузка видео", DesktopUploadSectionText.Title);
         Assert.Equal(
-            "Этот раздел подготовлен. Реальная загрузка будет включена в следующем approved desktop slice.",
+            "Этот раздел показывает безопасные сведения о выбранном видеофайле. Реальная загрузка будет включена в следующем approved desktop slice.",
             DesktopUploadSectionText.Description);
         Assert.Equal("Шаг 1. Выбор видеофайла", DesktopUploadSectionText.StepOneTitle);
         Assert.Equal("Выбрать видеофайл", DesktopUploadSectionText.SelectVideoFileButton);
         Assert.Equal(
-            "Выбор файла пока работает в режиме заготовки.",
+            "Выберите видеофайл для безопасного предпросмотра.",
             DesktopUploadSectionText.PlaceholderResult);
+        Assert.Equal("Открывается выбор видеофайла.", DesktopUploadSectionText.SelectingFileMessage);
+        Assert.Equal("Выбор файла отменён.", DesktopUploadSectionText.SelectionCanceledMessage);
+        Assert.Equal(
+            "Файл выбран. Показаны только безопасные сведения.",
+            DesktopUploadSectionText.SelectedFilePreviewMessage);
+        Assert.Equal(
+            "Не удалось получить безопасные сведения о файле.",
+            DesktopUploadSectionText.SelectionUnavailableMessage);
         Assert.Equal("Назад к рабочей области", DesktopUploadSectionText.BackToWorkspaceButton);
     }
 
     [Fact]
-    public void UploadSectionDoesNotReferenceApiFilePickerHashingOrUploadFlowBoundaries()
+    public void UploadSectionDoesNotReferenceApiHashingOrUploadFlowBoundaries()
     {
         string[] sourceFiles =
         [
             Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Components", "DesktopShell.razor"),
             Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "DesktopUploadSectionViewModel.cs"),
             Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "DesktopUploadSectionOptions.cs"),
-            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Boundaries", "DesktopSignInBoundary.cs")
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "FakeDesktopVideoFilePicker.cs"),
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "WpfDesktopVideoFilePicker.cs"),
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Boundaries", "DesktopVideoFilePickerBoundary.cs")
         ];
 
         foreach (string sourceFile in sourceFiles)
@@ -63,14 +73,15 @@ public sealed class DesktopUploadSectionTests
             Assert.DoesNotContain("App.Api", source, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("IControlPlaneApiClient", source, StringComparison.Ordinal);
             Assert.DoesNotContain("IDesktopUploadOrchestrator", source, StringComparison.Ordinal);
-            Assert.DoesNotContain("IDesktopFilePicker", source, StringComparison.Ordinal);
             Assert.DoesNotContain("ReadSha256", source, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("SHA-256", source, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("sha256", source, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("businessObjectKey", source, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("PreUploadCheck", source, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("DirectSiteUpload", source, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("UploadReceipt", source, StringComparison.OrdinalIgnoreCase);
-            Assert.DoesNotContain("FilePath", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("ReadAllBytes", source, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("OpenRead", source, StringComparison.OrdinalIgnoreCase);
         }
     }
 
@@ -89,30 +100,31 @@ public sealed class DesktopUploadSectionTests
     }
 
     [Fact]
-    public void FakeUploadFileSelectionDoesNothingWhenDisabled()
+    public async Task CancelSelectionShowsSafeRussianMessage()
     {
-        var viewModel = new DesktopUploadSectionViewModel(DesktopUploadSectionOptions.Disabled);
+        var viewModel = new DesktopUploadSectionViewModel(new CancelingDesktopVideoFilePicker());
 
-        DesktopUploadSelectedFile? selectedFile = viewModel.SelectVideoFilePlaceholder();
+        DesktopUploadSelectedFile? selectedFile = await viewModel.SelectVideoFileAsync(CancellationToken.None);
 
         Assert.Null(selectedFile);
         Assert.Null(viewModel.SelectedFile);
-        Assert.Equal(DesktopUploadSectionText.PlaceholderResult, viewModel.SelectionStatusMessage);
+        Assert.Equal(DesktopUploadSectionText.SelectionCanceledMessage, viewModel.SelectionStatusMessage);
+        Assert.False(viewModel.IsSelectingFile);
     }
 
     [Fact]
-    public void FakeSelectedFileStateIsSafeAndContainsNoRealPathOrSecret()
+    public async Task FakeSelectedFileStateIsSafeAndContainsNoRealPathOrSecret()
     {
-        var viewModel = new DesktopUploadSectionViewModel(
-            DesktopUploadSectionOptions.EnabledForDevFakeFileSelection);
+        var viewModel = new DesktopUploadSectionViewModel(new FakeDesktopVideoFilePicker());
 
-        DesktopUploadSelectedFile? selectedFile = viewModel.SelectVideoFilePlaceholder();
+        DesktopUploadSelectedFile? selectedFile = await viewModel.SelectVideoFileAsync(CancellationToken.None);
 
         Assert.NotNull(selectedFile);
         Assert.Equal("visual-smoke-video.mp4", selectedFile.FileName);
         Assert.Equal(12345678, selectedFile.SizeBytes);
         Assert.Equal("video/mp4", selectedFile.ContentType);
-        Assert.Equal(DesktopUploadSectionText.PlaceholderResult, viewModel.SelectionStatusMessage);
+        Assert.Equal(DesktopUploadSectionText.SelectedFilePreviewMessage, viewModel.SelectionStatusMessage);
+        Assert.False(viewModel.IsSelectingFile);
 
         string visibleState = selectedFile.ToString() + " " + viewModel.SelectionStatusMessage;
         Assert.DoesNotContain(@"\", visibleState, StringComparison.Ordinal);
@@ -126,15 +138,65 @@ public sealed class DesktopUploadSectionTests
     }
 
     [Fact]
-    public void SignOutResetReturnsUploadStateToWorkspace()
+    public async Task SelectedFilePreviewHidesPathSegments()
     {
-        var viewModel = new DesktopUploadSectionViewModel(
-            DesktopUploadSectionOptions.EnabledForDevFakeFileSelection);
+        string nestedFileName = Path.Combine("operator-private", "nested", "safe-preview.mp4");
+        var viewModel = new DesktopUploadSectionViewModel(new StaticDesktopVideoFilePicker(
+            DesktopVideoFilePickerResult.Selected(nestedFileName, 42, "video/mp4")));
+
+        DesktopUploadSelectedFile? selectedFile = await viewModel.SelectVideoFileAsync(CancellationToken.None);
+
+        Assert.NotNull(selectedFile);
+        Assert.Equal("safe-preview.mp4", selectedFile.FileName);
+        Assert.Equal(42, selectedFile.SizeBytes);
+        Assert.Equal("video/mp4", selectedFile.ContentType);
+
+        string visibleState = selectedFile.ToString() + " " + viewModel.SelectionStatusMessage;
+        Assert.DoesNotContain("operator-private", visibleState, StringComparison.Ordinal);
+        Assert.DoesNotContain("nested", visibleState, StringComparison.Ordinal);
+        Assert.DoesNotContain(@"\", selectedFile.FileName, StringComparison.Ordinal);
+        Assert.DoesNotContain("/", selectedFile.FileName, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task UnsafeContentTypeFallsBackToUnknownSafeText()
+    {
+        var viewModel = new DesktopUploadSectionViewModel(new StaticDesktopVideoFilePicker(
+            DesktopVideoFilePickerResult.Selected("safe-preview.mp4", 42, "Authorization/token")));
+
+        DesktopUploadSelectedFile? selectedFile = await viewModel.SelectVideoFileAsync(CancellationToken.None);
+
+        Assert.NotNull(selectedFile);
+        Assert.Equal(DesktopUploadSectionText.UnknownContentTypeValue, selectedFile.ContentType);
+        Assert.DoesNotContain("Authorization", selectedFile.ToString(), StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("token", selectedFile.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task SignOutResetReturnsUploadStateToWorkspace()
+    {
+        var viewModel = new DesktopUploadSectionViewModel(new FakeDesktopVideoFilePicker());
 
         viewModel.OpenUploadSection();
-        _ = viewModel.SelectVideoFilePlaceholder();
+        _ = await viewModel.SelectVideoFileAsync(CancellationToken.None);
 
         viewModel.ResetForSignedOutState();
+
+        Assert.Equal(DesktopWorkspaceSection.Workspace, viewModel.CurrentSection);
+        Assert.False(viewModel.IsUploadSectionOpen);
+        Assert.Null(viewModel.SelectedFile);
+        Assert.Equal(DesktopUploadSectionText.PlaceholderResult, viewModel.SelectionStatusMessage);
+    }
+
+    [Fact]
+    public async Task BackToWorkspaceResetsSelectedFileState()
+    {
+        var viewModel = new DesktopUploadSectionViewModel(new FakeDesktopVideoFilePicker());
+
+        viewModel.OpenUploadSection();
+        _ = await viewModel.SelectVideoFileAsync(CancellationToken.None);
+
+        viewModel.BackToWorkspace();
 
         Assert.Equal(DesktopWorkspaceSection.Workspace, viewModel.CurrentSection);
         Assert.False(viewModel.IsUploadSectionOpen);
@@ -153,10 +215,15 @@ public sealed class DesktopUploadSectionTests
             DesktopUploadSectionText.StepOneTitle,
             DesktopUploadSectionText.SelectVideoFileButton,
             DesktopUploadSectionText.PlaceholderResult,
+            DesktopUploadSectionText.SelectingFileMessage,
+            DesktopUploadSectionText.SelectionCanceledMessage,
+            DesktopUploadSectionText.SelectedFilePreviewMessage,
+            DesktopUploadSectionText.SelectionUnavailableMessage,
             DesktopUploadSectionText.BackToWorkspaceButton,
             DesktopUploadSectionText.SelectedFileNameLabel,
             DesktopUploadSectionText.SelectedFileSizeLabel,
             DesktopUploadSectionText.SelectedFileContentTypeLabel,
+            DesktopUploadSectionText.UnknownContentTypeValue,
             DesktopUploadSelectedFile.VisualSmokeFileName,
             DesktopUploadSelectedFile.VisualSmokeContentType
         ];
@@ -169,6 +236,24 @@ public sealed class DesktopUploadSectionTests
             Assert.DoesNotContain("refreshToken", visibleString, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("session_id", visibleString, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("raw response", visibleString, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    private sealed class CancelingDesktopVideoFilePicker : IDesktopVideoFilePicker
+    {
+        public ValueTask<DesktopVideoFilePickerResult> PickVideoFileAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return ValueTask.FromResult(DesktopVideoFilePickerResult.Canceled);
+        }
+    }
+
+    private sealed class StaticDesktopVideoFilePicker(DesktopVideoFilePickerResult result) : IDesktopVideoFilePicker
+    {
+        public ValueTask<DesktopVideoFilePickerResult> PickVideoFileAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return ValueTask.FromResult(result);
         }
     }
 


### PR DESCRIPTION
## Coder
Coder 1 acting as Coder 2 / Desktop Client

## Task ID S2-61
Desktop Upload Real File Picker Boundary / Safe Metadata Preview

## Module
App.Desktop / upload file picker boundary

## Scope
- Added an App.Desktop-local `IDesktopVideoFilePicker` boundary.
- Added native WPF picker implementation behind the boundary.
- Added debug/dev-test fake picker selected only by `AA_DESKTOP_DEV_FAKE_UPLOAD_FILE_ENABLED=true`.
- Updated upload section to preview safe metadata only: file name, size bytes, and safe content type.
- Added cancel/reset safe Russian UI messages and reset behavior for back/sign-out.

## Changed areas
- `docs/task-cards/S2-61_desktop-upload-file-picker-boundary-task-card.txt`
- `src/App.Desktop/**`
- `tests/Unit/App.Desktop.Tests/**`

## Base main SHA
`8e28328d3f05dc8a604024b673769d0e384fe0ac`

## Coordination log entries reviewed
- TEAM COORDINATION LOG issue #89 metadata/comments reviewed.
- Reviewed merge records for #127 S2-58, #128 S2-59, #129 S2-60.

## Handoff/task cards reviewed
- `docs/task-cards/S2-58_desktop-visual-smoke-fake-auth-task-card.txt`
- `docs/task-cards/S2-59_desktop-signed-in-shell-navigation-task-card.txt`
- `docs/task-cards/S2-60_desktop-upload-section-file-selection-placeholder-task-card.txt`

## Contracts
None.

## Migrations
None.

## Feature flags/env guard
- Existing S2-58 fake auth: `AA_DESKTOP_DEV_FAKE_AUTH_ENABLED=true` for visual smoke.
- S2-61 fake picker: `AA_DESKTOP_DEV_FAKE_UPLOAD_FILE_ENABLED=true` for visual smoke only.
- Fake picker is disabled by default.

## API impact
None. Upload section does not call App.Api.

## Web impact
None.

## Android impact
None.

## Offline behavior
None.

## Rollback
Revert this S2-61 PR.

## Validation
- `git diff --check` passed.
- `dotnet restore AnalyticsAutomation-Core.sln -nologo` passed.
- `dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore` passed.
- `dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal` passed with 0 warnings / 0 errors.
- `dotnet build AnalyticsAutomation-Core.sln -nologo -v minimal` passed with 0 warnings / 0 errors.
- `dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal` passed: 90/90.
- Hidden/control Unicode scan over changed text files passed.
- App.Desktop fake-auth/fake-picker visual smoke passed.

## Visual smoke screenshot folder/files
Folder: `C:\CODEX\Temp\S2-61_DESKTOP_FILE_PICKER_VISUAL_SMOKE_20260430_133430\`

Files:
- `01_baseline_signin.png`
- `02_signed_in_shell.png`
- `03_upload_section_before_file_selection.png`
- `04_after_fake_file_selection.png`
- `05_after_cancel_or_reset.png`
- `06_after_sign_out.png`

## Handoff docs/task card
- `docs/task-cards/S2-61_desktop-upload-file-picker-boundary-task-card.txt`

## Next step
Review the narrow desktop picker boundary and visual smoke evidence. Do not merge until approved.

## NO-GO / Deferred
- No file content read.
- No SHA-256.
- No businessObjectKey.
- No PreUploadCheck.
- No direct site upload.
- No UploadReceipt.
- No offline queue.
- No GroupTree runtime.
- No App.Api/contracts/migrations/deploy/App.Web/App.Mobile.Android changes.