### PR TITLE
[codex] S2-62 Desktop Upload SHA-256 Boundary

### DIFF
--- a/docs/task-cards/S2-62_desktop-upload-sha256-boundary-task-card.txt
+++ b/docs/task-cards/S2-62_desktop-upload-sha256-boundary-task-card.txt
@@ -1,0 +1,141 @@
+Title:
+S2-62 Desktop Upload Local SHA-256 Boundary / Hash Preview Placeholder
+
+Module:
+App.Desktop / upload SHA-256 boundary
+
+Owner:
+Coder 1 acting as Coder 2 / Desktop Client
+
+Client form:
+desktop standalone
+
+Type:
+narrow runtime desktop UI slice after S2-61 upload file picker boundary
+
+Status:
+Runtime task card created with implementation.
+
+Goal:
+Add an App.Desktop-local SHA-256 boundary for the selected video file, plus a safe upload-section hash preview state. The file is read only after an explicit operator action and only inside the desktop-local hash boundary.
+
+Context:
+S2-58 added debug-only fake auth visual smoke guarded by AA_DESKTOP_DEV_FAKE_AUTH_ENABLED=true.
+S2-59 added the Russian signed-in shell.
+S2-60 added the active "Загрузка видео" section placeholder.
+S2-61 added the App.Desktop-local video file picker boundary and safe metadata preview without reading file contents or computing SHA-256.
+
+Scope:
+- Keep the existing Russian SignIn UI before authentication.
+- After fake-auth SignIn, show the signed-in shell.
+- Open the upload section from "Загрузка видео".
+- Keep S2-61 safe metadata preview: file name, size, and content type only.
+- Add "Рассчитать SHA-256" after a file is selected.
+- Compute SHA-256 only through the App.Desktop-local hash boundary.
+- Show busy/status text and the resulting lowercase 64-character SHA-256 hex.
+- Keep local paths out of visible UI strings and safe error states.
+- Clear file/hash state on back and sign-out.
+
+Allowed changed areas:
+- docs/task-cards/S2-62_desktop-upload-sha256-boundary-task-card.txt
+- src/App.Desktop/**
+- tests/Unit/App.Desktop.Tests/**
+
+Forbidden changed areas:
+- src/App.Api/**
+- src/App.Worker/**
+- src/App.Web/**
+- src/App.Mobile.Android/**
+- src/App.UI.Shared/**
+- src/BuildingBlocks.Contracts/**
+- src/Modules/**
+- DB migrations
+- .github/workflows/**
+- deploy scripts
+- docs/ops/**
+- committed screenshots or runtime artifacts
+
+Contracts:
+none
+
+Migrations:
+none
+
+Feature flags/env guard:
+- Existing fake auth visual-smoke guard:
+  AA_DESKTOP_DEV_FAKE_AUTH_ENABLED=true
+- Existing fake picker visual-smoke guard:
+  AA_DESKTOP_DEV_FAKE_UPLOAD_FILE_ENABLED=true
+- Optional fake hash visual-smoke guard:
+  AA_DESKTOP_DEV_FAKE_UPLOAD_HASH_ENABLED=true
+- Fake hash is debug/dev-test only, disabled by default, and returns only:
+  0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+
+Events:
+none
+
+Offline behavior:
+none
+
+Security guardrails:
+- Do not show the full local path.
+- Do not display or log password, accessToken, refreshToken, Authorization, raw session id, raw response body, or token-like values.
+- Do not introduce PreUploadCheck, businessObjectKey, direct site upload, UploadReceipt, offline queue, GroupTree runtime, or App.Api calls from the upload section.
+- Do not persist selected files, local paths, hashes, upload drafts, tokens, or passwords.
+- Screenshots and runtime artifacts stay under C:\CODEX\Temp and are not committed.
+
+Explicitly out of scope:
+- PreUploadCheck.
+- businessObjectKey.
+- Direct site upload.
+- UploadReceipt.
+- Offline queue.
+- GroupTree runtime.
+- App.Api changes or App.Api calls.
+- Shared contract changes.
+- DB migrations.
+- Deploy/workflow changes.
+- App.Web changes.
+- App.Mobile.Android changes.
+- App.UI.Shared changes.
+
+Rollback:
+revert S2-62 PR
+
+Validation:
+- git diff --check
+- dotnet restore AnalyticsAutomation-Core.sln -nologo
+- dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore
+- dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal
+- dotnet build AnalyticsAutomation-Core.sln -nologo -v minimal
+- dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal
+- hidden/control Unicode scan over changed text files
+- App.Desktop fake-auth/fake-picker/fake-hash visual smoke with screenshots
+
+Definition of done:
+- App.Desktop has an IDesktopVideoHashService boundary.
+- The default implementation computes SHA-256 from the selected local file only when the operator invokes the hash action.
+- Hashing is cancellable through CancellationToken and exposes safe busy/status state in the upload section.
+- The fake/dev hash implementation is disabled by default and enabled only by AA_DESKTOP_DEV_FAKE_UPLOAD_HASH_ENABLED=true in debug/dev-test flow.
+- Fake hash does not read disk and returns the expected lowercase 64-character hex value.
+- Hash button/action is unavailable until a file is selected.
+- Successful hash result is visible after file selection and hash action.
+- Back/sign-out clear selection and hash state.
+- Safe errors do not expose the full local path.
+- Automated App.Desktop tests cover the env guard, fake hash, hash action availability, success state, reset behavior, forbidden upload-chain calls, and visible-string safety.
+- Required visual-smoke screenshots are saved under C:\CODEX\Temp and kept out of git.
+
+Visual-smoke definition of done:
+- Run App.Desktop with AA_DESKTOP_DEV_FAKE_AUTH_ENABLED=true, AA_DESKTOP_DEV_FAKE_UPLOAD_FILE_ENABLED=true, and AA_DESKTOP_DEV_FAKE_UPLOAD_HASH_ENABLED=true.
+- Do not set AA_DESKTOP_CONTROL_PLANE_BASE_ADDRESS.
+- Use non-secret test data visual-smoke-user / visual-smoke-password.
+- Capture screenshots under C:\CODEX\Temp\S2-62_DESKTOP_SHA256_BOUNDARY_VISUAL_SMOKE_<timestamp>\.
+- Required screenshots:
+  - 01_baseline_signin.png
+  - 02_signed_in_shell.png
+  - 03_upload_section_after_fake_file_selection.png
+  - 04_hash_in_progress_or_ready_state.png
+  - 05_after_fake_sha256_result.png
+  - 06_after_sign_out.png
+- Confirm no password, accessToken, refreshToken, Authorization, raw session id, raw response body, raw path, or real secret is visible.
+- Confirm screenshots and runtime artifacts are not committed.

--- a/src/App.Desktop/Boundaries/DesktopSignInBoundary.cs
+++ b/src/App.Desktop/Boundaries/DesktopSignInBoundary.cs
@@ -149,6 +149,16 @@ public static class DesktopUploadSectionText
     public const string SelectedFileSizeLabel = "Размер";
     public const string SelectedFileContentTypeLabel = "Тип содержимого";
     public const string UnknownContentTypeValue = "Не определён";
+    public const string StepTwoTitle = "Шаг 2. SHA-256";
+    public const string CalculateSha256Button = "Рассчитать SHA-256";
+    public const string CalculateSha256BusyButton = "Рассчитывается...";
+    public const string HashNotReadyMessage = "Выберите видеофайл, чтобы рассчитать SHA-256.";
+    public const string HashReadyMessage = "Файл выбран. Можно рассчитать SHA-256 локально на этом компьютере.";
+    public const string HashInProgressMessage = "Рассчитывается SHA-256. Файл читается только в локальной desktop-границе.";
+    public const string HashSucceededMessage = "SHA-256 рассчитан локально.";
+    public const string HashUnavailableMessage = "Не удалось рассчитать SHA-256 для выбранного файла.";
+    public const string HashCanceledMessage = "Расчёт SHA-256 отменён.";
+    public const string Sha256ResultLabel = "SHA-256";
 }
 
 public sealed record DesktopUploadSelectedFile(

--- a/src/App.Desktop/Boundaries/DesktopVideoFilePickerBoundary.cs
+++ b/src/App.Desktop/Boundaries/DesktopVideoFilePickerBoundary.cs
@@ -9,35 +9,43 @@ public sealed class DesktopVideoFilePickerResult
 {
     private DesktopVideoFilePickerResult(
         DesktopVideoFilePickerStatus status,
-        DesktopUploadSelectedFile? selectedFile)
+        DesktopUploadSelectedFile? selectedFile,
+        DesktopVideoHashSource? hashSource)
     {
         Status = status;
         SelectedFile = selectedFile;
+        HashSource = hashSource;
     }
 
     public DesktopVideoFilePickerStatus Status { get; }
 
     public DesktopUploadSelectedFile? SelectedFile { get; }
 
+    internal DesktopVideoHashSource? HashSource { get; }
+
     public static DesktopVideoFilePickerResult Canceled { get; } = new(
         DesktopVideoFilePickerStatus.Canceled,
-        selectedFile: null);
+        selectedFile: null,
+        hashSource: null);
 
     public static DesktopVideoFilePickerResult Unavailable { get; } = new(
         DesktopVideoFilePickerStatus.Unavailable,
-        selectedFile: null);
+        selectedFile: null,
+        hashSource: null);
 
     public static DesktopVideoFilePickerResult Selected(
         string fileNameOrPath,
         long sizeBytes,
-        string? contentType)
+        string? contentType,
+        DesktopVideoHashSource? hashSource = null)
     {
         return new DesktopVideoFilePickerResult(
             DesktopVideoFilePickerStatus.Selected,
             DesktopUploadSelectedFile.FromSafeMetadata(
                 fileNameOrPath,
                 sizeBytes,
-                contentType));
+                contentType),
+            hashSource);
     }
 }
 

--- a/src/App.Desktop/Boundaries/DesktopVideoHashBoundary.cs
+++ b/src/App.Desktop/Boundaries/DesktopVideoHashBoundary.cs
@@ -1,0 +1,163 @@
+namespace App.Desktop.Boundaries;
+
+public interface IDesktopVideoHashService
+{
+    ValueTask<DesktopVideoHashResult> CalculateSha256Async(
+        DesktopVideoHashRequest request,
+        CancellationToken cancellationToken);
+}
+
+public sealed class DesktopVideoHashRequest
+{
+    private DesktopVideoHashRequest(DesktopVideoHashSource source)
+    {
+        Source = source;
+    }
+
+    internal DesktopVideoHashSource Source { get; }
+
+    internal static DesktopVideoHashRequest FromSource(DesktopVideoHashSource source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+
+        return new DesktopVideoHashRequest(source);
+    }
+
+    internal bool TryGetLocalFilePath(out string filePath)
+    {
+        return Source.TryGetLocalFilePath(out filePath);
+    }
+
+    public override string ToString()
+    {
+        return $"{nameof(DesktopVideoHashRequest)} {{ Source = {Source.Kind} }}";
+    }
+}
+
+public sealed class DesktopVideoHashSource
+{
+    private DesktopVideoHashSource(DesktopVideoHashSourceKind kind, string? localFilePath)
+    {
+        Kind = kind;
+        LocalFilePath = localFilePath;
+    }
+
+    internal DesktopVideoHashSourceKind Kind { get; }
+
+    private string? LocalFilePath { get; }
+
+    internal static DesktopVideoHashSource VisualSmoke { get; } = new(
+        DesktopVideoHashSourceKind.VisualSmoke,
+        localFilePath: null);
+
+    internal static DesktopVideoHashSource FromLocalFilePath(string localFilePath)
+    {
+        if (string.IsNullOrWhiteSpace(localFilePath))
+        {
+            return new DesktopVideoHashSource(
+                DesktopVideoHashSourceKind.Unavailable,
+                localFilePath: null);
+        }
+
+        return new DesktopVideoHashSource(
+            DesktopVideoHashSourceKind.LocalFile,
+            localFilePath);
+    }
+
+    internal bool TryGetLocalFilePath(out string filePath)
+    {
+        filePath = string.Empty;
+
+        if (Kind != DesktopVideoHashSourceKind.LocalFile || string.IsNullOrWhiteSpace(LocalFilePath))
+        {
+            return false;
+        }
+
+        filePath = LocalFilePath;
+        return true;
+    }
+
+    public override string ToString()
+    {
+        return $"{nameof(DesktopVideoHashSource)} {{ Kind = {Kind} }}";
+    }
+}
+
+internal enum DesktopVideoHashSourceKind
+{
+    Unavailable,
+    LocalFile,
+    VisualSmoke
+}
+
+public sealed class DesktopVideoHashResult
+{
+    private DesktopVideoHashResult(
+        DesktopVideoHashStatus status,
+        string? sha256Hex)
+    {
+        Status = status;
+        Sha256Hex = sha256Hex;
+    }
+
+    public DesktopVideoHashStatus Status { get; }
+
+    public string? Sha256Hex { get; }
+
+    public static DesktopVideoHashResult Canceled { get; } = new(
+        DesktopVideoHashStatus.Canceled,
+        sha256Hex: null);
+
+    public static DesktopVideoHashResult Unavailable { get; } = new(
+        DesktopVideoHashStatus.Unavailable,
+        sha256Hex: null);
+
+    public static DesktopVideoHashResult Failed { get; } = new(
+        DesktopVideoHashStatus.Failed,
+        sha256Hex: null);
+
+    public static DesktopVideoHashResult Succeeded(string sha256Hex)
+    {
+        if (!IsLowercaseSha256Hex(sha256Hex))
+        {
+            throw new ArgumentException("SHA-256 must be a 64-character lowercase hex value.", nameof(sha256Hex));
+        }
+
+        return new DesktopVideoHashResult(
+            DesktopVideoHashStatus.Succeeded,
+            sha256Hex);
+    }
+
+    public override string ToString()
+    {
+        return $"{nameof(DesktopVideoHashResult)} {{ Status = {Status}, HasSha256 = {Sha256Hex is not null} }}";
+    }
+
+    private static bool IsLowercaseSha256Hex(string? value)
+    {
+        if (value is null || value.Length != 64)
+        {
+            return false;
+        }
+
+        foreach (char character in value)
+        {
+            bool isDigit = character is >= '0' and <= '9';
+            bool isLowerHex = character is >= 'a' and <= 'f';
+            if (!isDigit && !isLowerHex)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}
+
+public enum DesktopVideoHashStatus
+{
+    Succeeded,
+    Canceled,
+    Unavailable,
+    Failed
+}

--- a/src/App.Desktop/Components/DesktopShell.razor
+++ b/src/App.Desktop/Components/DesktopShell.razor
@@ -84,6 +84,33 @@
                                 </dl>
                             }
                         </div>
+
+                        <div class="desktop-upload__step">
+                            <h3>@DesktopUploadSectionText.StepTwoTitle</h3>
+                            <p class="desktop-upload__message" role="status" aria-live="polite">
+                                @UploadSectionViewModel.HashStatusMessage
+                            </p>
+
+                            <button
+                                class="desktop-upload__hash"
+                                type="button"
+                                disabled="@(!UploadSectionViewModel.CanCalculateHash)"
+                                @onclick="CalculateSha256Async">
+                                @(UploadSectionViewModel.IsHashing
+                                    ? DesktopUploadSectionText.CalculateSha256BusyButton
+                                    : DesktopUploadSectionText.CalculateSha256Button)
+                            </button>
+
+                            @if (UploadSectionViewModel.HasSha256Hash)
+                            {
+                                <dl class="desktop-upload__hash-result">
+                                    <div>
+                                        <dt>@DesktopUploadSectionText.Sha256ResultLabel</dt>
+                                        <dd>@UploadSectionViewModel.Sha256Hex</dd>
+                                    </div>
+                                </dl>
+                            }
+                        </div>
                     </section>
                 }
                 else
@@ -219,6 +246,17 @@
     private async Task SelectVideoFileAsync()
     {
         await UploadSectionViewModel.SelectVideoFileAsync(CancellationToken.None);
+    }
+
+    private async Task CalculateSha256Async()
+    {
+        ValueTask<DesktopVideoHashResult?> hashAttempt =
+            UploadSectionViewModel.CalculateSha256Async(CancellationToken.None);
+        StateHasChanged();
+
+        await hashAttempt;
+
+        StateHasChanged();
     }
 
     private string GetHeaderStatusText()

--- a/src/App.Desktop/Composition/DesktopCompositionRoot.cs
+++ b/src/App.Desktop/Composition/DesktopCompositionRoot.cs
@@ -81,6 +81,15 @@ public static class DesktopCompositionRoot
             services.AddSingleton<IDesktopVideoFilePicker, WpfDesktopVideoFilePicker>();
         }
 
+        if (uploadSectionOptions.IsDevFakeUploadHashEnabled)
+        {
+            services.AddSingleton<IDesktopVideoHashService, FakeDesktopVideoHashService>();
+        }
+        else
+        {
+            services.AddSingleton<IDesktopVideoHashService, DesktopVideoHashService>();
+        }
+
         services.AddSingleton<IDesktopFilePicker, PlaceholderDesktopFilePicker>();
         services.AddSingleton<ILocalFileMetadataService, PlaceholderLocalFileMetadataService>();
         services.AddSingleton<IControlPlaneApiClient, PlaceholderControlPlaneApiClient>();

--- a/src/App.Desktop/Properties/AssemblyInfo.cs
+++ b/src/App.Desktop/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("App.Desktop.Tests")]

--- a/src/App.Desktop/Services/Upload/DesktopUploadSectionOptions.cs
+++ b/src/App.Desktop/Services/Upload/DesktopUploadSectionOptions.cs
@@ -5,35 +5,76 @@ public sealed class DesktopUploadSectionOptions
     public const string DevFakeUploadFileEnabledEnvironmentVariable =
         "AA_DESKTOP_DEV_FAKE_UPLOAD_FILE_ENABLED";
 
-    private DesktopUploadSectionOptions(bool isDevFakeUploadFileEnabled)
+    public const string DevFakeUploadHashEnabledEnvironmentVariable =
+        "AA_DESKTOP_DEV_FAKE_UPLOAD_HASH_ENABLED";
+
+    private DesktopUploadSectionOptions(
+        bool isDevFakeUploadFileEnabled,
+        bool isDevFakeUploadHashEnabled)
     {
         IsDevFakeUploadFileEnabled = isDevFakeUploadFileEnabled;
+        IsDevFakeUploadHashEnabled = isDevFakeUploadHashEnabled;
     }
 
     public static DesktopUploadSectionOptions Disabled { get; } = new(
-        isDevFakeUploadFileEnabled: false);
+        isDevFakeUploadFileEnabled: false,
+        isDevFakeUploadHashEnabled: false);
 
 #if DEBUG
     public static DesktopUploadSectionOptions EnabledForDevFakeFileSelection { get; } = new(
-        isDevFakeUploadFileEnabled: true);
+        isDevFakeUploadFileEnabled: true,
+        isDevFakeUploadHashEnabled: false);
+
+    public static DesktopUploadSectionOptions EnabledForDevFakeFileSelectionAndHash { get; } = new(
+        isDevFakeUploadFileEnabled: true,
+        isDevFakeUploadHashEnabled: true);
 #else
     public static DesktopUploadSectionOptions EnabledForDevFakeFileSelection => Disabled;
+
+    public static DesktopUploadSectionOptions EnabledForDevFakeFileSelectionAndHash => Disabled;
 #endif
 
     public bool IsDevFakeUploadFileEnabled { get; }
 
+    public bool IsDevFakeUploadHashEnabled { get; }
+
     public static DesktopUploadSectionOptions FromEnvironment()
     {
         return FromEnvironmentValue(
-            Environment.GetEnvironmentVariable(DevFakeUploadFileEnabledEnvironmentVariable));
+            Environment.GetEnvironmentVariable(DevFakeUploadFileEnabledEnvironmentVariable),
+            Environment.GetEnvironmentVariable(DevFakeUploadHashEnabledEnvironmentVariable));
     }
 
     public static DesktopUploadSectionOptions FromEnvironmentValue(string? devFakeUploadFileEnabled)
     {
+        return FromEnvironmentValue(
+            devFakeUploadFileEnabled,
+            devFakeUploadHashEnabled: null);
+    }
+
+    public static DesktopUploadSectionOptions FromEnvironmentValue(
+        string? devFakeUploadFileEnabled,
+        string? devFakeUploadHashEnabled)
+    {
 #if DEBUG
-        if (IsDevFakeUploadFileEnabledValue(devFakeUploadFileEnabled))
+        bool isFakeFileEnabled = IsDevFakeUploadFileEnabledValue(devFakeUploadFileEnabled);
+        bool isFakeHashEnabled = IsDevFakeUploadHashEnabledValue(devFakeUploadHashEnabled);
+
+        if (isFakeFileEnabled && isFakeHashEnabled)
+        {
+            return EnabledForDevFakeFileSelectionAndHash;
+        }
+
+        if (isFakeFileEnabled)
         {
             return EnabledForDevFakeFileSelection;
+        }
+
+        if (isFakeHashEnabled)
+        {
+            return new DesktopUploadSectionOptions(
+                isDevFakeUploadFileEnabled: false,
+                isDevFakeUploadHashEnabled: true);
         }
 #endif
 
@@ -42,10 +83,16 @@ public sealed class DesktopUploadSectionOptions
 
     public override string ToString()
     {
-        return $"{nameof(DesktopUploadSectionOptions)} {{ IsDevFakeUploadFileEnabled = {IsDevFakeUploadFileEnabled} }}";
+        return $"{nameof(DesktopUploadSectionOptions)} {{ IsDevFakeUploadFileEnabled = {IsDevFakeUploadFileEnabled}, "
+            + $"IsDevFakeUploadHashEnabled = {IsDevFakeUploadHashEnabled} }}";
     }
 
     private static bool IsDevFakeUploadFileEnabledValue(string? value)
+    {
+        return string.Equals(value?.Trim(), "true", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsDevFakeUploadHashEnabledValue(string? value)
     {
         return string.Equals(value?.Trim(), "true", StringComparison.OrdinalIgnoreCase);
     }

--- a/src/App.Desktop/Services/Upload/DesktopUploadSectionViewModel.cs
+++ b/src/App.Desktop/Services/Upload/DesktopUploadSectionViewModel.cs
@@ -2,10 +2,16 @@ using App.Desktop.Boundaries;
 
 namespace App.Desktop.Services.Upload;
 
-public sealed class DesktopUploadSectionViewModel(IDesktopVideoFilePicker videoFilePicker)
+public sealed class DesktopUploadSectionViewModel(
+    IDesktopVideoFilePicker videoFilePicker,
+    IDesktopVideoHashService videoHashService)
 {
     private readonly IDesktopVideoFilePicker _videoFilePicker =
         videoFilePicker ?? throw new ArgumentNullException(nameof(videoFilePicker));
+    private readonly IDesktopVideoHashService _videoHashService =
+        videoHashService ?? throw new ArgumentNullException(nameof(videoHashService));
+
+    private DesktopVideoHashRequest? _selectedFileHashRequest;
 
     public DesktopWorkspaceSection CurrentSection { get; private set; } = DesktopWorkspaceSection.Workspace;
 
@@ -13,10 +19,21 @@ public sealed class DesktopUploadSectionViewModel(IDesktopVideoFilePicker videoF
 
     public bool IsSelectingFile { get; private set; }
 
+    public bool IsHashing { get; private set; }
+
+    public bool CanCalculateHash => SelectedFile is not null && !IsSelectingFile && !IsHashing;
+
     public DesktopUploadSelectedFile? SelectedFile { get; private set; }
 
     public string SelectionStatusMessage { get; private set; } =
         DesktopUploadSectionText.PlaceholderResult;
+
+    public string HashStatusMessage { get; private set; } =
+        DesktopUploadSectionText.HashNotReadyMessage;
+
+    public string? Sha256Hex { get; private set; }
+
+    public bool HasSha256Hash => Sha256Hex is not null;
 
     public void OpenUploadSection()
     {
@@ -44,6 +61,7 @@ public sealed class DesktopUploadSectionViewModel(IDesktopVideoFilePicker videoF
 
         IsSelectingFile = true;
         SelectionStatusMessage = DesktopUploadSectionText.SelectingFileMessage;
+        ResetSelectedFileHashState();
 
         try
         {
@@ -52,7 +70,11 @@ public sealed class DesktopUploadSectionViewModel(IDesktopVideoFilePicker videoF
             if (result.Status == DesktopVideoFilePickerStatus.Selected && result.SelectedFile is not null)
             {
                 SelectedFile = result.SelectedFile;
+                _selectedFileHashRequest = result.HashSource is null
+                    ? null
+                    : DesktopVideoHashRequest.FromSource(result.HashSource);
                 SelectionStatusMessage = DesktopUploadSectionText.SelectedFilePreviewMessage;
+                HashStatusMessage = DesktopUploadSectionText.HashReadyMessage;
                 return SelectedFile;
             }
 
@@ -68,9 +90,68 @@ public sealed class DesktopUploadSectionViewModel(IDesktopVideoFilePicker videoF
         }
     }
 
+    public async ValueTask<DesktopVideoHashResult?> CalculateSha256Async(CancellationToken cancellationToken)
+    {
+        if (!CanCalculateHash)
+        {
+            HashStatusMessage = DesktopUploadSectionText.HashNotReadyMessage;
+            return null;
+        }
+
+        IsHashing = true;
+        Sha256Hex = null;
+        HashStatusMessage = DesktopUploadSectionText.HashInProgressMessage;
+
+        try
+        {
+            if (_selectedFileHashRequest is null)
+            {
+                HashStatusMessage = DesktopUploadSectionText.HashUnavailableMessage;
+                return DesktopVideoHashResult.Unavailable;
+            }
+
+            DesktopVideoHashResult result = await _videoHashService.CalculateSha256Async(
+                _selectedFileHashRequest,
+                cancellationToken);
+
+            if (result.Status == DesktopVideoHashStatus.Succeeded && result.Sha256Hex is not null)
+            {
+                Sha256Hex = result.Sha256Hex;
+                HashStatusMessage = DesktopUploadSectionText.HashSucceededMessage;
+                return result;
+            }
+
+            HashStatusMessage = result.Status switch
+            {
+                DesktopVideoHashStatus.Canceled => DesktopUploadSectionText.HashCanceledMessage,
+                _ => DesktopUploadSectionText.HashUnavailableMessage
+            };
+
+            return result;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            HashStatusMessage = DesktopUploadSectionText.HashCanceledMessage;
+            return DesktopVideoHashResult.Canceled;
+        }
+        finally
+        {
+            IsHashing = false;
+        }
+    }
+
     private void ResetSelection()
     {
         SelectedFile = null;
         SelectionStatusMessage = DesktopUploadSectionText.PlaceholderResult;
+        ResetSelectedFileHashState();
+    }
+
+    private void ResetSelectedFileHashState()
+    {
+        _selectedFileHashRequest = null;
+        IsHashing = false;
+        Sha256Hex = null;
+        HashStatusMessage = DesktopUploadSectionText.HashNotReadyMessage;
     }
 }

--- a/src/App.Desktop/Services/Upload/DesktopVideoHashService.cs
+++ b/src/App.Desktop/Services/Upload/DesktopVideoHashService.cs
@@ -1,0 +1,53 @@
+using System.IO;
+using System.Security.Cryptography;
+
+using App.Desktop.Boundaries;
+
+namespace App.Desktop.Services.Upload;
+
+public sealed class DesktopVideoHashService : IDesktopVideoHashService
+{
+    private const int BufferSize = 1024 * 1024;
+
+    public async ValueTask<DesktopVideoHashResult> CalculateSha256Async(
+        DesktopVideoHashRequest request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (!request.TryGetLocalFilePath(out string filePath))
+        {
+            return DesktopVideoHashResult.Unavailable;
+        }
+
+        try
+        {
+            await using var stream = new FileStream(
+                filePath,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.Read,
+                BufferSize,
+                FileOptions.Asynchronous | FileOptions.SequentialScan);
+
+            byte[] hash = await SHA256.HashDataAsync(stream, cancellationToken);
+            return DesktopVideoHashResult.Succeeded(Convert.ToHexString(hash).ToLowerInvariant());
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return DesktopVideoHashResult.Canceled;
+        }
+        catch (Exception exception) when (IsSafeHashFailure(exception))
+        {
+            return DesktopVideoHashResult.Unavailable;
+        }
+    }
+
+    private static bool IsSafeHashFailure(Exception exception)
+    {
+        return exception is IOException
+            or UnauthorizedAccessException
+            or NotSupportedException
+            or ArgumentException;
+    }
+}

--- a/src/App.Desktop/Services/Upload/FakeDesktopVideoFilePicker.cs
+++ b/src/App.Desktop/Services/Upload/FakeDesktopVideoFilePicker.cs
@@ -11,6 +11,7 @@ public sealed class FakeDesktopVideoFilePicker : IDesktopVideoFilePicker
         return ValueTask.FromResult(DesktopVideoFilePickerResult.Selected(
             DesktopUploadSelectedFile.VisualSmokeFileName,
             DesktopUploadSelectedFile.VisualSmokeFileSizeBytes,
-            DesktopUploadSelectedFile.VisualSmokeContentType));
+            DesktopUploadSelectedFile.VisualSmokeContentType,
+            DesktopVideoHashSource.VisualSmoke));
     }
 }

--- a/src/App.Desktop/Services/Upload/FakeDesktopVideoHashService.cs
+++ b/src/App.Desktop/Services/Upload/FakeDesktopVideoHashService.cs
@@ -1,0 +1,19 @@
+using App.Desktop.Boundaries;
+
+namespace App.Desktop.Services.Upload;
+
+public sealed class FakeDesktopVideoHashService : IDesktopVideoHashService
+{
+    public const string VisualSmokeSha256Hex =
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    public ValueTask<DesktopVideoHashResult> CalculateSha256Async(
+        DesktopVideoHashRequest request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return ValueTask.FromResult(DesktopVideoHashResult.Succeeded(VisualSmokeSha256Hex));
+    }
+}

--- a/src/App.Desktop/Services/Upload/WpfDesktopVideoFilePicker.cs
+++ b/src/App.Desktop/Services/Upload/WpfDesktopVideoFilePicker.cs
@@ -45,7 +45,8 @@ public sealed class WpfDesktopVideoFilePicker : IDesktopVideoFilePicker
             return DesktopVideoFilePickerResult.Selected(
                 fileInfo.Name,
                 fileInfo.Length,
-                ResolveContentType(fileInfo.Extension));
+                ResolveContentType(fileInfo.Extension),
+                DesktopVideoHashSource.FromLocalFilePath(fileInfo.FullName));
         }
         catch (Exception exception) when (IsSafeMetadataFailure(exception))
         {

--- a/src/App.Desktop/wwwroot/app.css
+++ b/src/App.Desktop/wwwroot/app.css
@@ -279,7 +279,8 @@ body {
 }
 
 .desktop-upload__back,
-.desktop-upload__select {
+.desktop-upload__select,
+.desktop-upload__hash {
     min-height: 38px;
     padding: 0 16px;
     border-radius: 6px;
@@ -295,7 +296,8 @@ body {
     color: #253241;
 }
 
-.desktop-upload__select {
+.desktop-upload__select,
+.desktop-upload__hash {
     width: fit-content;
     border: 1px solid #18406b;
     background: #18406b;
@@ -303,7 +305,8 @@ body {
 }
 
 .desktop-upload__back:disabled,
-.desktop-upload__select:disabled {
+.desktop-upload__select:disabled,
+.desktop-upload__hash:disabled {
     color: #687789;
     border-color: #b9c3cf;
     background: #eef1f5;
@@ -333,14 +336,20 @@ body {
     line-height: 1.4;
 }
 
-.desktop-upload__selection {
+.desktop-upload__selection,
+.desktop-upload__hash-result {
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 12px;
     margin: 4px 0 0;
 }
 
-.desktop-upload__selection div {
+.desktop-upload__hash-result {
+    grid-template-columns: minmax(0, 1fr);
+}
+
+.desktop-upload__selection div,
+.desktop-upload__hash-result div {
     min-width: 0;
     padding: 12px;
     border: 1px solid #d7dde5;
@@ -348,14 +357,16 @@ body {
     background: #ffffff;
 }
 
-.desktop-upload__selection dt {
+.desktop-upload__selection dt,
+.desktop-upload__hash-result dt {
     margin: 0 0 4px;
     color: #52616f;
     font-size: 0.78rem;
     font-weight: 700;
 }
 
-.desktop-upload__selection dd {
+.desktop-upload__selection dd,
+.desktop-upload__hash-result dd {
     margin: 0;
     color: #18212f;
     font-size: 0.9rem;
@@ -384,11 +395,13 @@ body {
     }
 
     .desktop-upload__back,
-    .desktop-upload__select {
+    .desktop-upload__select,
+    .desktop-upload__hash {
         width: 100%;
     }
 
-    .desktop-upload__selection {
+    .desktop-upload__selection,
+    .desktop-upload__hash-result {
         grid-template-columns: 1fr;
     }
 }

--- a/tests/Unit/App.Desktop.Tests/DesktopCompositionRootTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopCompositionRootTests.cs
@@ -21,7 +21,9 @@ public sealed class DesktopCompositionRootTests
         Assert.IsType<DesktopSignInService>(services.GetRequiredService<IDesktopSignInService>());
         Assert.IsType<DesktopUploadSectionViewModel>(services.GetRequiredService<DesktopUploadSectionViewModel>());
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
         Assert.IsType<WpfDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
+        Assert.IsType<DesktopVideoHashService>(services.GetRequiredService<IDesktopVideoHashService>());
     }
 
     [Fact]
@@ -30,14 +32,17 @@ public sealed class DesktopCompositionRootTests
         using var environment = new EnvironmentVariableScope()
             .Set(DesktopAuthOptions.ControlPlaneBaseAddressEnvironmentVariable, null)
             .Set(DesktopAuthOptions.DevFakeAuthEnabledEnvironmentVariable, null)
-            .Set(DesktopUploadSectionOptions.DevFakeUploadFileEnabledEnvironmentVariable, null);
+            .Set(DesktopUploadSectionOptions.DevFakeUploadFileEnabledEnvironmentVariable, null)
+            .Set(DesktopUploadSectionOptions.DevFakeUploadHashEnabledEnvironmentVariable, null);
 
         using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
 
         Assert.False(services.GetRequiredService<DesktopAuthOptions>().IsDevFakeAuthEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
         Assert.IsType<UnavailableDesktopAuthClient>(services.GetRequiredService<IDesktopAuthClient>());
         Assert.IsType<WpfDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
+        Assert.IsType<DesktopVideoHashService>(services.GetRequiredService<IDesktopVideoHashService>());
     }
 
     [Fact]
@@ -46,16 +51,69 @@ public sealed class DesktopCompositionRootTests
         using var environment = new EnvironmentVariableScope()
             .Set(DesktopAuthOptions.ControlPlaneBaseAddressEnvironmentVariable, null)
             .Set(DesktopAuthOptions.DevFakeAuthEnabledEnvironmentVariable, null)
-            .Set(DesktopUploadSectionOptions.DevFakeUploadFileEnabledEnvironmentVariable, "true");
+            .Set(DesktopUploadSectionOptions.DevFakeUploadFileEnabledEnvironmentVariable, "true")
+            .Set(DesktopUploadSectionOptions.DevFakeUploadHashEnabledEnvironmentVariable, null);
 
         using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
 
 #if DEBUG
         Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
         Assert.IsType<FakeDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
+        Assert.IsType<DesktopVideoHashService>(services.GetRequiredService<IDesktopVideoHashService>());
 #else
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
         Assert.IsType<WpfDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
+        Assert.IsType<DesktopVideoHashService>(services.GetRequiredService<IDesktopVideoHashService>());
+#endif
+    }
+
+    [Fact]
+    public void EnvironmentOptionsEnableFakeUploadHashOnlyWhenExplicitlyRequested()
+    {
+        using var environment = new EnvironmentVariableScope()
+            .Set(DesktopAuthOptions.ControlPlaneBaseAddressEnvironmentVariable, null)
+            .Set(DesktopAuthOptions.DevFakeAuthEnabledEnvironmentVariable, null)
+            .Set(DesktopUploadSectionOptions.DevFakeUploadFileEnabledEnvironmentVariable, null)
+            .Set(DesktopUploadSectionOptions.DevFakeUploadHashEnabledEnvironmentVariable, "true");
+
+        using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
+
+#if DEBUG
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
+        Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
+        Assert.IsType<WpfDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
+        Assert.IsType<FakeDesktopVideoHashService>(services.GetRequiredService<IDesktopVideoHashService>());
+#else
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
+        Assert.IsType<WpfDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
+        Assert.IsType<DesktopVideoHashService>(services.GetRequiredService<IDesktopVideoHashService>());
+#endif
+    }
+
+    [Fact]
+    public void EnvironmentOptionsEnableFakeUploadFileAndHashTogetherForVisualSmoke()
+    {
+        using var environment = new EnvironmentVariableScope()
+            .Set(DesktopAuthOptions.ControlPlaneBaseAddressEnvironmentVariable, null)
+            .Set(DesktopAuthOptions.DevFakeAuthEnabledEnvironmentVariable, null)
+            .Set(DesktopUploadSectionOptions.DevFakeUploadFileEnabledEnvironmentVariable, "true")
+            .Set(DesktopUploadSectionOptions.DevFakeUploadHashEnabledEnvironmentVariable, "true");
+
+        using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
+
+#if DEBUG
+        Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
+        Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
+        Assert.IsType<FakeDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
+        Assert.IsType<FakeDesktopVideoHashService>(services.GetRequiredService<IDesktopVideoHashService>());
+#else
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
+        Assert.IsType<WpfDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
+        Assert.IsType<DesktopVideoHashService>(services.GetRequiredService<IDesktopVideoHashService>());
 #endif
     }
 

--- a/tests/Unit/App.Desktop.Tests/DesktopSignInServiceTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopSignInServiceTests.cs
@@ -259,6 +259,10 @@ public sealed class DesktopSignInServiceTests
         Assert.Contains("DesktopUploadSectionText.SelectVideoFileButton", markup, StringComparison.Ordinal);
         Assert.Contains("DesktopUploadSectionText.BackToWorkspaceButton", markup, StringComparison.Ordinal);
         Assert.Contains("UploadSectionViewModel.SelectVideoFileAsync(CancellationToken.None)", markup, StringComparison.Ordinal);
+        Assert.Contains("DesktopUploadSectionText.CalculateSha256Button", markup, StringComparison.Ordinal);
+        Assert.Contains("UploadSectionViewModel.CalculateSha256Async(CancellationToken.None)", markup, StringComparison.Ordinal);
+        Assert.Contains("UploadSectionViewModel.CanCalculateHash", markup, StringComparison.Ordinal);
+        Assert.Contains("UploadSectionViewModel.Sha256Hex", markup, StringComparison.Ordinal);
         Assert.DoesNotContain("<UploadPlaceholder", markup, StringComparison.Ordinal);
         Assert.DoesNotContain("IDesktopUploadOrchestrator", markup, StringComparison.Ordinal);
         Assert.DoesNotContain("IControlPlaneApiClient", markup, StringComparison.Ordinal);

--- a/tests/Unit/App.Desktop.Tests/DesktopUploadSectionTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopUploadSectionTests.cs
@@ -19,7 +19,7 @@ public sealed class DesktopUploadSectionTests
     [Fact]
     public void UploadCardNavigationOpensUploadSection()
     {
-        var viewModel = new DesktopUploadSectionViewModel(new CancelingDesktopVideoFilePicker());
+        var viewModel = CreateViewModel(new CancelingDesktopVideoFilePicker());
 
         Assert.Equal(DesktopWorkspaceSection.Workspace, viewModel.CurrentSection);
         Assert.False(viewModel.IsUploadSectionOpen);
@@ -51,10 +51,20 @@ public sealed class DesktopUploadSectionTests
             "Не удалось получить безопасные сведения о файле.",
             DesktopUploadSectionText.SelectionUnavailableMessage);
         Assert.Equal("Назад к рабочей области", DesktopUploadSectionText.BackToWorkspaceButton);
+        Assert.Equal("Шаг 2. SHA-256", DesktopUploadSectionText.StepTwoTitle);
+        Assert.Equal("Рассчитать SHA-256", DesktopUploadSectionText.CalculateSha256Button);
+        Assert.Equal("Рассчитывается...", DesktopUploadSectionText.CalculateSha256BusyButton);
+        Assert.Equal("Выберите видеофайл, чтобы рассчитать SHA-256.", DesktopUploadSectionText.HashNotReadyMessage);
+        Assert.Equal("Файл выбран. Можно рассчитать SHA-256 локально на этом компьютере.", DesktopUploadSectionText.HashReadyMessage);
+        Assert.Equal("Рассчитывается SHA-256. Файл читается только в локальной desktop-границе.", DesktopUploadSectionText.HashInProgressMessage);
+        Assert.Equal("SHA-256 рассчитан локально.", DesktopUploadSectionText.HashSucceededMessage);
+        Assert.Equal("Не удалось рассчитать SHA-256 для выбранного файла.", DesktopUploadSectionText.HashUnavailableMessage);
+        Assert.Equal("Расчёт SHA-256 отменён.", DesktopUploadSectionText.HashCanceledMessage);
+        Assert.Equal("SHA-256", DesktopUploadSectionText.Sha256ResultLabel);
     }
 
     [Fact]
-    public void UploadSectionDoesNotReferenceApiHashingOrUploadFlowBoundaries()
+    public void UploadSectionDoesNotReferenceApiOrUploadFlowBoundaries()
     {
         string[] sourceFiles =
         [
@@ -62,8 +72,11 @@ public sealed class DesktopUploadSectionTests
             Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "DesktopUploadSectionViewModel.cs"),
             Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "DesktopUploadSectionOptions.cs"),
             Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "FakeDesktopVideoFilePicker.cs"),
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "FakeDesktopVideoHashService.cs"),
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "DesktopVideoHashService.cs"),
             Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "WpfDesktopVideoFilePicker.cs"),
-            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Boundaries", "DesktopVideoFilePickerBoundary.cs")
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Boundaries", "DesktopVideoFilePickerBoundary.cs"),
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Boundaries", "DesktopVideoHashBoundary.cs")
         ];
 
         foreach (string sourceFile in sourceFiles)
@@ -73,49 +86,54 @@ public sealed class DesktopUploadSectionTests
             Assert.DoesNotContain("App.Api", source, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("IControlPlaneApiClient", source, StringComparison.Ordinal);
             Assert.DoesNotContain("IDesktopUploadOrchestrator", source, StringComparison.Ordinal);
-            Assert.DoesNotContain("ReadSha256", source, StringComparison.OrdinalIgnoreCase);
-            Assert.DoesNotContain("SHA-256", source, StringComparison.OrdinalIgnoreCase);
-            Assert.DoesNotContain("sha256", source, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("businessObjectKey", source, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("PreUploadCheck", source, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("DirectSiteUpload", source, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("UploadReceipt", source, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("ReadAllBytes", source, StringComparison.OrdinalIgnoreCase);
-            Assert.DoesNotContain("OpenRead", source, StringComparison.OrdinalIgnoreCase);
         }
     }
 
     [Fact]
-    public void FakeUploadFileSelectionIsDevOnlyAndDisabledByDefault()
+    public void FakeUploadFileSelectionAndHashAreDevOnlyAndDisabledByDefault()
     {
         Assert.False(DesktopUploadSectionOptions.Disabled.IsDevFakeUploadFileEnabled);
+        Assert.False(DesktopUploadSectionOptions.Disabled.IsDevFakeUploadHashEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue(null).IsDevFakeUploadFileEnabled);
+        Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue(null).IsDevFakeUploadHashEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("false").IsDevFakeUploadFileEnabled);
+        Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("false", "false").IsDevFakeUploadHashEnabled);
 
 #if DEBUG
         Assert.True(DesktopUploadSectionOptions.FromEnvironmentValue("true").IsDevFakeUploadFileEnabled);
+        Assert.True(DesktopUploadSectionOptions.FromEnvironmentValue("false", "true").IsDevFakeUploadHashEnabled);
+        Assert.True(DesktopUploadSectionOptions.FromEnvironmentValue("true", "true").IsDevFakeUploadHashEnabled);
 #else
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("true").IsDevFakeUploadFileEnabled);
+        Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("false", "true").IsDevFakeUploadHashEnabled);
+        Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("true", "true").IsDevFakeUploadHashEnabled);
 #endif
     }
 
     [Fact]
     public async Task CancelSelectionShowsSafeRussianMessage()
     {
-        var viewModel = new DesktopUploadSectionViewModel(new CancelingDesktopVideoFilePicker());
+        var viewModel = CreateViewModel(new CancelingDesktopVideoFilePicker());
 
         DesktopUploadSelectedFile? selectedFile = await viewModel.SelectVideoFileAsync(CancellationToken.None);
 
         Assert.Null(selectedFile);
         Assert.Null(viewModel.SelectedFile);
         Assert.Equal(DesktopUploadSectionText.SelectionCanceledMessage, viewModel.SelectionStatusMessage);
+        Assert.Equal(DesktopUploadSectionText.HashNotReadyMessage, viewModel.HashStatusMessage);
+        Assert.False(viewModel.CanCalculateHash);
         Assert.False(viewModel.IsSelectingFile);
     }
 
     [Fact]
     public async Task FakeSelectedFileStateIsSafeAndContainsNoRealPathOrSecret()
     {
-        var viewModel = new DesktopUploadSectionViewModel(new FakeDesktopVideoFilePicker());
+        var viewModel = CreateViewModel(new FakeDesktopVideoFilePicker());
 
         DesktopUploadSelectedFile? selectedFile = await viewModel.SelectVideoFileAsync(CancellationToken.None);
 
@@ -124,6 +142,8 @@ public sealed class DesktopUploadSectionTests
         Assert.Equal(12345678, selectedFile.SizeBytes);
         Assert.Equal("video/mp4", selectedFile.ContentType);
         Assert.Equal(DesktopUploadSectionText.SelectedFilePreviewMessage, viewModel.SelectionStatusMessage);
+        Assert.Equal(DesktopUploadSectionText.HashReadyMessage, viewModel.HashStatusMessage);
+        Assert.True(viewModel.CanCalculateHash);
         Assert.False(viewModel.IsSelectingFile);
 
         string visibleState = selectedFile.ToString() + " " + viewModel.SelectionStatusMessage;
@@ -141,7 +161,7 @@ public sealed class DesktopUploadSectionTests
     public async Task SelectedFilePreviewHidesPathSegments()
     {
         string nestedFileName = Path.Combine("operator-private", "nested", "safe-preview.mp4");
-        var viewModel = new DesktopUploadSectionViewModel(new StaticDesktopVideoFilePicker(
+        var viewModel = CreateViewModel(new StaticDesktopVideoFilePicker(
             DesktopVideoFilePickerResult.Selected(nestedFileName, 42, "video/mp4")));
 
         DesktopUploadSelectedFile? selectedFile = await viewModel.SelectVideoFileAsync(CancellationToken.None);
@@ -161,7 +181,7 @@ public sealed class DesktopUploadSectionTests
     [Fact]
     public async Task UnsafeContentTypeFallsBackToUnknownSafeText()
     {
-        var viewModel = new DesktopUploadSectionViewModel(new StaticDesktopVideoFilePicker(
+        var viewModel = CreateViewModel(new StaticDesktopVideoFilePicker(
             DesktopVideoFilePickerResult.Selected("safe-preview.mp4", 42, "Authorization/token")));
 
         DesktopUploadSelectedFile? selectedFile = await viewModel.SelectVideoFileAsync(CancellationToken.None);
@@ -173,12 +193,111 @@ public sealed class DesktopUploadSectionTests
     }
 
     [Fact]
+    public void HashActionIsUnavailableUntilFileSelected()
+    {
+        var viewModel = CreateViewModel(new FakeDesktopVideoFilePicker());
+
+        Assert.False(viewModel.CanCalculateHash);
+        Assert.Equal(DesktopUploadSectionText.HashNotReadyMessage, viewModel.HashStatusMessage);
+        Assert.Null(viewModel.Sha256Hex);
+    }
+
+    [Fact]
+    public async Task FakeHashReturnsExpectedLowercaseSha256Hex()
+    {
+        var result = await new FakeDesktopVideoHashService().CalculateSha256Async(
+            DesktopVideoHashRequest.FromSource(DesktopVideoHashSource.VisualSmoke),
+            CancellationToken.None);
+
+        Assert.Equal(DesktopVideoHashStatus.Succeeded, result.Status);
+        Assert.Equal(FakeDesktopVideoHashService.VisualSmokeSha256Hex, result.Sha256Hex);
+        string sha256Hex = result.Sha256Hex ?? throw new InvalidOperationException("SHA-256 was not returned.");
+        Assert.Equal(64, sha256Hex.Length);
+        Assert.Matches("^[0-9a-f]{64}$", sha256Hex);
+    }
+
+    [Fact]
+    public async Task SuccessfulHashResultVisibleAfterSelectedFile()
+    {
+        var viewModel = CreateViewModel(new FakeDesktopVideoFilePicker());
+
+        _ = await viewModel.SelectVideoFileAsync(CancellationToken.None);
+
+        Assert.True(viewModel.CanCalculateHash);
+        Assert.Equal(DesktopUploadSectionText.HashReadyMessage, viewModel.HashStatusMessage);
+
+        DesktopVideoHashResult? result = await viewModel.CalculateSha256Async(CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal(DesktopVideoHashStatus.Succeeded, result.Status);
+        Assert.Equal(FakeDesktopVideoHashService.VisualSmokeSha256Hex, viewModel.Sha256Hex);
+        Assert.True(viewModel.HasSha256Hash);
+        Assert.False(viewModel.IsHashing);
+        Assert.True(viewModel.CanCalculateHash);
+        Assert.Equal(DesktopUploadSectionText.HashSucceededMessage, viewModel.HashStatusMessage);
+    }
+
+    [Fact]
+    public async Task RealHashBoundaryComputesLowercaseSha256ForSelectedLocalFile()
+    {
+        string tempDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDirectory);
+        string localFile = Path.Combine(tempDirectory, "safe-preview.mp4");
+
+        try
+        {
+            await File.WriteAllTextAsync(localFile, "abc");
+            var request = DesktopVideoHashRequest.FromSource(DesktopVideoHashSource.FromLocalFilePath(localFile));
+
+            DesktopVideoHashResult result = await new DesktopVideoHashService().CalculateSha256Async(
+                request,
+                CancellationToken.None);
+
+            Assert.Equal(DesktopVideoHashStatus.Succeeded, result.Status);
+            Assert.Equal("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad", result.Sha256Hex);
+        }
+        finally
+        {
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task SafeHashErrorsDoNotExposeFullLocalPath()
+    {
+        string privateFolder = "operator-private-hash-source";
+        string localFile = Path.Combine(Path.GetTempPath(), privateFolder, "missing-video.mp4");
+        var viewModel = CreateViewModel(
+            new StaticDesktopVideoFilePicker(DesktopVideoFilePickerResult.Selected(
+                "safe-preview.mp4",
+                42,
+                "video/mp4",
+                DesktopVideoHashSource.FromLocalFilePath(localFile))),
+            new DesktopVideoHashService());
+
+        _ = await viewModel.SelectVideoFileAsync(CancellationToken.None);
+        DesktopVideoHashResult? result = await viewModel.CalculateSha256Async(CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal(DesktopVideoHashStatus.Unavailable, result.Status);
+        Assert.Null(viewModel.Sha256Hex);
+        Assert.Equal(DesktopUploadSectionText.HashUnavailableMessage, viewModel.HashStatusMessage);
+
+        string visibleState = viewModel.HashStatusMessage + " " + result;
+        Assert.DoesNotContain(Path.GetTempPath(), visibleState, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(privateFolder, visibleState, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("missing-video.mp4", visibleState, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(@"\", visibleState, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task SignOutResetReturnsUploadStateToWorkspace()
     {
-        var viewModel = new DesktopUploadSectionViewModel(new FakeDesktopVideoFilePicker());
+        var viewModel = CreateViewModel(new FakeDesktopVideoFilePicker());
 
         viewModel.OpenUploadSection();
         _ = await viewModel.SelectVideoFileAsync(CancellationToken.None);
+        _ = await viewModel.CalculateSha256Async(CancellationToken.None);
 
         viewModel.ResetForSignedOutState();
 
@@ -186,15 +305,19 @@ public sealed class DesktopUploadSectionTests
         Assert.False(viewModel.IsUploadSectionOpen);
         Assert.Null(viewModel.SelectedFile);
         Assert.Equal(DesktopUploadSectionText.PlaceholderResult, viewModel.SelectionStatusMessage);
+        Assert.Equal(DesktopUploadSectionText.HashNotReadyMessage, viewModel.HashStatusMessage);
+        Assert.Null(viewModel.Sha256Hex);
+        Assert.False(viewModel.CanCalculateHash);
     }
 
     [Fact]
     public async Task BackToWorkspaceResetsSelectedFileState()
     {
-        var viewModel = new DesktopUploadSectionViewModel(new FakeDesktopVideoFilePicker());
+        var viewModel = CreateViewModel(new FakeDesktopVideoFilePicker());
 
         viewModel.OpenUploadSection();
         _ = await viewModel.SelectVideoFileAsync(CancellationToken.None);
+        _ = await viewModel.CalculateSha256Async(CancellationToken.None);
 
         viewModel.BackToWorkspace();
 
@@ -202,6 +325,9 @@ public sealed class DesktopUploadSectionTests
         Assert.False(viewModel.IsUploadSectionOpen);
         Assert.Null(viewModel.SelectedFile);
         Assert.Equal(DesktopUploadSectionText.PlaceholderResult, viewModel.SelectionStatusMessage);
+        Assert.Equal(DesktopUploadSectionText.HashNotReadyMessage, viewModel.HashStatusMessage);
+        Assert.Null(viewModel.Sha256Hex);
+        Assert.False(viewModel.CanCalculateHash);
     }
 
     [Fact]
@@ -224,8 +350,19 @@ public sealed class DesktopUploadSectionTests
             DesktopUploadSectionText.SelectedFileSizeLabel,
             DesktopUploadSectionText.SelectedFileContentTypeLabel,
             DesktopUploadSectionText.UnknownContentTypeValue,
+            DesktopUploadSectionText.StepTwoTitle,
+            DesktopUploadSectionText.CalculateSha256Button,
+            DesktopUploadSectionText.CalculateSha256BusyButton,
+            DesktopUploadSectionText.HashNotReadyMessage,
+            DesktopUploadSectionText.HashReadyMessage,
+            DesktopUploadSectionText.HashInProgressMessage,
+            DesktopUploadSectionText.HashSucceededMessage,
+            DesktopUploadSectionText.HashUnavailableMessage,
+            DesktopUploadSectionText.HashCanceledMessage,
+            DesktopUploadSectionText.Sha256ResultLabel,
             DesktopUploadSelectedFile.VisualSmokeFileName,
-            DesktopUploadSelectedFile.VisualSmokeContentType
+            DesktopUploadSelectedFile.VisualSmokeContentType,
+            FakeDesktopVideoHashService.VisualSmokeSha256Hex
         ];
 
         foreach (string visibleString in visibleStrings)
@@ -237,6 +374,18 @@ public sealed class DesktopUploadSectionTests
             Assert.DoesNotContain("session_id", visibleString, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("raw response", visibleString, StringComparison.OrdinalIgnoreCase);
         }
+    }
+
+    private static DesktopUploadSectionViewModel CreateViewModel(IDesktopVideoFilePicker videoFilePicker)
+    {
+        return CreateViewModel(videoFilePicker, new FakeDesktopVideoHashService());
+    }
+
+    private static DesktopUploadSectionViewModel CreateViewModel(
+        IDesktopVideoFilePicker videoFilePicker,
+        IDesktopVideoHashService videoHashService)
+    {
+        return new DesktopUploadSectionViewModel(videoFilePicker, videoHashService);
     }
 
     private sealed class CancelingDesktopVideoFilePicker : IDesktopVideoFilePicker


### PR DESCRIPTION
## Coder
Coder 1 acting as Coder 2 / Desktop Client

## Task ID
S2-62 Desktop Upload Local SHA-256 Boundary / Hash Preview Placeholder

## Module
App.Desktop / upload SHA-256 boundary

## Scope
Desktop-only upload section slice. Adds a local SHA-256 boundary and safe hash preview state after the S2-61 file-picker metadata preview.

## Changed areas
- `docs/task-cards/S2-62_desktop-upload-sha256-boundary-task-card.txt`
- `src/App.Desktop/**`
- `tests/Unit/App.Desktop.Tests/**`

## Base main SHA
`e97ec84ca202da39d2f23ef091bb74d4d2ad4511`

## Coordination log entries reviewed
TEAM COORDINATION LOG issue #89 metadata/comments reviewed, including merge records for S2-58 #127, S2-59 #128, S2-60 #129, and S2-61 #130.

## Handoff/task cards reviewed
- `docs/task-cards/S2-58_desktop-visual-smoke-fake-auth-task-card.txt`
- `docs/task-cards/S2-59_desktop-signed-in-shell-navigation-task-card.txt`
- `docs/task-cards/S2-60_desktop-upload-section-file-selection-placeholder-task-card.txt`
- `docs/task-cards/S2-61_desktop-upload-file-picker-boundary-task-card.txt`

## Contracts
None.

## Migrations
None.

## Feature flags/env guard
- Existing fake auth: `AA_DESKTOP_DEV_FAKE_AUTH_ENABLED=true`
- Existing fake picker: `AA_DESKTOP_DEV_FAKE_UPLOAD_FILE_ENABLED=true`
- New optional fake hash for visual smoke only: `AA_DESKTOP_DEV_FAKE_UPLOAD_HASH_ENABLED=true`

## API impact
None. No App.Api calls from the upload section; no PreUploadCheck, businessObjectKey, direct site upload, or UploadReceipt.

## Web impact
None. No App.Web changes.

## Android impact
None. No App.Mobile.Android changes.

## Offline behavior
None.

## Rollback
Revert the S2-62 PR.

## Validation
- PASS `git diff --check`
- PASS `dotnet restore AnalyticsAutomation-Core.sln -nologo`
- PASS `dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore`
- PASS `dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal`
- PASS `dotnet build AnalyticsAutomation-Core.sln -nologo -v minimal` (existing analyzer warnings outside this desktop slice)
- PASS `dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal` (97/97)
- PASS hidden/control Unicode scan over changed text files
- PASS forbidden upload-chain added-lines scan for changed App.Desktop source diff
- PASS App.Desktop fake-auth/fake-picker/fake-hash visual smoke

## Visual smoke screenshot folder/files
Folder: `C:\CODEX\Temp\S2-62_DESKTOP_SHA256_BOUNDARY_VISUAL_SMOKE_20260430_142709\`

Files:
- `01_baseline_signin.png`
- `02_signed_in_shell.png`
- `03_upload_section_after_fake_file_selection.png`
- `04_hash_in_progress_or_ready_state.png`
- `05_after_fake_sha256_result.png`
- `06_after_sign_out.png`

Screenshots/runtime artifacts were not committed.

## Handoff docs/task card
`docs/task-cards/S2-62_desktop-upload-sha256-boundary-task-card.txt`

## Next step
Review the desktop-only SHA-256 boundary slice and visual-smoke evidence; merge only after approval.

## NO-GO / Deferred
Deferred: PreUploadCheck, businessObjectKey, direct site upload, UploadReceipt, offline queue, GroupTree runtime, App.Api changes/calls, contracts changes, migrations, deploy, App.Web, App.Mobile.Android, App.UI.Shared.