### PR TITLE
[codex] S2-63 Desktop Upload Business Object Key Placeholder

### DIFF
--- a/docs/task-cards/S2-63_desktop-upload-business-object-key-placeholder-task-card.txt
+++ b/docs/task-cards/S2-63_desktop-upload-business-object-key-placeholder-task-card.txt
@@ -1,0 +1,148 @@
+Title:
+S2-63 Desktop Upload Business Object Key Placeholder / Manual Entry Boundary
+
+Module:
+App.Desktop / upload businessObjectKey placeholder
+
+Owner:
+Coder 1 acting as Coder 2 / Desktop Client
+
+Client form:
+desktop standalone
+
+Type:
+narrow runtime desktop UI slice after S2-62 upload SHA-256 boundary
+
+Status:
+Runtime task card created with implementation.
+
+Goal:
+Add an App.Desktop-local manual businessObjectKey placeholder in the upload section, with safe validation/preview state and an optional fake/dev key for visual smoke only.
+
+Context:
+S2-58 added debug-only fake auth guarded by AA_DESKTOP_DEV_FAKE_AUTH_ENABLED=true.
+S2-59 added the Russian signed-in shell.
+S2-60 added the active "Загрузка видео" upload section placeholder.
+S2-61 added the App.Desktop-local video file picker boundary and safe metadata preview.
+S2-62 added the App.Desktop-local SHA-256 boundary and safe lowercase hash preview.
+
+Scope:
+- Keep the current Russian SignIn UI before authentication.
+- After fake-auth SignIn, show the signed-in shell.
+- Open the upload section from "Загрузка видео".
+- Keep Step 1 safe file metadata preview.
+- Keep Step 2 local SHA-256 preview.
+- Add Step 3 "Бизнес-объект" with a manual "Ключ бизнес-объекта" field.
+- Show the placeholder hint that manual entry is temporary for the desktop prototype and the production source will be approved in a later slice.
+- Validate manual input locally: trim whitespace, require 1..128 characters, reject newline/control characters, and keep preview limited to the sanitized key.
+- Add optional fake/dev key for visual smoke only:
+  - env guard: AA_DESKTOP_DEV_FAKE_BUSINESS_OBJECT_KEY_ENABLED=true
+  - fake value: visual-smoke-business-object-001
+- Clear upload state, including businessObjectKey state, on back and sign-out.
+
+Allowed changed areas:
+- docs/task-cards/S2-63_desktop-upload-business-object-key-placeholder-task-card.txt
+- src/App.Desktop/**
+- tests/Unit/App.Desktop.Tests/**
+
+Forbidden changed areas:
+- src/App.Api/**
+- src/App.Worker/**
+- src/App.Web/**
+- src/App.Mobile.Android/**
+- src/App.UI.Shared/**
+- src/BuildingBlocks.Contracts/**
+- src/Modules/**
+- DB migrations
+- .github/workflows/**
+- deploy scripts
+- docs/ops/**
+- committed screenshots or runtime artifacts
+
+Contracts:
+none
+
+Migrations:
+none
+
+Feature flags/env guard:
+- Existing fake auth visual-smoke guard:
+  AA_DESKTOP_DEV_FAKE_AUTH_ENABLED=true
+- Existing fake picker visual-smoke guard:
+  AA_DESKTOP_DEV_FAKE_UPLOAD_FILE_ENABLED=true
+- Existing fake hash visual-smoke guard:
+  AA_DESKTOP_DEV_FAKE_UPLOAD_HASH_ENABLED=true
+- Optional fake businessObjectKey visual-smoke guard:
+  AA_DESKTOP_DEV_FAKE_BUSINESS_OBJECT_KEY_ENABLED=true
+- Fake businessObjectKey is disabled by default and is visual-smoke/dev-test only.
+
+Events:
+none
+
+Offline behavior:
+none
+
+Security guardrails:
+- Do not send businessObjectKey to App.Api.
+- Do not add backend contracts, DTOs, migrations, or API routes.
+- Do not claim manual businessObjectKey is a production source of truth.
+- Do not display or log password, accessToken, refreshToken, Authorization, raw session id, raw response body, or token-like values.
+- Screenshots and runtime artifacts stay under C:\CODEX\Temp and are not committed.
+
+Explicitly out of scope:
+- PreUploadCheck.
+- Direct site upload.
+- UploadReceipt.
+- Backend-approved business object/report-draft binding flow.
+- GroupTree runtime.
+- Report draft runtime.
+- Offline queue.
+- App.Api changes or App.Api calls from upload section.
+- Shared contract changes.
+- DB migrations.
+- Deploy/workflow changes.
+- App.Web changes.
+- App.Mobile.Android changes.
+- App.UI.Shared changes.
+
+Deferred:
+Backend-approved business object/report-draft binding is not implemented in S2-63. Production direction remains a separate approved slice where businessObjectKey comes from a backend-approved business object or report-draft binding flow.
+
+Rollback:
+revert S2-63 PR
+
+Validation:
+- git diff --check
+- dotnet restore AnalyticsAutomation-Core.sln -nologo
+- dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore
+- dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal
+- dotnet build AnalyticsAutomation-Core.sln -nologo -v minimal
+- dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal
+- hidden/control Unicode scan over changed text files
+- App.Desktop fake-auth/fake-picker/fake-hash/fake-businessObjectKey visual smoke with screenshots
+
+Definition of done:
+- Upload section shows Step 1 file metadata, Step 2 SHA-256, Step 3 businessObjectKey placeholder, and a deferred PreUploadCheck note.
+- Manual businessObjectKey entry trims whitespace and previews only the sanitized accepted key.
+- Empty, multiline/control-character, over-length, and secret-like values show safe Russian validation messages without exposing tokens or credentials.
+- Fake businessObjectKey is disabled by default and enabled only by AA_DESKTOP_DEV_FAKE_BUSINESS_OBJECT_KEY_ENABLED=true in debug/dev-test visual smoke.
+- Fake businessObjectKey value is visual-smoke-business-object-001.
+- Back/sign-out clear selected file, hash, and businessObjectKey state.
+- No PreUploadCheck, direct site upload, UploadReceipt, App.Api call, contract, migration, deploy, App.Web, or App.Mobile.Android change is introduced.
+- Automated App.Desktop tests cover options, fake value, manual validation/sanitization, reset behavior, forbidden upload-chain calls, and visible-string safety.
+- Required visual-smoke screenshots are saved under C:\CODEX\Temp and kept out of git.
+
+Visual-smoke definition of done:
+- Run App.Desktop with AA_DESKTOP_DEV_FAKE_AUTH_ENABLED=true, AA_DESKTOP_DEV_FAKE_UPLOAD_FILE_ENABLED=true, AA_DESKTOP_DEV_FAKE_UPLOAD_HASH_ENABLED=true, and AA_DESKTOP_DEV_FAKE_BUSINESS_OBJECT_KEY_ENABLED=true.
+- Do not set AA_DESKTOP_CONTROL_PLANE_BASE_ADDRESS.
+- Use non-secret test data visual-smoke-user / visual-smoke-password.
+- Capture screenshots under C:\CODEX\Temp\S2-63_DESKTOP_BUSINESS_OBJECT_KEY_VISUAL_SMOKE_<timestamp>\.
+- Required screenshots:
+  - 01_baseline_signin.png
+  - 02_signed_in_shell.png
+  - 03_upload_section_after_fake_file_and_hash.png
+  - 04_business_object_key_empty_validation.png
+  - 05_after_fake_business_object_key.png
+  - 06_after_sign_out.png
+- Confirm no password, accessToken, refreshToken, Authorization, raw session id, raw response body, raw path, or real secret is visible.
+- Confirm screenshots and runtime artifacts are not committed.

--- a/src/App.Desktop/Boundaries/DesktopSignInBoundary.cs
+++ b/src/App.Desktop/Boundaries/DesktopSignInBoundary.cs
@@ -159,6 +159,23 @@ public static class DesktopUploadSectionText
     public const string HashUnavailableMessage = "Не удалось рассчитать SHA-256 для выбранного файла.";
     public const string HashCanceledMessage = "Расчёт SHA-256 отменён.";
     public const string Sha256ResultLabel = "SHA-256";
+    public const string StepThreeTitle = "Шаг 3. Бизнес-объект";
+    public const string BusinessObjectKeyLabel = "Ключ бизнес-объекта";
+    public const string BusinessObjectKeyHint = "Временный ручной ввод для desktop prototype. Production-источник будет утверждён отдельным slice.";
+    public const string BusinessObjectKeyApplyButton = "Проверить ключ";
+    public const string BusinessObjectKeyUseFakeButton = "Подставить dev-ключ";
+    public const string BusinessObjectKeyEmptyValidationMessage = "Введите ключ бизнес-объекта.";
+    public const string BusinessObjectKeyControlCharacterValidationMessage =
+        "Ключ бизнес-объекта не должен содержать переносы строк или управляющие символы.";
+    public const string BusinessObjectKeyLengthValidationMessage =
+        "Ключ бизнес-объекта должен быть от 1 до 128 символов.";
+    public const string BusinessObjectKeySecretValidationMessage =
+        "Ключ бизнес-объекта не должен содержать секретные значения.";
+    public const string BusinessObjectKeyAcceptedMessage =
+        "Ключ бизнес-объекта принят для безопасного preview.";
+    public const string BusinessObjectKeyPreviewLabel = "businessObjectKey";
+    public const string NextStepDeferredMessage =
+        "Следующий шаг отложен: PreUploadCheck будет добавлен отдельным approved desktop slice.";
 }
 
 public sealed record DesktopUploadSelectedFile(

--- a/src/App.Desktop/Components/DesktopShell.razor
+++ b/src/App.Desktop/Components/DesktopShell.razor
@@ -111,6 +111,69 @@
                                 </dl>
                             }
                         </div>
+
+                        <div class="desktop-upload__step">
+                            <h3>@DesktopUploadSectionText.StepThreeTitle</h3>
+                            <p
+                                id="desktop-upload-business-object-key-status"
+                                class="desktop-upload__message"
+                                role="status"
+                                aria-live="polite">
+                                @UploadSectionViewModel.BusinessObjectKeyStatusMessage
+                            </p>
+
+                            <label class="desktop-upload__field" for="desktop-upload-business-object-key">
+                                <span>@DesktopUploadSectionText.BusinessObjectKeyLabel</span>
+                                <input
+                                    id="desktop-upload-business-object-key"
+                                    name="businessObjectKey"
+                                    autocomplete="off"
+                                    spellcheck="false"
+                                    maxlength="@DesktopUploadBusinessObjectKey.MaxLength"
+                                    aria-describedby="desktop-upload-business-object-key-status desktop-upload-business-object-key-hint"
+                                    @bind-value="UploadSectionViewModel.BusinessObjectKeyInput"
+                                    @bind-value:event="oninput" />
+                            </label>
+
+                            <p id="desktop-upload-business-object-key-hint" class="desktop-upload__hint">
+                                @DesktopUploadSectionText.BusinessObjectKeyHint
+                            </p>
+
+                            <div class="desktop-upload__actions">
+                                <button
+                                    class="desktop-upload__key"
+                                    type="button"
+                                    disabled="@SignInViewModel.IsBusy"
+                                    @onclick="ApplyBusinessObjectKey">
+                                    @DesktopUploadSectionText.BusinessObjectKeyApplyButton
+                                </button>
+
+                                @if (UploadSectionViewModel.IsDevFakeBusinessObjectKeyEnabled)
+                                {
+                                    <button
+                                        class="desktop-upload__key desktop-upload__key--secondary"
+                                        type="button"
+                                        disabled="@SignInViewModel.IsBusy"
+                                        @onclick="UseDevFakeBusinessObjectKey">
+                                        @DesktopUploadSectionText.BusinessObjectKeyUseFakeButton
+                                    </button>
+                                }
+                            </div>
+
+                            @if (UploadSectionViewModel.HasBusinessObjectKey)
+                            {
+                                <dl class="desktop-upload__business-object-key">
+                                    <div>
+                                        <dt>@DesktopUploadSectionText.BusinessObjectKeyPreviewLabel</dt>
+                                        <dd>@UploadSectionViewModel.BusinessObjectKeyPreview</dd>
+                                    </div>
+                                </dl>
+                            }
+
+                            <p class="desktop-upload__deferred">
+                                @DesktopUploadSectionText.NextStepDeferredMessage
+                            </p>
+                        </div>
                     </section>
                 }
                 else
@@ -257,6 +320,16 @@
         await hashAttempt;
 
         StateHasChanged();
+    }
+
+    private void ApplyBusinessObjectKey()
+    {
+        UploadSectionViewModel.ApplyBusinessObjectKey();
+    }
+
+    private void UseDevFakeBusinessObjectKey()
+    {
+        UploadSectionViewModel.UseDevFakeBusinessObjectKey();
     }
 
     private string GetHeaderStatusText()

--- a/src/App.Desktop/Services/Upload/DesktopUploadBusinessObjectKey.cs
+++ b/src/App.Desktop/Services/Upload/DesktopUploadBusinessObjectKey.cs
@@ -39,6 +39,13 @@ public static class DesktopUploadBusinessObjectKeyValidator
             return Invalid(safeInputValue, DesktopUploadSectionText.BusinessObjectKeyEmptyValidationMessage);
         }
 
+        if (ContainsBlockedFragment(safeInputValue))
+        {
+            return Invalid(
+                string.Empty,
+                DesktopUploadSectionText.BusinessObjectKeySecretValidationMessage);
+        }
+
         if (ContainsControlCharacter(value))
         {
             return Invalid(
@@ -51,13 +58,6 @@ public static class DesktopUploadBusinessObjectKeyValidator
             return Invalid(
                 safeInputValue[..DesktopUploadBusinessObjectKey.MaxLength],
                 DesktopUploadSectionText.BusinessObjectKeyLengthValidationMessage);
-        }
-
-        if (ContainsBlockedFragment(safeInputValue))
-        {
-            return Invalid(
-                string.Empty,
-                DesktopUploadSectionText.BusinessObjectKeySecretValidationMessage);
         }
 
         var businessObjectKey = new DesktopUploadBusinessObjectKey(safeInputValue);

--- a/src/App.Desktop/Services/Upload/DesktopUploadBusinessObjectKey.cs
+++ b/src/App.Desktop/Services/Upload/DesktopUploadBusinessObjectKey.cs
@@ -1,0 +1,135 @@
+using App.Desktop.Boundaries;
+
+namespace App.Desktop.Services.Upload;
+
+public sealed record DesktopUploadBusinessObjectKey(string Value)
+{
+    public const int MaxLength = 128;
+    public const string VisualSmokeValue = "visual-smoke-business-object-001";
+}
+
+public sealed record DesktopUploadBusinessObjectKeyValidation(
+    bool IsValid,
+    DesktopUploadBusinessObjectKey? BusinessObjectKey,
+    string SafeInputValue,
+    string Message);
+
+public static class DesktopUploadBusinessObjectKeyValidator
+{
+    private static readonly string[] BlockedFragments =
+    [
+        "authorization",
+        "bearer",
+        "password",
+        "token",
+        "sessionid",
+        "session_id",
+        "access_token",
+        "accesstoken",
+        "refresh_token",
+        "refreshtoken"
+    ];
+
+    public static DesktopUploadBusinessObjectKeyValidation ValidateManualInput(string? value)
+    {
+        string safeInputValue = CreateSafeSingleLineInput(value);
+
+        if (string.IsNullOrEmpty(safeInputValue))
+        {
+            return Invalid(safeInputValue, DesktopUploadSectionText.BusinessObjectKeyEmptyValidationMessage);
+        }
+
+        if (ContainsControlCharacter(value))
+        {
+            return Invalid(
+                safeInputValue,
+                DesktopUploadSectionText.BusinessObjectKeyControlCharacterValidationMessage);
+        }
+
+        if (safeInputValue.Length > DesktopUploadBusinessObjectKey.MaxLength)
+        {
+            return Invalid(
+                safeInputValue[..DesktopUploadBusinessObjectKey.MaxLength],
+                DesktopUploadSectionText.BusinessObjectKeyLengthValidationMessage);
+        }
+
+        if (ContainsBlockedFragment(safeInputValue))
+        {
+            return Invalid(
+                string.Empty,
+                DesktopUploadSectionText.BusinessObjectKeySecretValidationMessage);
+        }
+
+        var businessObjectKey = new DesktopUploadBusinessObjectKey(safeInputValue);
+        return new DesktopUploadBusinessObjectKeyValidation(
+            IsValid: true,
+            businessObjectKey,
+            safeInputValue,
+            DesktopUploadSectionText.BusinessObjectKeyAcceptedMessage);
+    }
+
+    private static DesktopUploadBusinessObjectKeyValidation Invalid(string safeInputValue, string message)
+    {
+        return new DesktopUploadBusinessObjectKeyValidation(
+            IsValid: false,
+            BusinessObjectKey: null,
+            safeInputValue,
+            message);
+    }
+
+    private static string CreateSafeSingleLineInput(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return string.Empty;
+        }
+
+        var safeCharacters = new char[value.Length];
+        var safeLength = 0;
+
+        foreach (char character in value.Trim())
+        {
+            if (char.IsControl(character))
+            {
+                continue;
+            }
+
+            safeCharacters[safeLength] = character;
+            safeLength++;
+        }
+
+        return new string(safeCharacters, 0, safeLength).Trim();
+    }
+
+    private static bool ContainsControlCharacter(string? value)
+    {
+        if (value is null)
+        {
+            return false;
+        }
+
+        foreach (char character in value)
+        {
+            if (char.IsControl(character))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool ContainsBlockedFragment(string value)
+    {
+        string lower = value.ToLowerInvariant();
+        foreach (string blockedFragment in BlockedFragments)
+        {
+            if (lower.Contains(blockedFragment, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/App.Desktop/Services/Upload/DesktopUploadSectionOptions.cs
+++ b/src/App.Desktop/Services/Upload/DesktopUploadSectionOptions.cs
@@ -8,41 +8,59 @@ public sealed class DesktopUploadSectionOptions
     public const string DevFakeUploadHashEnabledEnvironmentVariable =
         "AA_DESKTOP_DEV_FAKE_UPLOAD_HASH_ENABLED";
 
+    public const string DevFakeBusinessObjectKeyEnabledEnvironmentVariable =
+        "AA_DESKTOP_DEV_FAKE_BUSINESS_OBJECT_KEY_ENABLED";
+
     private DesktopUploadSectionOptions(
         bool isDevFakeUploadFileEnabled,
-        bool isDevFakeUploadHashEnabled)
+        bool isDevFakeUploadHashEnabled,
+        bool isDevFakeBusinessObjectKeyEnabled)
     {
         IsDevFakeUploadFileEnabled = isDevFakeUploadFileEnabled;
         IsDevFakeUploadHashEnabled = isDevFakeUploadHashEnabled;
+        IsDevFakeBusinessObjectKeyEnabled = isDevFakeBusinessObjectKeyEnabled;
     }
 
     public static DesktopUploadSectionOptions Disabled { get; } = new(
         isDevFakeUploadFileEnabled: false,
-        isDevFakeUploadHashEnabled: false);
+        isDevFakeUploadHashEnabled: false,
+        isDevFakeBusinessObjectKeyEnabled: false);
 
 #if DEBUG
     public static DesktopUploadSectionOptions EnabledForDevFakeFileSelection { get; } = new(
         isDevFakeUploadFileEnabled: true,
-        isDevFakeUploadHashEnabled: false);
+        isDevFakeUploadHashEnabled: false,
+        isDevFakeBusinessObjectKeyEnabled: false);
 
     public static DesktopUploadSectionOptions EnabledForDevFakeFileSelectionAndHash { get; } = new(
         isDevFakeUploadFileEnabled: true,
-        isDevFakeUploadHashEnabled: true);
+        isDevFakeUploadHashEnabled: true,
+        isDevFakeBusinessObjectKeyEnabled: false);
+
+    public static DesktopUploadSectionOptions EnabledForDevFakeBusinessObjectKey { get; } = new(
+        isDevFakeUploadFileEnabled: false,
+        isDevFakeUploadHashEnabled: false,
+        isDevFakeBusinessObjectKeyEnabled: true);
 #else
     public static DesktopUploadSectionOptions EnabledForDevFakeFileSelection => Disabled;
 
     public static DesktopUploadSectionOptions EnabledForDevFakeFileSelectionAndHash => Disabled;
+
+    public static DesktopUploadSectionOptions EnabledForDevFakeBusinessObjectKey => Disabled;
 #endif
 
     public bool IsDevFakeUploadFileEnabled { get; }
 
     public bool IsDevFakeUploadHashEnabled { get; }
 
+    public bool IsDevFakeBusinessObjectKeyEnabled { get; }
+
     public static DesktopUploadSectionOptions FromEnvironment()
     {
         return FromEnvironmentValue(
             Environment.GetEnvironmentVariable(DevFakeUploadFileEnabledEnvironmentVariable),
-            Environment.GetEnvironmentVariable(DevFakeUploadHashEnabledEnvironmentVariable));
+            Environment.GetEnvironmentVariable(DevFakeUploadHashEnabledEnvironmentVariable),
+            Environment.GetEnvironmentVariable(DevFakeBusinessObjectKeyEnabledEnvironmentVariable));
     }
 
     public static DesktopUploadSectionOptions FromEnvironmentValue(string? devFakeUploadFileEnabled)
@@ -56,35 +74,37 @@ public sealed class DesktopUploadSectionOptions
         string? devFakeUploadFileEnabled,
         string? devFakeUploadHashEnabled)
     {
+        return FromEnvironmentValue(
+            devFakeUploadFileEnabled,
+            devFakeUploadHashEnabled,
+            devFakeBusinessObjectKeyEnabled: null);
+    }
+
+    public static DesktopUploadSectionOptions FromEnvironmentValue(
+        string? devFakeUploadFileEnabled,
+        string? devFakeUploadHashEnabled,
+        string? devFakeBusinessObjectKeyEnabled)
+    {
 #if DEBUG
         bool isFakeFileEnabled = IsDevFakeUploadFileEnabledValue(devFakeUploadFileEnabled);
         bool isFakeHashEnabled = IsDevFakeUploadHashEnabledValue(devFakeUploadHashEnabled);
+        bool isFakeBusinessObjectKeyEnabled =
+            IsDevFakeBusinessObjectKeyEnabledValue(devFakeBusinessObjectKeyEnabled);
 
-        if (isFakeFileEnabled && isFakeHashEnabled)
-        {
-            return EnabledForDevFakeFileSelectionAndHash;
-        }
-
-        if (isFakeFileEnabled)
-        {
-            return EnabledForDevFakeFileSelection;
-        }
-
-        if (isFakeHashEnabled)
-        {
-            return new DesktopUploadSectionOptions(
-                isDevFakeUploadFileEnabled: false,
-                isDevFakeUploadHashEnabled: true);
-        }
-#endif
-
+        return new DesktopUploadSectionOptions(
+            isFakeFileEnabled,
+            isFakeHashEnabled,
+            isFakeBusinessObjectKeyEnabled);
+#else
         return Disabled;
+#endif
     }
 
     public override string ToString()
     {
         return $"{nameof(DesktopUploadSectionOptions)} {{ IsDevFakeUploadFileEnabled = {IsDevFakeUploadFileEnabled}, "
-            + $"IsDevFakeUploadHashEnabled = {IsDevFakeUploadHashEnabled} }}";
+            + $"IsDevFakeUploadHashEnabled = {IsDevFakeUploadHashEnabled}, "
+            + $"IsDevFakeBusinessObjectKeyEnabled = {IsDevFakeBusinessObjectKeyEnabled} }}";
     }
 
     private static bool IsDevFakeUploadFileEnabledValue(string? value)
@@ -93,6 +113,11 @@ public sealed class DesktopUploadSectionOptions
     }
 
     private static bool IsDevFakeUploadHashEnabledValue(string? value)
+    {
+        return string.Equals(value?.Trim(), "true", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsDevFakeBusinessObjectKeyEnabledValue(string? value)
     {
         return string.Equals(value?.Trim(), "true", StringComparison.OrdinalIgnoreCase);
     }

--- a/src/App.Desktop/Services/Upload/DesktopUploadSectionViewModel.cs
+++ b/src/App.Desktop/Services/Upload/DesktopUploadSectionViewModel.cs
@@ -4,12 +4,22 @@ namespace App.Desktop.Services.Upload;
 
 public sealed class DesktopUploadSectionViewModel(
     IDesktopVideoFilePicker videoFilePicker,
-    IDesktopVideoHashService videoHashService)
+    IDesktopVideoHashService videoHashService,
+    DesktopUploadSectionOptions uploadSectionOptions)
 {
+    public DesktopUploadSectionViewModel(
+        IDesktopVideoFilePicker videoFilePicker,
+        IDesktopVideoHashService videoHashService)
+        : this(videoFilePicker, videoHashService, DesktopUploadSectionOptions.Disabled)
+    {
+    }
+
     private readonly IDesktopVideoFilePicker _videoFilePicker =
         videoFilePicker ?? throw new ArgumentNullException(nameof(videoFilePicker));
     private readonly IDesktopVideoHashService _videoHashService =
         videoHashService ?? throw new ArgumentNullException(nameof(videoHashService));
+    private readonly DesktopUploadSectionOptions _uploadSectionOptions =
+        uploadSectionOptions ?? throw new ArgumentNullException(nameof(uploadSectionOptions));
 
     private DesktopVideoHashRequest? _selectedFileHashRequest;
 
@@ -34,6 +44,20 @@ public sealed class DesktopUploadSectionViewModel(
     public string? Sha256Hex { get; private set; }
 
     public bool HasSha256Hash => Sha256Hex is not null;
+
+    public bool IsDevFakeBusinessObjectKeyEnabled =>
+        _uploadSectionOptions.IsDevFakeBusinessObjectKeyEnabled;
+
+    public string BusinessObjectKeyInput { get; set; } = string.Empty;
+
+    public DesktopUploadBusinessObjectKey? BusinessObjectKey { get; private set; }
+
+    public bool HasBusinessObjectKey => BusinessObjectKey is not null;
+
+    public string? BusinessObjectKeyPreview => BusinessObjectKey?.Value;
+
+    public string BusinessObjectKeyStatusMessage { get; private set; } =
+        DesktopUploadSectionText.BusinessObjectKeyEmptyValidationMessage;
 
     public void OpenUploadSection()
     {
@@ -62,6 +86,7 @@ public sealed class DesktopUploadSectionViewModel(
         IsSelectingFile = true;
         SelectionStatusMessage = DesktopUploadSectionText.SelectingFileMessage;
         ResetSelectedFileHashState();
+        ResetBusinessObjectKeyState();
 
         try
         {
@@ -140,11 +165,35 @@ public sealed class DesktopUploadSectionViewModel(
         }
     }
 
+    public DesktopUploadBusinessObjectKeyValidation ApplyBusinessObjectKey()
+    {
+        DesktopUploadBusinessObjectKeyValidation validation =
+            DesktopUploadBusinessObjectKeyValidator.ValidateManualInput(BusinessObjectKeyInput);
+
+        BusinessObjectKeyInput = validation.SafeInputValue;
+        BusinessObjectKey = validation.BusinessObjectKey;
+        BusinessObjectKeyStatusMessage = validation.Message;
+
+        return validation;
+    }
+
+    public DesktopUploadBusinessObjectKeyValidation? UseDevFakeBusinessObjectKey()
+    {
+        if (!IsDevFakeBusinessObjectKeyEnabled)
+        {
+            return null;
+        }
+
+        BusinessObjectKeyInput = DesktopUploadBusinessObjectKey.VisualSmokeValue;
+        return ApplyBusinessObjectKey();
+    }
+
     private void ResetSelection()
     {
         SelectedFile = null;
         SelectionStatusMessage = DesktopUploadSectionText.PlaceholderResult;
         ResetSelectedFileHashState();
+        ResetBusinessObjectKeyState();
     }
 
     private void ResetSelectedFileHashState()
@@ -153,5 +202,12 @@ public sealed class DesktopUploadSectionViewModel(
         IsHashing = false;
         Sha256Hex = null;
         HashStatusMessage = DesktopUploadSectionText.HashNotReadyMessage;
+    }
+
+    private void ResetBusinessObjectKeyState()
+    {
+        BusinessObjectKeyInput = string.Empty;
+        BusinessObjectKey = null;
+        BusinessObjectKeyStatusMessage = DesktopUploadSectionText.BusinessObjectKeyEmptyValidationMessage;
     }
 }

--- a/src/App.Desktop/wwwroot/app.css
+++ b/src/App.Desktop/wwwroot/app.css
@@ -280,7 +280,8 @@ body {
 
 .desktop-upload__back,
 .desktop-upload__select,
-.desktop-upload__hash {
+.desktop-upload__hash,
+.desktop-upload__key {
     min-height: 38px;
     padding: 0 16px;
     border-radius: 6px;
@@ -297,7 +298,8 @@ body {
 }
 
 .desktop-upload__select,
-.desktop-upload__hash {
+.desktop-upload__hash,
+.desktop-upload__key {
     width: fit-content;
     border: 1px solid #18406b;
     background: #18406b;
@@ -306,10 +308,17 @@ body {
 
 .desktop-upload__back:disabled,
 .desktop-upload__select:disabled,
-.desktop-upload__hash:disabled {
+.desktop-upload__hash:disabled,
+.desktop-upload__key:disabled {
     color: #687789;
     border-color: #b9c3cf;
     background: #eef1f5;
+}
+
+.desktop-upload__key--secondary {
+    border-color: #54708b;
+    background: #ffffff;
+    color: #253241;
 }
 
 .desktop-upload__step {
@@ -336,8 +345,43 @@ body {
     line-height: 1.4;
 }
 
+.desktop-upload__field {
+    display: grid;
+    gap: 6px;
+    color: #2b3644;
+    font-size: 0.85rem;
+    font-weight: 650;
+}
+
+.desktop-upload__field input {
+    min-width: 0;
+    height: 38px;
+    box-sizing: border-box;
+    padding: 7px 9px;
+    border: 1px solid #bac4d0;
+    border-radius: 6px;
+    color: #18212f;
+    font: inherit;
+    font-weight: 400;
+}
+
+.desktop-upload__hint,
+.desktop-upload__deferred {
+    margin: 0;
+    color: #52616f;
+    font-size: 0.84rem;
+    line-height: 1.4;
+}
+
+.desktop-upload__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
 .desktop-upload__selection,
-.desktop-upload__hash-result {
+.desktop-upload__hash-result,
+.desktop-upload__business-object-key {
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 12px;
@@ -348,8 +392,13 @@ body {
     grid-template-columns: minmax(0, 1fr);
 }
 
+.desktop-upload__business-object-key {
+    grid-template-columns: minmax(0, 1fr);
+}
+
 .desktop-upload__selection div,
-.desktop-upload__hash-result div {
+.desktop-upload__hash-result div,
+.desktop-upload__business-object-key div {
     min-width: 0;
     padding: 12px;
     border: 1px solid #d7dde5;
@@ -358,7 +407,8 @@ body {
 }
 
 .desktop-upload__selection dt,
-.desktop-upload__hash-result dt {
+.desktop-upload__hash-result dt,
+.desktop-upload__business-object-key dt {
     margin: 0 0 4px;
     color: #52616f;
     font-size: 0.78rem;
@@ -366,7 +416,8 @@ body {
 }
 
 .desktop-upload__selection dd,
-.desktop-upload__hash-result dd {
+.desktop-upload__hash-result dd,
+.desktop-upload__business-object-key dd {
     margin: 0;
     color: #18212f;
     font-size: 0.9rem;
@@ -396,12 +447,18 @@ body {
 
     .desktop-upload__back,
     .desktop-upload__select,
-    .desktop-upload__hash {
+    .desktop-upload__hash,
+    .desktop-upload__key {
         width: 100%;
     }
 
     .desktop-upload__selection,
-    .desktop-upload__hash-result {
+    .desktop-upload__hash-result,
+    .desktop-upload__business-object-key {
         grid-template-columns: 1fr;
+    }
+
+    .desktop-upload__actions {
+        flex-direction: column;
     }
 }

--- a/tests/Unit/App.Desktop.Tests/DesktopCompositionRootTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopCompositionRootTests.cs
@@ -22,6 +22,7 @@ public sealed class DesktopCompositionRootTests
         Assert.IsType<DesktopUploadSectionViewModel>(services.GetRequiredService<DesktopUploadSectionViewModel>());
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
         Assert.IsType<WpfDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
         Assert.IsType<DesktopVideoHashService>(services.GetRequiredService<IDesktopVideoHashService>());
     }
@@ -33,13 +34,15 @@ public sealed class DesktopCompositionRootTests
             .Set(DesktopAuthOptions.ControlPlaneBaseAddressEnvironmentVariable, null)
             .Set(DesktopAuthOptions.DevFakeAuthEnabledEnvironmentVariable, null)
             .Set(DesktopUploadSectionOptions.DevFakeUploadFileEnabledEnvironmentVariable, null)
-            .Set(DesktopUploadSectionOptions.DevFakeUploadHashEnabledEnvironmentVariable, null);
+            .Set(DesktopUploadSectionOptions.DevFakeUploadHashEnabledEnvironmentVariable, null)
+            .Set(DesktopUploadSectionOptions.DevFakeBusinessObjectKeyEnabledEnvironmentVariable, null);
 
         using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
 
         Assert.False(services.GetRequiredService<DesktopAuthOptions>().IsDevFakeAuthEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
         Assert.IsType<UnavailableDesktopAuthClient>(services.GetRequiredService<IDesktopAuthClient>());
         Assert.IsType<WpfDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
         Assert.IsType<DesktopVideoHashService>(services.GetRequiredService<IDesktopVideoHashService>());
@@ -52,18 +55,21 @@ public sealed class DesktopCompositionRootTests
             .Set(DesktopAuthOptions.ControlPlaneBaseAddressEnvironmentVariable, null)
             .Set(DesktopAuthOptions.DevFakeAuthEnabledEnvironmentVariable, null)
             .Set(DesktopUploadSectionOptions.DevFakeUploadFileEnabledEnvironmentVariable, "true")
-            .Set(DesktopUploadSectionOptions.DevFakeUploadHashEnabledEnvironmentVariable, null);
+            .Set(DesktopUploadSectionOptions.DevFakeUploadHashEnabledEnvironmentVariable, null)
+            .Set(DesktopUploadSectionOptions.DevFakeBusinessObjectKeyEnabledEnvironmentVariable, null);
 
         using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
 
 #if DEBUG
         Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
         Assert.IsType<FakeDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
         Assert.IsType<DesktopVideoHashService>(services.GetRequiredService<IDesktopVideoHashService>());
 #else
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
         Assert.IsType<WpfDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
         Assert.IsType<DesktopVideoHashService>(services.GetRequiredService<IDesktopVideoHashService>());
 #endif
@@ -76,18 +82,21 @@ public sealed class DesktopCompositionRootTests
             .Set(DesktopAuthOptions.ControlPlaneBaseAddressEnvironmentVariable, null)
             .Set(DesktopAuthOptions.DevFakeAuthEnabledEnvironmentVariable, null)
             .Set(DesktopUploadSectionOptions.DevFakeUploadFileEnabledEnvironmentVariable, null)
-            .Set(DesktopUploadSectionOptions.DevFakeUploadHashEnabledEnvironmentVariable, "true");
+            .Set(DesktopUploadSectionOptions.DevFakeUploadHashEnabledEnvironmentVariable, "true")
+            .Set(DesktopUploadSectionOptions.DevFakeBusinessObjectKeyEnabledEnvironmentVariable, null);
 
         using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
 
 #if DEBUG
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
         Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
         Assert.IsType<WpfDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
         Assert.IsType<FakeDesktopVideoHashService>(services.GetRequiredService<IDesktopVideoHashService>());
 #else
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
         Assert.IsType<WpfDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
         Assert.IsType<DesktopVideoHashService>(services.GetRequiredService<IDesktopVideoHashService>());
 #endif
@@ -100,18 +109,78 @@ public sealed class DesktopCompositionRootTests
             .Set(DesktopAuthOptions.ControlPlaneBaseAddressEnvironmentVariable, null)
             .Set(DesktopAuthOptions.DevFakeAuthEnabledEnvironmentVariable, null)
             .Set(DesktopUploadSectionOptions.DevFakeUploadFileEnabledEnvironmentVariable, "true")
-            .Set(DesktopUploadSectionOptions.DevFakeUploadHashEnabledEnvironmentVariable, "true");
+            .Set(DesktopUploadSectionOptions.DevFakeUploadHashEnabledEnvironmentVariable, "true")
+            .Set(DesktopUploadSectionOptions.DevFakeBusinessObjectKeyEnabledEnvironmentVariable, null);
 
         using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
 
 #if DEBUG
         Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
         Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
         Assert.IsType<FakeDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
         Assert.IsType<FakeDesktopVideoHashService>(services.GetRequiredService<IDesktopVideoHashService>());
 #else
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
+        Assert.IsType<WpfDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
+        Assert.IsType<DesktopVideoHashService>(services.GetRequiredService<IDesktopVideoHashService>());
+#endif
+    }
+
+    [Fact]
+    public void EnvironmentOptionsEnableFakeBusinessObjectKeyOnlyWhenExplicitlyRequested()
+    {
+        using var environment = new EnvironmentVariableScope()
+            .Set(DesktopAuthOptions.ControlPlaneBaseAddressEnvironmentVariable, null)
+            .Set(DesktopAuthOptions.DevFakeAuthEnabledEnvironmentVariable, null)
+            .Set(DesktopUploadSectionOptions.DevFakeUploadFileEnabledEnvironmentVariable, null)
+            .Set(DesktopUploadSectionOptions.DevFakeUploadHashEnabledEnvironmentVariable, null)
+            .Set(DesktopUploadSectionOptions.DevFakeBusinessObjectKeyEnabledEnvironmentVariable, "true");
+
+        using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
+
+#if DEBUG
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
+        Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
+        Assert.True(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakeBusinessObjectKeyEnabled);
+#else
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakeBusinessObjectKeyEnabled);
+#endif
+    }
+
+    [Fact]
+    public void EnvironmentOptionsEnableFakeUploadFileHashAndBusinessObjectKeyTogetherForVisualSmoke()
+    {
+        using var environment = new EnvironmentVariableScope()
+            .Set(DesktopAuthOptions.ControlPlaneBaseAddressEnvironmentVariable, null)
+            .Set(DesktopAuthOptions.DevFakeAuthEnabledEnvironmentVariable, "true")
+            .Set(DesktopUploadSectionOptions.DevFakeUploadFileEnabledEnvironmentVariable, "true")
+            .Set(DesktopUploadSectionOptions.DevFakeUploadHashEnabledEnvironmentVariable, "true")
+            .Set(DesktopUploadSectionOptions.DevFakeBusinessObjectKeyEnabledEnvironmentVariable, "true");
+
+        using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
+
+#if DEBUG
+        Assert.True(services.GetRequiredService<DesktopAuthOptions>().IsDevFakeAuthEnabled);
+        Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
+        Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
+        Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
+        Assert.IsType<FakeDesktopAuthClient>(services.GetRequiredService<IDesktopAuthClient>());
+        Assert.IsType<FakeDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
+        Assert.IsType<FakeDesktopVideoHashService>(services.GetRequiredService<IDesktopVideoHashService>());
+        Assert.True(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakeBusinessObjectKeyEnabled);
+#else
+        Assert.False(services.GetRequiredService<DesktopAuthOptions>().IsDevFakeAuthEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
+        Assert.IsType<UnavailableDesktopAuthClient>(services.GetRequiredService<IDesktopAuthClient>());
         Assert.IsType<WpfDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
         Assert.IsType<DesktopVideoHashService>(services.GetRequiredService<IDesktopVideoHashService>());
 #endif

--- a/tests/Unit/App.Desktop.Tests/DesktopSignInServiceTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopSignInServiceTests.cs
@@ -213,7 +213,8 @@ public sealed class DesktopSignInServiceTests
 
         Assert.Contains("@bind-value=\"SignInViewModel.Login\"", markup, StringComparison.Ordinal);
         Assert.Contains("@bind-value=\"SignInViewModel.Password\"", markup, StringComparison.Ordinal);
-        Assert.Equal(2, CountOccurrences(markup, "@bind-value:event=\"oninput\""));
+        Assert.Contains("@bind-value=\"UploadSectionViewModel.BusinessObjectKeyInput\"", markup, StringComparison.Ordinal);
+        Assert.Equal(3, CountOccurrences(markup, "@bind-value:event=\"oninput\""));
         Assert.DoesNotContain("@oninput=\"UpdateLogin\"", markup, StringComparison.Ordinal);
         Assert.DoesNotContain("@oninput=\"UpdatePassword\"", markup, StringComparison.Ordinal);
     }
@@ -263,11 +264,15 @@ public sealed class DesktopSignInServiceTests
         Assert.Contains("UploadSectionViewModel.CalculateSha256Async(CancellationToken.None)", markup, StringComparison.Ordinal);
         Assert.Contains("UploadSectionViewModel.CanCalculateHash", markup, StringComparison.Ordinal);
         Assert.Contains("UploadSectionViewModel.Sha256Hex", markup, StringComparison.Ordinal);
+        Assert.Contains("DesktopUploadSectionText.StepThreeTitle", markup, StringComparison.Ordinal);
+        Assert.Contains("UploadSectionViewModel.BusinessObjectKeyInput", markup, StringComparison.Ordinal);
+        Assert.Contains("UploadSectionViewModel.ApplyBusinessObjectKey()", markup, StringComparison.Ordinal);
+        Assert.Contains("UploadSectionViewModel.UseDevFakeBusinessObjectKey()", markup, StringComparison.Ordinal);
         Assert.DoesNotContain("<UploadPlaceholder", markup, StringComparison.Ordinal);
         Assert.DoesNotContain("IDesktopUploadOrchestrator", markup, StringComparison.Ordinal);
         Assert.DoesNotContain("IControlPlaneApiClient", markup, StringComparison.Ordinal);
         Assert.DoesNotContain("IDesktopFilePicker", markup, StringComparison.Ordinal);
-        Assert.DoesNotContain("PreUploadCheck", markup, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("RequestPreUploadCheckAsync", markup, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/Unit/App.Desktop.Tests/DesktopUploadSectionTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopUploadSectionTests.cs
@@ -219,7 +219,7 @@ public sealed class DesktopUploadSectionTests
     }
 
     [Fact]
-    public void MultilineOrControlCharacterBusinessObjectKeyIsRejectedAndInputIsMadeSingleLine()
+    public void MultilineOrControlCharacterBusinessObjectKeyWithoutBlockedFragmentIsRejectedAndInputIsMadeSingleLine()
     {
         var viewModel = CreateViewModel(new FakeDesktopVideoFilePicker());
         viewModel.BusinessObjectKeyInput = "safe-key\r\nhidden";
@@ -235,6 +235,42 @@ public sealed class DesktopUploadSectionTests
         Assert.Equal(
             DesktopUploadSectionText.BusinessObjectKeyControlCharacterValidationMessage,
             viewModel.BusinessObjectKeyStatusMessage);
+    }
+
+    [Theory]
+    [InlineData("tok\nen", "token")]
+    [InlineData("ac\ncessToken", "accessToken")]
+    [InlineData("refresh\rToken", "refreshToken")]
+    [InlineData("authori\tzation", "authorization")]
+    [InlineData("pass\nword", "password")]
+    public void ControlCharacterBusinessObjectKeyWithBlockedFragmentIsRejectedAndCleared(
+        string input,
+        string blockedFragment)
+    {
+        var viewModel = CreateViewModel(new FakeDesktopVideoFilePicker());
+        viewModel.BusinessObjectKeyInput = input;
+
+        DesktopUploadBusinessObjectKeyValidation validation = viewModel.ApplyBusinessObjectKey();
+
+        Assert.False(validation.IsValid);
+        Assert.Null(validation.BusinessObjectKey);
+        Assert.Null(viewModel.BusinessObjectKey);
+        Assert.Null(viewModel.BusinessObjectKeyPreview);
+        Assert.False(viewModel.HasBusinessObjectKey);
+        Assert.Equal(string.Empty, validation.SafeInputValue);
+        Assert.Equal(string.Empty, viewModel.BusinessObjectKeyInput);
+        Assert.Equal(
+            DesktopUploadSectionText.BusinessObjectKeySecretValidationMessage,
+            viewModel.BusinessObjectKeyStatusMessage);
+
+        string visibleState = validation.SafeInputValue
+            + " "
+            + viewModel.BusinessObjectKeyInput
+            + " "
+            + (viewModel.BusinessObjectKeyPreview ?? string.Empty)
+            + " "
+            + viewModel.BusinessObjectKeyStatusMessage;
+        Assert.DoesNotContain(blockedFragment, visibleState, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/tests/Unit/App.Desktop.Tests/DesktopUploadSectionTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopUploadSectionTests.cs
@@ -61,6 +61,30 @@ public sealed class DesktopUploadSectionTests
         Assert.Equal("Не удалось рассчитать SHA-256 для выбранного файла.", DesktopUploadSectionText.HashUnavailableMessage);
         Assert.Equal("Расчёт SHA-256 отменён.", DesktopUploadSectionText.HashCanceledMessage);
         Assert.Equal("SHA-256", DesktopUploadSectionText.Sha256ResultLabel);
+        Assert.Equal("Шаг 3. Бизнес-объект", DesktopUploadSectionText.StepThreeTitle);
+        Assert.Equal("Ключ бизнес-объекта", DesktopUploadSectionText.BusinessObjectKeyLabel);
+        Assert.Equal(
+            "Временный ручной ввод для desktop prototype. Production-источник будет утверждён отдельным slice.",
+            DesktopUploadSectionText.BusinessObjectKeyHint);
+        Assert.Equal("Проверить ключ", DesktopUploadSectionText.BusinessObjectKeyApplyButton);
+        Assert.Equal("Подставить dev-ключ", DesktopUploadSectionText.BusinessObjectKeyUseFakeButton);
+        Assert.Equal("Введите ключ бизнес-объекта.", DesktopUploadSectionText.BusinessObjectKeyEmptyValidationMessage);
+        Assert.Equal(
+            "Ключ бизнес-объекта не должен содержать переносы строк или управляющие символы.",
+            DesktopUploadSectionText.BusinessObjectKeyControlCharacterValidationMessage);
+        Assert.Equal(
+            "Ключ бизнес-объекта должен быть от 1 до 128 символов.",
+            DesktopUploadSectionText.BusinessObjectKeyLengthValidationMessage);
+        Assert.Equal(
+            "Ключ бизнес-объекта не должен содержать секретные значения.",
+            DesktopUploadSectionText.BusinessObjectKeySecretValidationMessage);
+        Assert.Equal(
+            "Ключ бизнес-объекта принят для безопасного preview.",
+            DesktopUploadSectionText.BusinessObjectKeyAcceptedMessage);
+        Assert.Equal("businessObjectKey", DesktopUploadSectionText.BusinessObjectKeyPreviewLabel);
+        Assert.Equal(
+            "Следующий шаг отложен: PreUploadCheck будет добавлен отдельным approved desktop slice.",
+            DesktopUploadSectionText.NextStepDeferredMessage);
     }
 
     [Fact]
@@ -74,6 +98,7 @@ public sealed class DesktopUploadSectionTests
             Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "FakeDesktopVideoFilePicker.cs"),
             Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "FakeDesktopVideoHashService.cs"),
             Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "DesktopVideoHashService.cs"),
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "DesktopUploadBusinessObjectKey.cs"),
             Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "WpfDesktopVideoFilePicker.cs"),
             Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Boundaries", "DesktopVideoFilePickerBoundary.cs"),
             Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Boundaries", "DesktopVideoHashBoundary.cs")
@@ -86,8 +111,10 @@ public sealed class DesktopUploadSectionTests
             Assert.DoesNotContain("App.Api", source, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("IControlPlaneApiClient", source, StringComparison.Ordinal);
             Assert.DoesNotContain("IDesktopUploadOrchestrator", source, StringComparison.Ordinal);
-            Assert.DoesNotContain("businessObjectKey", source, StringComparison.OrdinalIgnoreCase);
-            Assert.DoesNotContain("PreUploadCheck", source, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("RequestPreUploadCheckAsync", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("ControlPlanePreUploadCheckRequest", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("RecordUploadReceiptAsync", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("ControlPlaneUploadReceiptDraft", source, StringComparison.Ordinal);
             Assert.DoesNotContain("DirectSiteUpload", source, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("UploadReceipt", source, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("ReadAllBytes", source, StringComparison.OrdinalIgnoreCase);
@@ -95,24 +122,156 @@ public sealed class DesktopUploadSectionTests
     }
 
     [Fact]
-    public void FakeUploadFileSelectionAndHashAreDevOnlyAndDisabledByDefault()
+    public void FakeUploadFileSelectionHashAndBusinessObjectKeyAreDevOnlyAndDisabledByDefault()
     {
         Assert.False(DesktopUploadSectionOptions.Disabled.IsDevFakeUploadFileEnabled);
         Assert.False(DesktopUploadSectionOptions.Disabled.IsDevFakeUploadHashEnabled);
+        Assert.False(DesktopUploadSectionOptions.Disabled.IsDevFakeBusinessObjectKeyEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue(null).IsDevFakeUploadFileEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue(null).IsDevFakeUploadHashEnabled);
+        Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue(null).IsDevFakeBusinessObjectKeyEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("false").IsDevFakeUploadFileEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("false", "false").IsDevFakeUploadHashEnabled);
+        Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "false").IsDevFakeBusinessObjectKeyEnabled);
 
 #if DEBUG
         Assert.True(DesktopUploadSectionOptions.FromEnvironmentValue("true").IsDevFakeUploadFileEnabled);
         Assert.True(DesktopUploadSectionOptions.FromEnvironmentValue("false", "true").IsDevFakeUploadHashEnabled);
         Assert.True(DesktopUploadSectionOptions.FromEnvironmentValue("true", "true").IsDevFakeUploadHashEnabled);
+        Assert.True(DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "true").IsDevFakeBusinessObjectKeyEnabled);
+        Assert.True(DesktopUploadSectionOptions.FromEnvironmentValue("true", "true", "true").IsDevFakeBusinessObjectKeyEnabled);
 #else
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("true").IsDevFakeUploadFileEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("false", "true").IsDevFakeUploadHashEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("true", "true").IsDevFakeUploadHashEnabled);
+        Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "true").IsDevFakeBusinessObjectKeyEnabled);
+        Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("true", "true", "true").IsDevFakeBusinessObjectKeyEnabled);
 #endif
+    }
+
+    [Fact]
+    public void FakeBusinessObjectKeyIsDisabledByDefault()
+    {
+        var viewModel = CreateViewModel(new FakeDesktopVideoFilePicker());
+
+        DesktopUploadBusinessObjectKeyValidation? validation = viewModel.UseDevFakeBusinessObjectKey();
+
+        Assert.False(viewModel.IsDevFakeBusinessObjectKeyEnabled);
+        Assert.Null(validation);
+        Assert.Null(viewModel.BusinessObjectKey);
+        Assert.Null(viewModel.BusinessObjectKeyPreview);
+        Assert.False(viewModel.HasBusinessObjectKey);
+        Assert.Equal(string.Empty, viewModel.BusinessObjectKeyInput);
+    }
+
+    [Fact]
+    public void FakeBusinessObjectKeyUsesVisualSmokeValueWhenExplicitlyEnabled()
+    {
+        var viewModel = CreateViewModel(
+            new FakeDesktopVideoFilePicker(),
+            new FakeDesktopVideoHashService(),
+            DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "true"));
+
+        DesktopUploadBusinessObjectKeyValidation? validation = viewModel.UseDevFakeBusinessObjectKey();
+
+#if DEBUG
+        Assert.NotNull(validation);
+        Assert.True(validation.IsValid);
+        Assert.True(viewModel.IsDevFakeBusinessObjectKeyEnabled);
+        Assert.Equal(DesktopUploadBusinessObjectKey.VisualSmokeValue, viewModel.BusinessObjectKeyInput);
+        Assert.Equal("visual-smoke-business-object-001", viewModel.BusinessObjectKeyPreview);
+        Assert.Equal(DesktopUploadSectionText.BusinessObjectKeyAcceptedMessage, viewModel.BusinessObjectKeyStatusMessage);
+#else
+        Assert.Null(validation);
+        Assert.False(viewModel.IsDevFakeBusinessObjectKeyEnabled);
+        Assert.Null(viewModel.BusinessObjectKeyPreview);
+#endif
+    }
+
+    [Fact]
+    public void ManualBusinessObjectKeyTrimsWhitespaceAndShowsSafePreview()
+    {
+        var viewModel = CreateViewModel(new FakeDesktopVideoFilePicker());
+        viewModel.BusinessObjectKeyInput = "  report-draft-001  ";
+
+        DesktopUploadBusinessObjectKeyValidation validation = viewModel.ApplyBusinessObjectKey();
+
+        Assert.True(validation.IsValid);
+        Assert.Equal("report-draft-001", viewModel.BusinessObjectKeyInput);
+        Assert.Equal("report-draft-001", viewModel.BusinessObjectKeyPreview);
+        Assert.True(viewModel.HasBusinessObjectKey);
+        Assert.Equal(DesktopUploadSectionText.BusinessObjectKeyAcceptedMessage, viewModel.BusinessObjectKeyStatusMessage);
+    }
+
+    [Fact]
+    public void EmptyBusinessObjectKeyShowsSafeRussianValidationMessage()
+    {
+        var viewModel = CreateViewModel(new FakeDesktopVideoFilePicker());
+        viewModel.BusinessObjectKeyInput = "   ";
+
+        DesktopUploadBusinessObjectKeyValidation validation = viewModel.ApplyBusinessObjectKey();
+
+        Assert.False(validation.IsValid);
+        Assert.Null(viewModel.BusinessObjectKey);
+        Assert.Null(viewModel.BusinessObjectKeyPreview);
+        Assert.Equal(string.Empty, viewModel.BusinessObjectKeyInput);
+        Assert.Equal(DesktopUploadSectionText.BusinessObjectKeyEmptyValidationMessage, viewModel.BusinessObjectKeyStatusMessage);
+    }
+
+    [Fact]
+    public void MultilineOrControlCharacterBusinessObjectKeyIsRejectedAndInputIsMadeSingleLine()
+    {
+        var viewModel = CreateViewModel(new FakeDesktopVideoFilePicker());
+        viewModel.BusinessObjectKeyInput = "safe-key\r\nhidden";
+
+        DesktopUploadBusinessObjectKeyValidation validation = viewModel.ApplyBusinessObjectKey();
+
+        Assert.False(validation.IsValid);
+        Assert.Null(viewModel.BusinessObjectKey);
+        Assert.Null(viewModel.BusinessObjectKeyPreview);
+        Assert.DoesNotContain("\r", viewModel.BusinessObjectKeyInput, StringComparison.Ordinal);
+        Assert.DoesNotContain("\n", viewModel.BusinessObjectKeyInput, StringComparison.Ordinal);
+        Assert.Equal("safe-keyhidden", viewModel.BusinessObjectKeyInput);
+        Assert.Equal(
+            DesktopUploadSectionText.BusinessObjectKeyControlCharacterValidationMessage,
+            viewModel.BusinessObjectKeyStatusMessage);
+    }
+
+    [Fact]
+    public void BusinessObjectKeyLengthLimitIsEnforced()
+    {
+        var viewModel = CreateViewModel(new FakeDesktopVideoFilePicker());
+        viewModel.BusinessObjectKeyInput = new string('a', DesktopUploadBusinessObjectKey.MaxLength + 1);
+
+        DesktopUploadBusinessObjectKeyValidation validation = viewModel.ApplyBusinessObjectKey();
+
+        Assert.False(validation.IsValid);
+        Assert.Null(viewModel.BusinessObjectKey);
+        Assert.Null(viewModel.BusinessObjectKeyPreview);
+        Assert.Equal(DesktopUploadBusinessObjectKey.MaxLength, viewModel.BusinessObjectKeyInput.Length);
+        Assert.Equal(DesktopUploadSectionText.BusinessObjectKeyLengthValidationMessage, viewModel.BusinessObjectKeyStatusMessage);
+    }
+
+    [Fact]
+    public void BusinessObjectKeyPreviewDoesNotContainTokensPasswordOrAuthorization()
+    {
+        var viewModel = CreateViewModel(new FakeDesktopVideoFilePicker());
+        viewModel.BusinessObjectKeyInput = "Authorization-password-token";
+
+        DesktopUploadBusinessObjectKeyValidation validation = viewModel.ApplyBusinessObjectKey();
+
+        Assert.False(validation.IsValid);
+        Assert.Null(viewModel.BusinessObjectKeyPreview);
+        Assert.Equal(string.Empty, viewModel.BusinessObjectKeyInput);
+
+        string visibleState = viewModel.BusinessObjectKeyStatusMessage
+            + " "
+            + (viewModel.BusinessObjectKeyPreview ?? string.Empty);
+        Assert.DoesNotContain("password", visibleState, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Authorization", visibleState, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("accessToken", visibleState, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("refreshToken", visibleState, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("token", visibleState, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -298,6 +457,8 @@ public sealed class DesktopUploadSectionTests
         viewModel.OpenUploadSection();
         _ = await viewModel.SelectVideoFileAsync(CancellationToken.None);
         _ = await viewModel.CalculateSha256Async(CancellationToken.None);
+        viewModel.BusinessObjectKeyInput = "report-draft-001";
+        _ = viewModel.ApplyBusinessObjectKey();
 
         viewModel.ResetForSignedOutState();
 
@@ -308,6 +469,10 @@ public sealed class DesktopUploadSectionTests
         Assert.Equal(DesktopUploadSectionText.HashNotReadyMessage, viewModel.HashStatusMessage);
         Assert.Null(viewModel.Sha256Hex);
         Assert.False(viewModel.CanCalculateHash);
+        Assert.Null(viewModel.BusinessObjectKey);
+        Assert.Null(viewModel.BusinessObjectKeyPreview);
+        Assert.Equal(string.Empty, viewModel.BusinessObjectKeyInput);
+        Assert.Equal(DesktopUploadSectionText.BusinessObjectKeyEmptyValidationMessage, viewModel.BusinessObjectKeyStatusMessage);
     }
 
     [Fact]
@@ -318,6 +483,8 @@ public sealed class DesktopUploadSectionTests
         viewModel.OpenUploadSection();
         _ = await viewModel.SelectVideoFileAsync(CancellationToken.None);
         _ = await viewModel.CalculateSha256Async(CancellationToken.None);
+        viewModel.BusinessObjectKeyInput = "report-draft-001";
+        _ = viewModel.ApplyBusinessObjectKey();
 
         viewModel.BackToWorkspace();
 
@@ -328,6 +495,10 @@ public sealed class DesktopUploadSectionTests
         Assert.Equal(DesktopUploadSectionText.HashNotReadyMessage, viewModel.HashStatusMessage);
         Assert.Null(viewModel.Sha256Hex);
         Assert.False(viewModel.CanCalculateHash);
+        Assert.Null(viewModel.BusinessObjectKey);
+        Assert.Null(viewModel.BusinessObjectKeyPreview);
+        Assert.Equal(string.Empty, viewModel.BusinessObjectKeyInput);
+        Assert.Equal(DesktopUploadSectionText.BusinessObjectKeyEmptyValidationMessage, viewModel.BusinessObjectKeyStatusMessage);
     }
 
     [Fact]
@@ -360,9 +531,22 @@ public sealed class DesktopUploadSectionTests
             DesktopUploadSectionText.HashUnavailableMessage,
             DesktopUploadSectionText.HashCanceledMessage,
             DesktopUploadSectionText.Sha256ResultLabel,
+            DesktopUploadSectionText.StepThreeTitle,
+            DesktopUploadSectionText.BusinessObjectKeyLabel,
+            DesktopUploadSectionText.BusinessObjectKeyHint,
+            DesktopUploadSectionText.BusinessObjectKeyApplyButton,
+            DesktopUploadSectionText.BusinessObjectKeyUseFakeButton,
+            DesktopUploadSectionText.BusinessObjectKeyEmptyValidationMessage,
+            DesktopUploadSectionText.BusinessObjectKeyControlCharacterValidationMessage,
+            DesktopUploadSectionText.BusinessObjectKeyLengthValidationMessage,
+            DesktopUploadSectionText.BusinessObjectKeySecretValidationMessage,
+            DesktopUploadSectionText.BusinessObjectKeyAcceptedMessage,
+            DesktopUploadSectionText.BusinessObjectKeyPreviewLabel,
+            DesktopUploadSectionText.NextStepDeferredMessage,
             DesktopUploadSelectedFile.VisualSmokeFileName,
             DesktopUploadSelectedFile.VisualSmokeContentType,
-            FakeDesktopVideoHashService.VisualSmokeSha256Hex
+            FakeDesktopVideoHashService.VisualSmokeSha256Hex,
+            DesktopUploadBusinessObjectKey.VisualSmokeValue
         ];
 
         foreach (string visibleString in visibleStrings)
@@ -385,7 +569,15 @@ public sealed class DesktopUploadSectionTests
         IDesktopVideoFilePicker videoFilePicker,
         IDesktopVideoHashService videoHashService)
     {
-        return new DesktopUploadSectionViewModel(videoFilePicker, videoHashService);
+        return CreateViewModel(videoFilePicker, videoHashService, DesktopUploadSectionOptions.Disabled);
+    }
+
+    private static DesktopUploadSectionViewModel CreateViewModel(
+        IDesktopVideoFilePicker videoFilePicker,
+        IDesktopVideoHashService videoHashService,
+        DesktopUploadSectionOptions uploadSectionOptions)
+    {
+        return new DesktopUploadSectionViewModel(videoFilePicker, videoHashService, uploadSectionOptions);
     }
 
     private sealed class CancelingDesktopVideoFilePicker : IDesktopVideoFilePicker


### PR DESCRIPTION
## Coder
Coder 1 acting as Coder 2 / Desktop Client

## Task ID
S2-63 Desktop Upload Business Object Key Placeholder / Manual Entry Boundary

## Module
App.Desktop / upload businessObjectKey placeholder

## Scope
Desktop standalone UI slice only. Adds manual businessObjectKey placeholder state, safe validation/preview, and optional fake/dev key for local visual smoke.

## Changed areas
- `docs/task-cards/S2-63_desktop-upload-business-object-key-placeholder-task-card.txt`
- `src/App.Desktop/Boundaries/DesktopSignInBoundary.cs`
- `src/App.Desktop/Components/DesktopShell.razor`
- `src/App.Desktop/Services/Upload/DesktopUploadBusinessObjectKey.cs`
- `src/App.Desktop/Services/Upload/DesktopUploadSectionOptions.cs`
- `src/App.Desktop/Services/Upload/DesktopUploadSectionViewModel.cs`
- `src/App.Desktop/wwwroot/app.css`
- `tests/Unit/App.Desktop.Tests/DesktopCompositionRootTests.cs`
- `tests/Unit/App.Desktop.Tests/DesktopSignInServiceTests.cs`
- `tests/Unit/App.Desktop.Tests/DesktopUploadSectionTests.cs`

## Base main SHA
`54b52378e6aee08389de3f58c0bf7a4931c7b548`

## Coordination log entries reviewed
TEAM COORDINATION LOG issue #89 metadata/comments reviewed, including relevant desktop merge records:
- #127 S2-58 Desktop Visual Smoke Fake Auth Harness
- #128 S2-59 Desktop Signed-in Shell Navigation Placeholder
- #129 S2-60 Desktop Upload Section File Selection Placeholder
- #130 S2-61 Desktop Upload File Picker Boundary
- #131 S2-62 Desktop Upload SHA-256 Boundary

## Handoff/task cards reviewed
- `docs/task-cards/S2-58_desktop-visual-smoke-fake-auth-task-card.txt`
- `docs/task-cards/S2-59_desktop-signed-in-shell-navigation-task-card.txt`
- `docs/task-cards/S2-60_desktop-upload-section-file-selection-placeholder-task-card.txt`
- `docs/task-cards/S2-61_desktop-upload-file-picker-boundary-task-card.txt`
- `docs/task-cards/S2-62_desktop-upload-sha256-boundary-task-card.txt`

## Contracts
None. No DTO/shared contract/backend contract changes.

## Migrations
None.

## Feature flags/env guard
Uses existing visual-smoke guards:
- `AA_DESKTOP_DEV_FAKE_AUTH_ENABLED=true`
- `AA_DESKTOP_DEV_FAKE_UPLOAD_FILE_ENABLED=true`
- `AA_DESKTOP_DEV_FAKE_UPLOAD_HASH_ENABLED=true`

Adds optional visual-smoke/dev-test guard, disabled by default:
- `AA_DESKTOP_DEV_FAKE_BUSINESS_OBJECT_KEY_ENABLED=true`

Fake value: `visual-smoke-business-object-001`.

## API impact
None. No App.Api calls are made from the upload section. businessObjectKey is not sent to App.Api.

## Web impact
None.

## Android impact
None.

## Offline behavior
None.

## Rollback
Revert this S2-63 PR.

## Validation
- [x] `git diff --check`
- [x] `dotnet restore AnalyticsAutomation-Core.sln -nologo`
- [x] `dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore`
- [x] `dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal`
- [x] `dotnet build AnalyticsAutomation-Core.sln -nologo -v minimal` (passes with existing warnings outside this slice)
- [x] `dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal`
- [x] hidden/control Unicode scan over changed/untracked text files
- [x] App.Desktop fake-auth/fake-picker/fake-hash/fake-businessObjectKey visual smoke with screenshots

## Visual smoke screenshot folder/files
Folder:
`C:\CODEX\Temp\S2-63_DESKTOP_BUSINESS_OBJECT_KEY_VISUAL_SMOKE_20260430_165542\`

Files:
- `01_baseline_signin.png`
- `02_signed_in_shell.png`
- `03_upload_section_after_fake_file_and_hash.png`
- `04_business_object_key_empty_validation.png`
- `05_after_fake_business_object_key.png`
- `06_after_sign_out.png`

Screenshots/runtime artifacts were not committed.

## Handoff docs/task card
- `docs/task-cards/S2-63_desktop-upload-business-object-key-placeholder-task-card.txt`

## Next step
Backend-approved business object/report-draft binding flow remains a separate approved slice.

## NO-GO / Deferred
Not implemented in S2-63:
- PreUploadCheck
- direct site upload
- UploadReceipt
- backend-approved binding flow
- GroupTree runtime
- report draft runtime
- offline queue
- App.Api changes/calls
- contracts changes
- migrations
- deploy
- App.Web/App.Mobile.Android changes

## Review Fix - S2-63 PR #132

Old head before review fix: `5685f0157a7d0ed24b6c89abf4f2c7d434ac8dd3`.
New head after review fix: `5189a12a282ed89c32ddccb764795ddecafcb4f3`.

Addressed active Codex review blocker in `src/App.Desktop/Services/Upload/DesktopUploadBusinessObjectKey.cs`: blocked/secret-like fragments are now checked on the normalized safe single-line value before any visible `SafeInputValue` is returned for control-character or length validation paths. Split values such as `tok\nen`, `ac\ncessToken`, `refresh\rToken`, `authori\tzation`, and `pass\nword` are rejected with an empty visible input instead of surfacing normalized secret-like text.

Tests added/updated in `tests/Unit/App.Desktop.Tests/DesktopUploadSectionTests.cs`:
- split control-character blocked fragments are rejected and cleared;
- ordinary control-character input without a blocked fragment remains rejected with the safe Russian control-character message;
- accepted preview remains limited to sanitized non-secret keys;
- no PreUploadCheck, direct site upload, or UploadReceipt flow is introduced by this slice.

Validation after review fix:
- [x] `git diff --check`
- [x] `dotnet restore AnalyticsAutomation-Core.sln -nologo`
- [x] `dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore`
- [x] `dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal`
- [x] `dotnet build AnalyticsAutomation-Core.sln -nologo -v minimal`
- [x] `dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal` (111 passed)
- [x] hidden/control Unicode scan over changed text files

Scope confirmation: no App.Api, contracts, migrations, deploy, App.Web, App.Mobile.Android, App.Worker, App.UI.Shared, or Modules changes.
