### PR TITLE
[codex] S2-64 Desktop PreUploadCheck Request Preview

### DIFF
--- a/docs/task-cards/S2-64_desktop-preuploadcheck-request-preview-task-card.txt
+++ b/docs/task-cards/S2-64_desktop-preuploadcheck-request-preview-task-card.txt
@@ -1,0 +1,126 @@
+Title:
+S2-64 Desktop Upload PreUploadCheck Request Preview / Fake Decision Boundary
+
+Module:
+App.Desktop / upload PreUploadCheck request preview and fake decision boundary
+
+Owner:
+Coder 1 acting as Coder 2 / Desktop Client
+
+Client form:
+desktop standalone
+
+Type:
+narrow runtime desktop UI slice after S2-63 upload businessObjectKey placeholder
+
+Status:
+Runtime task card created with implementation.
+
+Goal:
+Add a safe App.Desktop-local PreUploadCheck request preview in the upload section and a dev/fake decision boundary for visual smoke only.
+
+Context:
+S2-58 added debug-only fake auth for visual smoke.
+S2-59 added the signed-in desktop shell.
+S2-60 added the active upload section entry.
+S2-61 added safe file metadata preview.
+S2-62 added the App.Desktop-local SHA-256 boundary and lowercase hash preview.
+S2-63 added the temporary manual businessObjectKey placeholder without App.Api calls.
+
+Scope:
+- Keep the current Russian SignIn UI before authentication.
+- After fake-auth SignIn, show the signed-in shell.
+- Keep upload Step 1 safe file metadata, Step 2 SHA-256, and Step 3 businessObjectKey placeholder.
+- Add Step 4 "Предварительная проверка".
+- Show a request preview built only from safe fields:
+  - file name without the local path;
+  - size;
+  - content type;
+  - SHA-256;
+  - businessObjectKey preview;
+  - capturedAtUtc local placeholder.
+- Add "Проверить перед загрузкой".
+- When AA_DESKTOP_DEV_FAKE_PREUPLOAD_CHECK_ENABLED is not true, show a safe deferred message and do not call App.Api.
+- When AA_DESKTOP_DEV_FAKE_PREUPLOAD_CHECK_ENABLED=true, call only the App.Desktop-local fake boundary and show ALLOW for visual smoke.
+
+Allowed changed areas:
+- docs/task-cards/S2-64_desktop-preuploadcheck-request-preview-task-card.txt
+- src/App.Desktop/**
+- tests/Unit/App.Desktop.Tests/**
+
+Forbidden changed areas:
+- src/App.Api/**
+- src/App.Worker/**
+- src/App.Web/**
+- src/App.Mobile.Android/**
+- src/App.UI.Shared/**
+- src/BuildingBlocks.Contracts/**
+- src/Modules/**
+- DB migrations
+- .github/workflows/**
+- deploy scripts
+- docs/ops/**
+- committed screenshots or runtime artifacts
+
+Contracts:
+none
+
+Migrations:
+none
+
+Feature flags/env guard:
+- Existing fake auth visual-smoke guard:
+  AA_DESKTOP_DEV_FAKE_AUTH_ENABLED=true
+- Existing fake picker visual-smoke guard:
+  AA_DESKTOP_DEV_FAKE_UPLOAD_FILE_ENABLED=true
+- Existing fake hash visual-smoke guard:
+  AA_DESKTOP_DEV_FAKE_UPLOAD_HASH_ENABLED=true
+- Existing fake businessObjectKey visual-smoke guard:
+  AA_DESKTOP_DEV_FAKE_BUSINESS_OBJECT_KEY_ENABLED=true
+- New fake PreUploadCheck visual-smoke guard:
+  AA_DESKTOP_DEV_FAKE_PREUPLOAD_CHECK_ENABLED=true
+
+Events:
+none
+
+Offline behavior:
+none
+
+Security guardrails:
+- Do not send the preview to App.Api.
+- Do not add backend DTOs, shared contracts, API routes, migrations, or deploy changes.
+- Do not claim manual businessObjectKey is a production source of truth.
+- Do not display a full local file path.
+- Do not display or log password, accessToken, refreshToken, Authorization, raw session id, raw response body, or token-like values.
+- Do not direct site upload.
+- Do not create UploadReceipt.
+- Screenshots and runtime artifacts stay under C:\CODEX\Temp and are not committed.
+
+Deferred:
+Real App.Api PreUploadCheck integration is not implemented in S2-64. The real control-plane client remains a separate approved slice after backend-approved business object/report-draft binding is agreed. App.Api remains the control plane; video bytes do not go through App.Api.
+
+Rollback:
+revert S2-64 PR
+
+Validation:
+- git diff --check
+- dotnet restore AnalyticsAutomation-Core.sln -nologo
+- dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore
+- dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal
+- dotnet build AnalyticsAutomation-Core.sln -nologo -v minimal
+- dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal
+- hidden/control Unicode scan over changed text files
+- App.Desktop fake-auth/fake-picker/fake-hash/fake-businessObjectKey/fake-PreUploadCheck visual smoke with screenshots
+
+Definition of done:
+- Step 4 shows a safe PreUploadCheck request preview only after selected file, SHA-256, and businessObjectKey are present.
+- Preview shows safe file name, size, content type, SHA-256, businessObjectKey, and capturedAtUtc placeholder.
+- Preview never shows the full local path.
+- Fake PreUploadCheck is disabled by default.
+- Fake PreUploadCheck is enabled only by AA_DESKTOP_DEV_FAKE_PREUPLOAD_CHECK_ENABLED=true in debug/dev-test visual smoke.
+- Disabled fake PreUploadCheck shows the safe deferred Russian message and makes no App.Api call.
+- Enabled fake PreUploadCheck shows ALLOW and the safe Russian dev-smoke allowed message.
+- Back/sign-out clear PreUploadCheck preview and decision state.
+- No direct site upload, UploadReceipt, offline queue, GroupTree runtime, report draft runtime, App.Api change, contract change, migration, deploy, App.Web, or App.Mobile.Android change is introduced.
+- Automated App.Desktop tests cover env guard behavior, safe preview requirements, fake ALLOW decision, reset behavior, forbidden upload-chain calls, and visible-string safety.
+- Visual-smoke screenshots are saved under C:\CODEX\Temp and kept out of git.

--- a/src/App.Desktop/Boundaries/DesktopPreUploadCheckBoundary.cs
+++ b/src/App.Desktop/Boundaries/DesktopPreUploadCheckBoundary.cs
@@ -1,0 +1,10 @@
+using App.Desktop.Services.Upload;
+
+namespace App.Desktop.Boundaries;
+
+public interface IDesktopPreUploadCheckClient
+{
+    ValueTask<DesktopPreUploadCheckResult> CheckAsync(
+        DesktopPreUploadCheckRequestPreview requestPreview,
+        CancellationToken cancellationToken);
+}

--- a/src/App.Desktop/Boundaries/DesktopSignInBoundary.cs
+++ b/src/App.Desktop/Boundaries/DesktopSignInBoundary.cs
@@ -137,7 +137,7 @@ public static class DesktopUploadSectionText
     public const string Description =
         "Этот раздел показывает безопасные сведения о выбранном видеофайле. Реальная загрузка будет включена в следующем approved desktop slice.";
     public const string NavigationCardMessage = "Открыть заготовку выбора видеофайла.";
-    public const string StepOneTitle = "Шаг 1. Выбор видеофайла";
+    public const string StepOneTitle = "Шаг 1. Метаданные файла";
     public const string SelectVideoFileButton = "Выбрать видеофайл";
     public const string PlaceholderResult = "Выберите видеофайл для безопасного предпросмотра.";
     public const string SelectingFileMessage = "Открывается выбор видеофайла.";
@@ -174,8 +174,35 @@ public static class DesktopUploadSectionText
     public const string BusinessObjectKeyAcceptedMessage =
         "Ключ бизнес-объекта принят для безопасного preview.";
     public const string BusinessObjectKeyPreviewLabel = "businessObjectKey";
+    public const string StepFourTitle = "Шаг 4. Предварительная проверка";
+    public const string PreUploadCheckNotReadyMessage =
+        "Выберите файл, рассчитайте SHA-256 и укажите ключ бизнес-объекта для preview запроса.";
+    public const string PreUploadCheckReadyMessage =
+        "Preview запроса готов. Реальный вызов App.Api в этом slice не выполняется.";
+    public const string PreUploadCheckInProgressMessage =
+        "Выполняется предварительная проверка в desktop-local dev boundary.";
+    public const string PreUploadCheckDeferredMessage =
+        "Предварительная проверка пока доступна только в dev-smoke режиме. Реальный вызов App.Api будет добавлен отдельным approved slice.";
+    public const string PreUploadCheckAllowedDevMessage =
+        "Предварительная проверка: загрузка разрешена в dev-smoke режиме.";
+    public const string PreUploadCheckAllowWithReviewDevMessage =
+        "Предварительная проверка: загрузка разрешена с review в dev-smoke режиме.";
+    public const string PreUploadCheckBlockHardDuplicateDevMessage =
+        "Предварительная проверка: загрузка заблокирована как hard duplicate в dev-smoke режиме.";
+    public const string PreUploadCheckBlockPossibleFalsificationDevMessage =
+        "Предварительная проверка: загрузка заблокирована как possible falsification в dev-smoke режиме.";
+    public const string PreUploadCheckCanceledMessage = "Предварительная проверка отменена.";
+    public const string PreUploadCheckButton = "Проверить перед загрузкой";
+    public const string PreUploadCheckBusyButton = "Проверяется...";
+    public const string PreUploadCheckFileNameLabel = "Имя файла";
+    public const string PreUploadCheckFileSizeLabel = "Размер";
+    public const string PreUploadCheckContentTypeLabel = "Тип содержимого";
+    public const string PreUploadCheckSha256Label = "SHA-256";
+    public const string PreUploadCheckBusinessObjectKeyLabel = "businessObjectKey";
+    public const string PreUploadCheckCapturedAtUtcLabel = "capturedAtUtc";
+    public const string PreUploadCheckDecisionLabel = "Решение";
     public const string NextStepDeferredMessage =
-        "Следующий шаг отложен: PreUploadCheck будет добавлен отдельным approved desktop slice.";
+        "Следующий шаг отложен: direct site upload boundary будет добавлен отдельным approved desktop slice.";
 }
 
 public sealed record DesktopUploadSelectedFile(

--- a/src/App.Desktop/Components/DesktopShell.razor
+++ b/src/App.Desktop/Components/DesktopShell.razor
@@ -169,6 +169,67 @@
                                     </div>
                                 </dl>
                             }
+                        </div>
+
+                        <div class="desktop-upload__step">
+                            <h3>@DesktopUploadSectionText.StepFourTitle</h3>
+                            <p
+                                id="desktop-upload-preuploadcheck-status"
+                                class="desktop-upload__message"
+                                role="status"
+                                aria-live="polite">
+                                @UploadSectionViewModel.PreUploadCheckStatusMessage
+                            </p>
+
+                            @if (UploadSectionViewModel.PreUploadCheckRequestPreview is { } preUploadCheckPreview)
+                            {
+                                <dl class="desktop-upload__preupload-preview">
+                                    <div>
+                                        <dt>@DesktopUploadSectionText.PreUploadCheckFileNameLabel</dt>
+                                        <dd>@preUploadCheckPreview.FileName</dd>
+                                    </div>
+                                    <div>
+                                        <dt>@DesktopUploadSectionText.PreUploadCheckFileSizeLabel</dt>
+                                        <dd>@preUploadCheckPreview.SizeBytes</dd>
+                                    </div>
+                                    <div>
+                                        <dt>@DesktopUploadSectionText.PreUploadCheckContentTypeLabel</dt>
+                                        <dd>@preUploadCheckPreview.ContentType</dd>
+                                    </div>
+                                    <div>
+                                        <dt>@DesktopUploadSectionText.PreUploadCheckSha256Label</dt>
+                                        <dd>@preUploadCheckPreview.Sha256Hex</dd>
+                                    </div>
+                                    <div>
+                                        <dt>@DesktopUploadSectionText.PreUploadCheckBusinessObjectKeyLabel</dt>
+                                        <dd>@preUploadCheckPreview.BusinessObjectKeyPreview</dd>
+                                    </div>
+                                    <div>
+                                        <dt>@DesktopUploadSectionText.PreUploadCheckCapturedAtUtcLabel</dt>
+                                        <dd>@preUploadCheckPreview.CapturedAtUtc</dd>
+                                    </div>
+                                </dl>
+                            }
+
+                            <button
+                                class="desktop-upload__preupload"
+                                type="button"
+                                disabled="@(SignInViewModel.IsBusy || !UploadSectionViewModel.CanRequestPreUploadCheck)"
+                                @onclick="CheckPreUploadAsync">
+                                @(UploadSectionViewModel.IsCheckingPreUpload
+                                    ? DesktopUploadSectionText.PreUploadCheckBusyButton
+                                    : DesktopUploadSectionText.PreUploadCheckButton)
+                            </button>
+
+                            @if (UploadSectionViewModel.HasPreUploadCheckDecision)
+                            {
+                                <dl class="desktop-upload__preupload-decision">
+                                    <div>
+                                        <dt>@DesktopUploadSectionText.PreUploadCheckDecisionLabel</dt>
+                                        <dd>@UploadSectionViewModel.PreUploadCheckDecisionPreview</dd>
+                                    </div>
+                                </dl>
+                            }
 
                             <p class="desktop-upload__deferred">
                                 @DesktopUploadSectionText.NextStepDeferredMessage
@@ -330,6 +391,17 @@
     private void UseDevFakeBusinessObjectKey()
     {
         UploadSectionViewModel.UseDevFakeBusinessObjectKey();
+    }
+
+    private async Task CheckPreUploadAsync()
+    {
+        ValueTask<DesktopPreUploadCheckResult?> checkAttempt =
+            UploadSectionViewModel.CheckPreUploadAsync(CancellationToken.None);
+        StateHasChanged();
+
+        await checkAttempt;
+
+        StateHasChanged();
     }
 
     private string GetHeaderStatusText()

--- a/src/App.Desktop/Composition/DesktopCompositionRoot.cs
+++ b/src/App.Desktop/Composition/DesktopCompositionRoot.cs
@@ -90,6 +90,15 @@ public static class DesktopCompositionRoot
             services.AddSingleton<IDesktopVideoHashService, DesktopVideoHashService>();
         }
 
+        if (uploadSectionOptions.IsDevFakePreUploadCheckEnabled)
+        {
+            services.AddSingleton<IDesktopPreUploadCheckClient, FakeDesktopPreUploadCheckClient>();
+        }
+        else
+        {
+            services.AddSingleton<IDesktopPreUploadCheckClient, DisabledDesktopPreUploadCheckClient>();
+        }
+
         services.AddSingleton<IDesktopFilePicker, PlaceholderDesktopFilePicker>();
         services.AddSingleton<ILocalFileMetadataService, PlaceholderLocalFileMetadataService>();
         services.AddSingleton<IControlPlaneApiClient, PlaceholderControlPlaneApiClient>();

--- a/src/App.Desktop/Services/Upload/DesktopPreUploadCheck.cs
+++ b/src/App.Desktop/Services/Upload/DesktopPreUploadCheck.cs
@@ -1,0 +1,190 @@
+using App.Desktop.Boundaries;
+
+namespace App.Desktop.Services.Upload;
+
+public sealed class DesktopPreUploadCheckRequestPreview
+{
+    public const string CapturedAtUtcPlaceholder = "desktop-local-preview";
+
+    private DesktopPreUploadCheckRequestPreview(
+        string fileName,
+        long sizeBytes,
+        string contentType,
+        string sha256Hex,
+        string businessObjectKeyPreview,
+        string capturedAtUtc)
+    {
+        FileName = fileName;
+        SizeBytes = sizeBytes;
+        ContentType = contentType;
+        Sha256Hex = sha256Hex;
+        BusinessObjectKeyPreview = businessObjectKeyPreview;
+        CapturedAtUtc = capturedAtUtc;
+    }
+
+    public string FileName { get; }
+
+    public long SizeBytes { get; }
+
+    public string ContentType { get; }
+
+    public string Sha256Hex { get; }
+
+    public string BusinessObjectKeyPreview { get; }
+
+    public string CapturedAtUtc { get; }
+
+    public static DesktopPreUploadCheckRequestPreview? TryCreate(
+        DesktopUploadSelectedFile? selectedFile,
+        string? sha256Hex,
+        DesktopUploadBusinessObjectKey? businessObjectKey)
+    {
+        string safeSha256Hex = sha256Hex ?? string.Empty;
+
+        if (selectedFile is null
+            || !IsLowercaseSha256Hex(safeSha256Hex)
+            || businessObjectKey is null
+            || !IsSafeBusinessObjectKeyPreview(businessObjectKey.Value))
+        {
+            return null;
+        }
+
+        return new DesktopPreUploadCheckRequestPreview(
+            selectedFile.FileName,
+            selectedFile.SizeBytes,
+            selectedFile.ContentType,
+            safeSha256Hex,
+            businessObjectKey.Value,
+            CapturedAtUtcPlaceholder);
+    }
+
+    public override string ToString()
+    {
+        return $"{nameof(DesktopPreUploadCheckRequestPreview)} {{ FileName = {FileName}, "
+            + $"SizeBytes = {SizeBytes}, ContentType = {ContentType}, HasSha256 = {Sha256Hex.Length == 64}, "
+            + $"BusinessObjectKeyPreview = {BusinessObjectKeyPreview}, CapturedAtUtc = {CapturedAtUtc} }}";
+    }
+
+    private static bool IsLowercaseSha256Hex(string? value)
+    {
+        if (value is null || value.Length != 64)
+        {
+            return false;
+        }
+
+        foreach (char character in value)
+        {
+            bool isDigit = character is >= '0' and <= '9';
+            bool isLowerHex = character is >= 'a' and <= 'f';
+            if (!isDigit && !isLowerHex)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool IsSafeBusinessObjectKeyPreview(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value) || value.Length > DesktopUploadBusinessObjectKey.MaxLength)
+        {
+            return false;
+        }
+
+        foreach (char character in value)
+        {
+            if (char.IsControl(character))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}
+
+public sealed class DesktopPreUploadCheckResult
+{
+    private DesktopPreUploadCheckResult(
+        DesktopPreUploadCheckStatus status,
+        DesktopPreUploadCheckDecision? decision,
+        string message)
+    {
+        Status = status;
+        Decision = decision;
+        Message = message;
+    }
+
+    public DesktopPreUploadCheckStatus Status { get; }
+
+    public DesktopPreUploadCheckDecision? Decision { get; }
+
+    public string? DecisionPreview => Decision switch
+    {
+        DesktopPreUploadCheckDecision.Allow => "ALLOW",
+        DesktopPreUploadCheckDecision.AllowWithReview => "ALLOW_WITH_REVIEW",
+        DesktopPreUploadCheckDecision.BlockHardDuplicate => "BLOCK_HARD_DUPLICATE",
+        DesktopPreUploadCheckDecision.BlockPossibleFalsification => "BLOCK_POSSIBLE_FALSIFICATION",
+        _ => null
+    };
+
+    public string Message { get; }
+
+    public static DesktopPreUploadCheckResult Deferred { get; } = new(
+        DesktopPreUploadCheckStatus.Deferred,
+        decision: null,
+        DesktopUploadSectionText.PreUploadCheckDeferredMessage);
+
+    public static DesktopPreUploadCheckResult Canceled { get; } = new(
+        DesktopPreUploadCheckStatus.Canceled,
+        decision: null,
+        DesktopUploadSectionText.PreUploadCheckCanceledMessage);
+
+    public static DesktopPreUploadCheckResult FromFakeDecision(DesktopPreUploadCheckDecision decision)
+    {
+        string message = decision switch
+        {
+            DesktopPreUploadCheckDecision.Allow => DesktopUploadSectionText.PreUploadCheckAllowedDevMessage,
+            DesktopPreUploadCheckDecision.AllowWithReview =>
+                DesktopUploadSectionText.PreUploadCheckAllowWithReviewDevMessage,
+            DesktopPreUploadCheckDecision.BlockHardDuplicate =>
+                DesktopUploadSectionText.PreUploadCheckBlockHardDuplicateDevMessage,
+            DesktopPreUploadCheckDecision.BlockPossibleFalsification =>
+                DesktopUploadSectionText.PreUploadCheckBlockPossibleFalsificationDevMessage,
+            _ => DesktopUploadSectionText.PreUploadCheckDeferredMessage
+        };
+
+        DesktopPreUploadCheckStatus status = decision switch
+        {
+            DesktopPreUploadCheckDecision.Allow => DesktopPreUploadCheckStatus.Allowed,
+            DesktopPreUploadCheckDecision.AllowWithReview => DesktopPreUploadCheckStatus.AllowedWithReview,
+            _ => DesktopPreUploadCheckStatus.Blocked
+        };
+
+        return new DesktopPreUploadCheckResult(status, decision, message);
+    }
+
+    public override string ToString()
+    {
+        return $"{nameof(DesktopPreUploadCheckResult)} {{ Status = {Status}, Decision = {DecisionPreview ?? "<none>"}, "
+            + $"Message = {Message} }}";
+    }
+}
+
+public enum DesktopPreUploadCheckStatus
+{
+    Deferred,
+    Allowed,
+    AllowedWithReview,
+    Blocked,
+    Canceled
+}
+
+public enum DesktopPreUploadCheckDecision
+{
+    Allow,
+    AllowWithReview,
+    BlockHardDuplicate,
+    BlockPossibleFalsification
+}

--- a/src/App.Desktop/Services/Upload/DesktopUploadSectionOptions.cs
+++ b/src/App.Desktop/Services/Upload/DesktopUploadSectionOptions.cs
@@ -11,42 +11,59 @@ public sealed class DesktopUploadSectionOptions
     public const string DevFakeBusinessObjectKeyEnabledEnvironmentVariable =
         "AA_DESKTOP_DEV_FAKE_BUSINESS_OBJECT_KEY_ENABLED";
 
+    public const string DevFakePreUploadCheckEnabledEnvironmentVariable =
+        "AA_DESKTOP_DEV_FAKE_PREUPLOAD_CHECK_ENABLED";
+
     private DesktopUploadSectionOptions(
         bool isDevFakeUploadFileEnabled,
         bool isDevFakeUploadHashEnabled,
-        bool isDevFakeBusinessObjectKeyEnabled)
+        bool isDevFakeBusinessObjectKeyEnabled,
+        bool isDevFakePreUploadCheckEnabled)
     {
         IsDevFakeUploadFileEnabled = isDevFakeUploadFileEnabled;
         IsDevFakeUploadHashEnabled = isDevFakeUploadHashEnabled;
         IsDevFakeBusinessObjectKeyEnabled = isDevFakeBusinessObjectKeyEnabled;
+        IsDevFakePreUploadCheckEnabled = isDevFakePreUploadCheckEnabled;
     }
 
     public static DesktopUploadSectionOptions Disabled { get; } = new(
         isDevFakeUploadFileEnabled: false,
         isDevFakeUploadHashEnabled: false,
-        isDevFakeBusinessObjectKeyEnabled: false);
+        isDevFakeBusinessObjectKeyEnabled: false,
+        isDevFakePreUploadCheckEnabled: false);
 
 #if DEBUG
     public static DesktopUploadSectionOptions EnabledForDevFakeFileSelection { get; } = new(
         isDevFakeUploadFileEnabled: true,
         isDevFakeUploadHashEnabled: false,
-        isDevFakeBusinessObjectKeyEnabled: false);
+        isDevFakeBusinessObjectKeyEnabled: false,
+        isDevFakePreUploadCheckEnabled: false);
 
     public static DesktopUploadSectionOptions EnabledForDevFakeFileSelectionAndHash { get; } = new(
         isDevFakeUploadFileEnabled: true,
         isDevFakeUploadHashEnabled: true,
-        isDevFakeBusinessObjectKeyEnabled: false);
+        isDevFakeBusinessObjectKeyEnabled: false,
+        isDevFakePreUploadCheckEnabled: false);
 
     public static DesktopUploadSectionOptions EnabledForDevFakeBusinessObjectKey { get; } = new(
         isDevFakeUploadFileEnabled: false,
         isDevFakeUploadHashEnabled: false,
-        isDevFakeBusinessObjectKeyEnabled: true);
+        isDevFakeBusinessObjectKeyEnabled: true,
+        isDevFakePreUploadCheckEnabled: false);
+
+    public static DesktopUploadSectionOptions EnabledForDevFakePreUploadCheck { get; } = new(
+        isDevFakeUploadFileEnabled: false,
+        isDevFakeUploadHashEnabled: false,
+        isDevFakeBusinessObjectKeyEnabled: false,
+        isDevFakePreUploadCheckEnabled: true);
 #else
     public static DesktopUploadSectionOptions EnabledForDevFakeFileSelection => Disabled;
 
     public static DesktopUploadSectionOptions EnabledForDevFakeFileSelectionAndHash => Disabled;
 
     public static DesktopUploadSectionOptions EnabledForDevFakeBusinessObjectKey => Disabled;
+
+    public static DesktopUploadSectionOptions EnabledForDevFakePreUploadCheck => Disabled;
 #endif
 
     public bool IsDevFakeUploadFileEnabled { get; }
@@ -55,12 +72,15 @@ public sealed class DesktopUploadSectionOptions
 
     public bool IsDevFakeBusinessObjectKeyEnabled { get; }
 
+    public bool IsDevFakePreUploadCheckEnabled { get; }
+
     public static DesktopUploadSectionOptions FromEnvironment()
     {
         return FromEnvironmentValue(
             Environment.GetEnvironmentVariable(DevFakeUploadFileEnabledEnvironmentVariable),
             Environment.GetEnvironmentVariable(DevFakeUploadHashEnabledEnvironmentVariable),
-            Environment.GetEnvironmentVariable(DevFakeBusinessObjectKeyEnabledEnvironmentVariable));
+            Environment.GetEnvironmentVariable(DevFakeBusinessObjectKeyEnabledEnvironmentVariable),
+            Environment.GetEnvironmentVariable(DevFakePreUploadCheckEnabledEnvironmentVariable));
     }
 
     public static DesktopUploadSectionOptions FromEnvironmentValue(string? devFakeUploadFileEnabled)
@@ -85,16 +105,31 @@ public sealed class DesktopUploadSectionOptions
         string? devFakeUploadHashEnabled,
         string? devFakeBusinessObjectKeyEnabled)
     {
+        return FromEnvironmentValue(
+            devFakeUploadFileEnabled,
+            devFakeUploadHashEnabled,
+            devFakeBusinessObjectKeyEnabled,
+            devFakePreUploadCheckEnabled: null);
+    }
+
+    public static DesktopUploadSectionOptions FromEnvironmentValue(
+        string? devFakeUploadFileEnabled,
+        string? devFakeUploadHashEnabled,
+        string? devFakeBusinessObjectKeyEnabled,
+        string? devFakePreUploadCheckEnabled)
+    {
 #if DEBUG
         bool isFakeFileEnabled = IsDevFakeUploadFileEnabledValue(devFakeUploadFileEnabled);
         bool isFakeHashEnabled = IsDevFakeUploadHashEnabledValue(devFakeUploadHashEnabled);
         bool isFakeBusinessObjectKeyEnabled =
             IsDevFakeBusinessObjectKeyEnabledValue(devFakeBusinessObjectKeyEnabled);
+        bool isFakePreUploadCheckEnabled = IsDevFakePreUploadCheckEnabledValue(devFakePreUploadCheckEnabled);
 
         return new DesktopUploadSectionOptions(
             isFakeFileEnabled,
             isFakeHashEnabled,
-            isFakeBusinessObjectKeyEnabled);
+            isFakeBusinessObjectKeyEnabled,
+            isFakePreUploadCheckEnabled);
 #else
         return Disabled;
 #endif
@@ -104,7 +139,8 @@ public sealed class DesktopUploadSectionOptions
     {
         return $"{nameof(DesktopUploadSectionOptions)} {{ IsDevFakeUploadFileEnabled = {IsDevFakeUploadFileEnabled}, "
             + $"IsDevFakeUploadHashEnabled = {IsDevFakeUploadHashEnabled}, "
-            + $"IsDevFakeBusinessObjectKeyEnabled = {IsDevFakeBusinessObjectKeyEnabled} }}";
+            + $"IsDevFakeBusinessObjectKeyEnabled = {IsDevFakeBusinessObjectKeyEnabled}, "
+            + $"IsDevFakePreUploadCheckEnabled = {IsDevFakePreUploadCheckEnabled} }}";
     }
 
     private static bool IsDevFakeUploadFileEnabledValue(string? value)
@@ -118,6 +154,11 @@ public sealed class DesktopUploadSectionOptions
     }
 
     private static bool IsDevFakeBusinessObjectKeyEnabledValue(string? value)
+    {
+        return string.Equals(value?.Trim(), "true", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsDevFakePreUploadCheckEnabledValue(string? value)
     {
         return string.Equals(value?.Trim(), "true", StringComparison.OrdinalIgnoreCase);
     }

--- a/src/App.Desktop/Services/Upload/DesktopUploadSectionViewModel.cs
+++ b/src/App.Desktop/Services/Upload/DesktopUploadSectionViewModel.cs
@@ -5,12 +5,29 @@ namespace App.Desktop.Services.Upload;
 public sealed class DesktopUploadSectionViewModel(
     IDesktopVideoFilePicker videoFilePicker,
     IDesktopVideoHashService videoHashService,
+    IDesktopPreUploadCheckClient preUploadCheckClient,
     DesktopUploadSectionOptions uploadSectionOptions)
 {
     public DesktopUploadSectionViewModel(
         IDesktopVideoFilePicker videoFilePicker,
         IDesktopVideoHashService videoHashService)
-        : this(videoFilePicker, videoHashService, DesktopUploadSectionOptions.Disabled)
+        : this(
+            videoFilePicker,
+            videoHashService,
+            new DisabledDesktopPreUploadCheckClient(),
+            DesktopUploadSectionOptions.Disabled)
+    {
+    }
+
+    public DesktopUploadSectionViewModel(
+        IDesktopVideoFilePicker videoFilePicker,
+        IDesktopVideoHashService videoHashService,
+        DesktopUploadSectionOptions uploadSectionOptions)
+        : this(
+            videoFilePicker,
+            videoHashService,
+            new DisabledDesktopPreUploadCheckClient(),
+            uploadSectionOptions)
     {
     }
 
@@ -18,6 +35,8 @@ public sealed class DesktopUploadSectionViewModel(
         videoFilePicker ?? throw new ArgumentNullException(nameof(videoFilePicker));
     private readonly IDesktopVideoHashService _videoHashService =
         videoHashService ?? throw new ArgumentNullException(nameof(videoHashService));
+    private readonly IDesktopPreUploadCheckClient _preUploadCheckClient =
+        preUploadCheckClient ?? throw new ArgumentNullException(nameof(preUploadCheckClient));
     private readonly DesktopUploadSectionOptions _uploadSectionOptions =
         uploadSectionOptions ?? throw new ArgumentNullException(nameof(uploadSectionOptions));
 
@@ -30,6 +49,8 @@ public sealed class DesktopUploadSectionViewModel(
     public bool IsSelectingFile { get; private set; }
 
     public bool IsHashing { get; private set; }
+
+    public bool IsCheckingPreUpload { get; private set; }
 
     public bool CanCalculateHash => SelectedFile is not null && !IsSelectingFile && !IsHashing;
 
@@ -48,6 +69,9 @@ public sealed class DesktopUploadSectionViewModel(
     public bool IsDevFakeBusinessObjectKeyEnabled =>
         _uploadSectionOptions.IsDevFakeBusinessObjectKeyEnabled;
 
+    public bool IsDevFakePreUploadCheckEnabled =>
+        _uploadSectionOptions.IsDevFakePreUploadCheckEnabled;
+
     public string BusinessObjectKeyInput { get; set; } = string.Empty;
 
     public DesktopUploadBusinessObjectKey? BusinessObjectKey { get; private set; }
@@ -58,6 +82,23 @@ public sealed class DesktopUploadSectionViewModel(
 
     public string BusinessObjectKeyStatusMessage { get; private set; } =
         DesktopUploadSectionText.BusinessObjectKeyEmptyValidationMessage;
+
+    public DesktopPreUploadCheckRequestPreview? PreUploadCheckRequestPreview =>
+        DesktopPreUploadCheckRequestPreview.TryCreate(SelectedFile, Sha256Hex, BusinessObjectKey);
+
+    public bool HasPreUploadCheckRequestPreview => PreUploadCheckRequestPreview is not null;
+
+    public bool CanRequestPreUploadCheck =>
+        HasPreUploadCheckRequestPreview && !IsSelectingFile && !IsHashing && !IsCheckingPreUpload;
+
+    public DesktopPreUploadCheckResult? PreUploadCheckResult { get; private set; }
+
+    public bool HasPreUploadCheckDecision => PreUploadCheckResult?.Decision is not null;
+
+    public string? PreUploadCheckDecisionPreview => PreUploadCheckResult?.DecisionPreview;
+
+    public string PreUploadCheckStatusMessage { get; private set; } =
+        DesktopUploadSectionText.PreUploadCheckNotReadyMessage;
 
     public void OpenUploadSection()
     {
@@ -87,6 +128,7 @@ public sealed class DesktopUploadSectionViewModel(
         SelectionStatusMessage = DesktopUploadSectionText.SelectingFileMessage;
         ResetSelectedFileHashState();
         ResetBusinessObjectKeyState();
+        ResetPreUploadCheckState();
 
         try
         {
@@ -100,6 +142,7 @@ public sealed class DesktopUploadSectionViewModel(
                     : DesktopVideoHashRequest.FromSource(result.HashSource);
                 SelectionStatusMessage = DesktopUploadSectionText.SelectedFilePreviewMessage;
                 HashStatusMessage = DesktopUploadSectionText.HashReadyMessage;
+                RefreshPreUploadCheckReadiness();
                 return SelectedFile;
             }
 
@@ -126,6 +169,7 @@ public sealed class DesktopUploadSectionViewModel(
         IsHashing = true;
         Sha256Hex = null;
         HashStatusMessage = DesktopUploadSectionText.HashInProgressMessage;
+        ResetPreUploadCheckState();
 
         try
         {
@@ -143,6 +187,7 @@ public sealed class DesktopUploadSectionViewModel(
             {
                 Sha256Hex = result.Sha256Hex;
                 HashStatusMessage = DesktopUploadSectionText.HashSucceededMessage;
+                RefreshPreUploadCheckReadiness();
                 return result;
             }
 
@@ -157,6 +202,7 @@ public sealed class DesktopUploadSectionViewModel(
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             HashStatusMessage = DesktopUploadSectionText.HashCanceledMessage;
+            RefreshPreUploadCheckReadiness();
             return DesktopVideoHashResult.Canceled;
         }
         finally
@@ -173,6 +219,8 @@ public sealed class DesktopUploadSectionViewModel(
         BusinessObjectKeyInput = validation.SafeInputValue;
         BusinessObjectKey = validation.BusinessObjectKey;
         BusinessObjectKeyStatusMessage = validation.Message;
+        ResetPreUploadCheckDecision();
+        RefreshPreUploadCheckReadiness();
 
         return validation;
     }
@@ -188,12 +236,56 @@ public sealed class DesktopUploadSectionViewModel(
         return ApplyBusinessObjectKey();
     }
 
+    public async ValueTask<DesktopPreUploadCheckResult?> CheckPreUploadAsync(CancellationToken cancellationToken)
+    {
+        if (IsCheckingPreUpload)
+        {
+            return PreUploadCheckResult;
+        }
+
+        DesktopPreUploadCheckRequestPreview? requestPreview = PreUploadCheckRequestPreview;
+        if (requestPreview is null)
+        {
+            PreUploadCheckStatusMessage = DesktopUploadSectionText.PreUploadCheckNotReadyMessage;
+            return null;
+        }
+
+        if (!IsDevFakePreUploadCheckEnabled)
+        {
+            PreUploadCheckResult = DesktopPreUploadCheckResult.Deferred;
+            PreUploadCheckStatusMessage = DesktopUploadSectionText.PreUploadCheckDeferredMessage;
+            return PreUploadCheckResult;
+        }
+
+        IsCheckingPreUpload = true;
+        PreUploadCheckResult = null;
+        PreUploadCheckStatusMessage = DesktopUploadSectionText.PreUploadCheckInProgressMessage;
+
+        try
+        {
+            PreUploadCheckResult = await _preUploadCheckClient.CheckAsync(requestPreview, cancellationToken);
+            PreUploadCheckStatusMessage = PreUploadCheckResult.Message;
+            return PreUploadCheckResult;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            PreUploadCheckResult = DesktopPreUploadCheckResult.Canceled;
+            PreUploadCheckStatusMessage = DesktopUploadSectionText.PreUploadCheckCanceledMessage;
+            return PreUploadCheckResult;
+        }
+        finally
+        {
+            IsCheckingPreUpload = false;
+        }
+    }
+
     private void ResetSelection()
     {
         SelectedFile = null;
         SelectionStatusMessage = DesktopUploadSectionText.PlaceholderResult;
         ResetSelectedFileHashState();
         ResetBusinessObjectKeyState();
+        ResetPreUploadCheckState();
     }
 
     private void ResetSelectedFileHashState()
@@ -202,6 +294,7 @@ public sealed class DesktopUploadSectionViewModel(
         IsHashing = false;
         Sha256Hex = null;
         HashStatusMessage = DesktopUploadSectionText.HashNotReadyMessage;
+        ResetPreUploadCheckState();
     }
 
     private void ResetBusinessObjectKeyState()
@@ -209,5 +302,31 @@ public sealed class DesktopUploadSectionViewModel(
         BusinessObjectKeyInput = string.Empty;
         BusinessObjectKey = null;
         BusinessObjectKeyStatusMessage = DesktopUploadSectionText.BusinessObjectKeyEmptyValidationMessage;
+        ResetPreUploadCheckState();
+    }
+
+    private void ResetPreUploadCheckState()
+    {
+        IsCheckingPreUpload = false;
+        PreUploadCheckResult = null;
+        PreUploadCheckStatusMessage = DesktopUploadSectionText.PreUploadCheckNotReadyMessage;
+    }
+
+    private void ResetPreUploadCheckDecision()
+    {
+        IsCheckingPreUpload = false;
+        PreUploadCheckResult = null;
+    }
+
+    private void RefreshPreUploadCheckReadiness()
+    {
+        if (IsCheckingPreUpload)
+        {
+            return;
+        }
+
+        PreUploadCheckStatusMessage = HasPreUploadCheckRequestPreview
+            ? DesktopUploadSectionText.PreUploadCheckReadyMessage
+            : DesktopUploadSectionText.PreUploadCheckNotReadyMessage;
     }
 }

--- a/src/App.Desktop/Services/Upload/DisabledDesktopPreUploadCheckClient.cs
+++ b/src/App.Desktop/Services/Upload/DisabledDesktopPreUploadCheckClient.cs
@@ -1,0 +1,16 @@
+using App.Desktop.Boundaries;
+
+namespace App.Desktop.Services.Upload;
+
+public sealed class DisabledDesktopPreUploadCheckClient : IDesktopPreUploadCheckClient
+{
+    public ValueTask<DesktopPreUploadCheckResult> CheckAsync(
+        DesktopPreUploadCheckRequestPreview requestPreview,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(requestPreview);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return ValueTask.FromResult(DesktopPreUploadCheckResult.Deferred);
+    }
+}

--- a/src/App.Desktop/Services/Upload/FakeDesktopPreUploadCheckClient.cs
+++ b/src/App.Desktop/Services/Upload/FakeDesktopPreUploadCheckClient.cs
@@ -1,0 +1,17 @@
+using App.Desktop.Boundaries;
+
+namespace App.Desktop.Services.Upload;
+
+public sealed class FakeDesktopPreUploadCheckClient(
+    DesktopPreUploadCheckDecision decision = DesktopPreUploadCheckDecision.Allow) : IDesktopPreUploadCheckClient
+{
+    public ValueTask<DesktopPreUploadCheckResult> CheckAsync(
+        DesktopPreUploadCheckRequestPreview requestPreview,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(requestPreview);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return ValueTask.FromResult(DesktopPreUploadCheckResult.FromFakeDecision(decision));
+    }
+}

--- a/src/App.Desktop/wwwroot/app.css
+++ b/src/App.Desktop/wwwroot/app.css
@@ -281,7 +281,8 @@ body {
 .desktop-upload__back,
 .desktop-upload__select,
 .desktop-upload__hash,
-.desktop-upload__key {
+.desktop-upload__key,
+.desktop-upload__preupload {
     min-height: 38px;
     padding: 0 16px;
     border-radius: 6px;
@@ -299,7 +300,8 @@ body {
 
 .desktop-upload__select,
 .desktop-upload__hash,
-.desktop-upload__key {
+.desktop-upload__key,
+.desktop-upload__preupload {
     width: fit-content;
     border: 1px solid #18406b;
     background: #18406b;
@@ -309,7 +311,8 @@ body {
 .desktop-upload__back:disabled,
 .desktop-upload__select:disabled,
 .desktop-upload__hash:disabled,
-.desktop-upload__key:disabled {
+.desktop-upload__key:disabled,
+.desktop-upload__preupload:disabled {
     color: #687789;
     border-color: #b9c3cf;
     background: #eef1f5;
@@ -381,7 +384,9 @@ body {
 
 .desktop-upload__selection,
 .desktop-upload__hash-result,
-.desktop-upload__business-object-key {
+.desktop-upload__business-object-key,
+.desktop-upload__preupload-preview,
+.desktop-upload__preupload-decision {
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 12px;
@@ -396,9 +401,19 @@ body {
     grid-template-columns: minmax(0, 1fr);
 }
 
+.desktop-upload__preupload-preview {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.desktop-upload__preupload-decision {
+    grid-template-columns: minmax(0, 1fr);
+}
+
 .desktop-upload__selection div,
 .desktop-upload__hash-result div,
-.desktop-upload__business-object-key div {
+.desktop-upload__business-object-key div,
+.desktop-upload__preupload-preview div,
+.desktop-upload__preupload-decision div {
     min-width: 0;
     padding: 12px;
     border: 1px solid #d7dde5;
@@ -408,7 +423,9 @@ body {
 
 .desktop-upload__selection dt,
 .desktop-upload__hash-result dt,
-.desktop-upload__business-object-key dt {
+.desktop-upload__business-object-key dt,
+.desktop-upload__preupload-preview dt,
+.desktop-upload__preupload-decision dt {
     margin: 0 0 4px;
     color: #52616f;
     font-size: 0.78rem;
@@ -417,7 +434,9 @@ body {
 
 .desktop-upload__selection dd,
 .desktop-upload__hash-result dd,
-.desktop-upload__business-object-key dd {
+.desktop-upload__business-object-key dd,
+.desktop-upload__preupload-preview dd,
+.desktop-upload__preupload-decision dd {
     margin: 0;
     color: #18212f;
     font-size: 0.9rem;
@@ -448,13 +467,16 @@ body {
     .desktop-upload__back,
     .desktop-upload__select,
     .desktop-upload__hash,
-    .desktop-upload__key {
+    .desktop-upload__key,
+    .desktop-upload__preupload {
         width: 100%;
     }
 
     .desktop-upload__selection,
     .desktop-upload__hash-result,
-    .desktop-upload__business-object-key {
+    .desktop-upload__business-object-key,
+    .desktop-upload__preupload-preview,
+    .desktop-upload__preupload-decision {
         grid-template-columns: 1fr;
     }
 

--- a/tests/Unit/App.Desktop.Tests/DesktopCompositionRootTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopCompositionRootTests.cs
@@ -23,8 +23,11 @@ public sealed class DesktopCompositionRootTests
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
         Assert.IsType<WpfDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
         Assert.IsType<DesktopVideoHashService>(services.GetRequiredService<IDesktopVideoHashService>());
+        Assert.IsType<DisabledDesktopPreUploadCheckClient>(
+            services.GetRequiredService<IDesktopPreUploadCheckClient>());
     }
 
     [Fact]
@@ -35,7 +38,8 @@ public sealed class DesktopCompositionRootTests
             .Set(DesktopAuthOptions.DevFakeAuthEnabledEnvironmentVariable, null)
             .Set(DesktopUploadSectionOptions.DevFakeUploadFileEnabledEnvironmentVariable, null)
             .Set(DesktopUploadSectionOptions.DevFakeUploadHashEnabledEnvironmentVariable, null)
-            .Set(DesktopUploadSectionOptions.DevFakeBusinessObjectKeyEnabledEnvironmentVariable, null);
+            .Set(DesktopUploadSectionOptions.DevFakeBusinessObjectKeyEnabledEnvironmentVariable, null)
+            .Set(DesktopUploadSectionOptions.DevFakePreUploadCheckEnabledEnvironmentVariable, null);
 
         using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
 
@@ -43,9 +47,12 @@ public sealed class DesktopCompositionRootTests
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
         Assert.IsType<UnavailableDesktopAuthClient>(services.GetRequiredService<IDesktopAuthClient>());
         Assert.IsType<WpfDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
         Assert.IsType<DesktopVideoHashService>(services.GetRequiredService<IDesktopVideoHashService>());
+        Assert.IsType<DisabledDesktopPreUploadCheckClient>(
+            services.GetRequiredService<IDesktopPreUploadCheckClient>());
     }
 
     [Fact]
@@ -56,7 +63,8 @@ public sealed class DesktopCompositionRootTests
             .Set(DesktopAuthOptions.DevFakeAuthEnabledEnvironmentVariable, null)
             .Set(DesktopUploadSectionOptions.DevFakeUploadFileEnabledEnvironmentVariable, "true")
             .Set(DesktopUploadSectionOptions.DevFakeUploadHashEnabledEnvironmentVariable, null)
-            .Set(DesktopUploadSectionOptions.DevFakeBusinessObjectKeyEnabledEnvironmentVariable, null);
+            .Set(DesktopUploadSectionOptions.DevFakeBusinessObjectKeyEnabledEnvironmentVariable, null)
+            .Set(DesktopUploadSectionOptions.DevFakePreUploadCheckEnabledEnvironmentVariable, null);
 
         using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
 
@@ -64,14 +72,20 @@ public sealed class DesktopCompositionRootTests
         Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
         Assert.IsType<FakeDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
         Assert.IsType<DesktopVideoHashService>(services.GetRequiredService<IDesktopVideoHashService>());
+        Assert.IsType<DisabledDesktopPreUploadCheckClient>(
+            services.GetRequiredService<IDesktopPreUploadCheckClient>());
 #else
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
         Assert.IsType<WpfDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
         Assert.IsType<DesktopVideoHashService>(services.GetRequiredService<IDesktopVideoHashService>());
+        Assert.IsType<DisabledDesktopPreUploadCheckClient>(
+            services.GetRequiredService<IDesktopPreUploadCheckClient>());
 #endif
     }
 
@@ -83,7 +97,8 @@ public sealed class DesktopCompositionRootTests
             .Set(DesktopAuthOptions.DevFakeAuthEnabledEnvironmentVariable, null)
             .Set(DesktopUploadSectionOptions.DevFakeUploadFileEnabledEnvironmentVariable, null)
             .Set(DesktopUploadSectionOptions.DevFakeUploadHashEnabledEnvironmentVariable, "true")
-            .Set(DesktopUploadSectionOptions.DevFakeBusinessObjectKeyEnabledEnvironmentVariable, null);
+            .Set(DesktopUploadSectionOptions.DevFakeBusinessObjectKeyEnabledEnvironmentVariable, null)
+            .Set(DesktopUploadSectionOptions.DevFakePreUploadCheckEnabledEnvironmentVariable, null);
 
         using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
 
@@ -91,14 +106,20 @@ public sealed class DesktopCompositionRootTests
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
         Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
         Assert.IsType<WpfDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
         Assert.IsType<FakeDesktopVideoHashService>(services.GetRequiredService<IDesktopVideoHashService>());
+        Assert.IsType<DisabledDesktopPreUploadCheckClient>(
+            services.GetRequiredService<IDesktopPreUploadCheckClient>());
 #else
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
         Assert.IsType<WpfDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
         Assert.IsType<DesktopVideoHashService>(services.GetRequiredService<IDesktopVideoHashService>());
+        Assert.IsType<DisabledDesktopPreUploadCheckClient>(
+            services.GetRequiredService<IDesktopPreUploadCheckClient>());
 #endif
     }
 
@@ -110,7 +131,8 @@ public sealed class DesktopCompositionRootTests
             .Set(DesktopAuthOptions.DevFakeAuthEnabledEnvironmentVariable, null)
             .Set(DesktopUploadSectionOptions.DevFakeUploadFileEnabledEnvironmentVariable, "true")
             .Set(DesktopUploadSectionOptions.DevFakeUploadHashEnabledEnvironmentVariable, "true")
-            .Set(DesktopUploadSectionOptions.DevFakeBusinessObjectKeyEnabledEnvironmentVariable, null);
+            .Set(DesktopUploadSectionOptions.DevFakeBusinessObjectKeyEnabledEnvironmentVariable, null)
+            .Set(DesktopUploadSectionOptions.DevFakePreUploadCheckEnabledEnvironmentVariable, null);
 
         using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
 
@@ -118,14 +140,20 @@ public sealed class DesktopCompositionRootTests
         Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
         Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
         Assert.IsType<FakeDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
         Assert.IsType<FakeDesktopVideoHashService>(services.GetRequiredService<IDesktopVideoHashService>());
+        Assert.IsType<DisabledDesktopPreUploadCheckClient>(
+            services.GetRequiredService<IDesktopPreUploadCheckClient>());
 #else
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
         Assert.IsType<WpfDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
         Assert.IsType<DesktopVideoHashService>(services.GetRequiredService<IDesktopVideoHashService>());
+        Assert.IsType<DisabledDesktopPreUploadCheckClient>(
+            services.GetRequiredService<IDesktopPreUploadCheckClient>());
 #endif
     }
 
@@ -137,7 +165,8 @@ public sealed class DesktopCompositionRootTests
             .Set(DesktopAuthOptions.DevFakeAuthEnabledEnvironmentVariable, null)
             .Set(DesktopUploadSectionOptions.DevFakeUploadFileEnabledEnvironmentVariable, null)
             .Set(DesktopUploadSectionOptions.DevFakeUploadHashEnabledEnvironmentVariable, null)
-            .Set(DesktopUploadSectionOptions.DevFakeBusinessObjectKeyEnabledEnvironmentVariable, "true");
+            .Set(DesktopUploadSectionOptions.DevFakeBusinessObjectKeyEnabledEnvironmentVariable, "true")
+            .Set(DesktopUploadSectionOptions.DevFakePreUploadCheckEnabledEnvironmentVariable, null);
 
         using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
 
@@ -145,12 +174,52 @@ public sealed class DesktopCompositionRootTests
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
         Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
         Assert.True(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakeBusinessObjectKeyEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakePreUploadCheckEnabled);
+        Assert.IsType<DisabledDesktopPreUploadCheckClient>(
+            services.GetRequiredService<IDesktopPreUploadCheckClient>());
 #else
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakeBusinessObjectKeyEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakePreUploadCheckEnabled);
+        Assert.IsType<DisabledDesktopPreUploadCheckClient>(
+            services.GetRequiredService<IDesktopPreUploadCheckClient>());
+#endif
+    }
+
+    [Fact]
+    public void EnvironmentOptionsEnableFakePreUploadCheckOnlyWhenExplicitlyRequested()
+    {
+        using var environment = new EnvironmentVariableScope()
+            .Set(DesktopAuthOptions.ControlPlaneBaseAddressEnvironmentVariable, null)
+            .Set(DesktopAuthOptions.DevFakeAuthEnabledEnvironmentVariable, null)
+            .Set(DesktopUploadSectionOptions.DevFakeUploadFileEnabledEnvironmentVariable, null)
+            .Set(DesktopUploadSectionOptions.DevFakeUploadHashEnabledEnvironmentVariable, null)
+            .Set(DesktopUploadSectionOptions.DevFakeBusinessObjectKeyEnabledEnvironmentVariable, null)
+            .Set(DesktopUploadSectionOptions.DevFakePreUploadCheckEnabledEnvironmentVariable, "true");
+
+        using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
+
+#if DEBUG
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
+        Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
+        Assert.True(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakePreUploadCheckEnabled);
+        Assert.IsType<FakeDesktopPreUploadCheckClient>(
+            services.GetRequiredService<IDesktopPreUploadCheckClient>());
+#else
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakePreUploadCheckEnabled);
+        Assert.IsType<DisabledDesktopPreUploadCheckClient>(
+            services.GetRequiredService<IDesktopPreUploadCheckClient>());
 #endif
     }
 
@@ -162,7 +231,8 @@ public sealed class DesktopCompositionRootTests
             .Set(DesktopAuthOptions.DevFakeAuthEnabledEnvironmentVariable, "true")
             .Set(DesktopUploadSectionOptions.DevFakeUploadFileEnabledEnvironmentVariable, "true")
             .Set(DesktopUploadSectionOptions.DevFakeUploadHashEnabledEnvironmentVariable, "true")
-            .Set(DesktopUploadSectionOptions.DevFakeBusinessObjectKeyEnabledEnvironmentVariable, "true");
+            .Set(DesktopUploadSectionOptions.DevFakeBusinessObjectKeyEnabledEnvironmentVariable, "true")
+            .Set(DesktopUploadSectionOptions.DevFakePreUploadCheckEnabledEnvironmentVariable, "true");
 
         using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
 
@@ -171,18 +241,25 @@ public sealed class DesktopCompositionRootTests
         Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
         Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
         Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
+        Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
         Assert.IsType<FakeDesktopAuthClient>(services.GetRequiredService<IDesktopAuthClient>());
         Assert.IsType<FakeDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
         Assert.IsType<FakeDesktopVideoHashService>(services.GetRequiredService<IDesktopVideoHashService>());
         Assert.True(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakeBusinessObjectKeyEnabled);
+        Assert.True(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakePreUploadCheckEnabled);
+        Assert.IsType<FakeDesktopPreUploadCheckClient>(
+            services.GetRequiredService<IDesktopPreUploadCheckClient>());
 #else
         Assert.False(services.GetRequiredService<DesktopAuthOptions>().IsDevFakeAuthEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
         Assert.IsType<UnavailableDesktopAuthClient>(services.GetRequiredService<IDesktopAuthClient>());
         Assert.IsType<WpfDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
         Assert.IsType<DesktopVideoHashService>(services.GetRequiredService<IDesktopVideoHashService>());
+        Assert.IsType<DisabledDesktopPreUploadCheckClient>(
+            services.GetRequiredService<IDesktopPreUploadCheckClient>());
 #endif
     }
 

--- a/tests/Unit/App.Desktop.Tests/DesktopSignInServiceTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopSignInServiceTests.cs
@@ -268,6 +268,9 @@ public sealed class DesktopSignInServiceTests
         Assert.Contains("UploadSectionViewModel.BusinessObjectKeyInput", markup, StringComparison.Ordinal);
         Assert.Contains("UploadSectionViewModel.ApplyBusinessObjectKey()", markup, StringComparison.Ordinal);
         Assert.Contains("UploadSectionViewModel.UseDevFakeBusinessObjectKey()", markup, StringComparison.Ordinal);
+        Assert.Contains("DesktopUploadSectionText.StepFourTitle", markup, StringComparison.Ordinal);
+        Assert.Contains("UploadSectionViewModel.PreUploadCheckRequestPreview", markup, StringComparison.Ordinal);
+        Assert.Contains("UploadSectionViewModel.CheckPreUploadAsync(CancellationToken.None)", markup, StringComparison.Ordinal);
         Assert.DoesNotContain("<UploadPlaceholder", markup, StringComparison.Ordinal);
         Assert.DoesNotContain("IDesktopUploadOrchestrator", markup, StringComparison.Ordinal);
         Assert.DoesNotContain("IControlPlaneApiClient", markup, StringComparison.Ordinal);

--- a/tests/Unit/App.Desktop.Tests/DesktopUploadSectionTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopUploadSectionTests.cs
@@ -37,7 +37,7 @@ public sealed class DesktopUploadSectionTests
         Assert.Equal(
             "Этот раздел показывает безопасные сведения о выбранном видеофайле. Реальная загрузка будет включена в следующем approved desktop slice.",
             DesktopUploadSectionText.Description);
-        Assert.Equal("Шаг 1. Выбор видеофайла", DesktopUploadSectionText.StepOneTitle);
+        Assert.Equal("Шаг 1. Метаданные файла", DesktopUploadSectionText.StepOneTitle);
         Assert.Equal("Выбрать видеофайл", DesktopUploadSectionText.SelectVideoFileButton);
         Assert.Equal(
             "Выберите видеофайл для безопасного предпросмотра.",
@@ -82,8 +82,33 @@ public sealed class DesktopUploadSectionTests
             "Ключ бизнес-объекта принят для безопасного preview.",
             DesktopUploadSectionText.BusinessObjectKeyAcceptedMessage);
         Assert.Equal("businessObjectKey", DesktopUploadSectionText.BusinessObjectKeyPreviewLabel);
+        Assert.Equal("Шаг 4. Предварительная проверка", DesktopUploadSectionText.StepFourTitle);
         Assert.Equal(
-            "Следующий шаг отложен: PreUploadCheck будет добавлен отдельным approved desktop slice.",
+            "Выберите файл, рассчитайте SHA-256 и укажите ключ бизнес-объекта для preview запроса.",
+            DesktopUploadSectionText.PreUploadCheckNotReadyMessage);
+        Assert.Equal(
+            "Preview запроса готов. Реальный вызов App.Api в этом slice не выполняется.",
+            DesktopUploadSectionText.PreUploadCheckReadyMessage);
+        Assert.Equal(
+            "Выполняется предварительная проверка в desktop-local dev boundary.",
+            DesktopUploadSectionText.PreUploadCheckInProgressMessage);
+        Assert.Equal(
+            "Предварительная проверка пока доступна только в dev-smoke режиме. Реальный вызов App.Api будет добавлен отдельным approved slice.",
+            DesktopUploadSectionText.PreUploadCheckDeferredMessage);
+        Assert.Equal(
+            "Предварительная проверка: загрузка разрешена в dev-smoke режиме.",
+            DesktopUploadSectionText.PreUploadCheckAllowedDevMessage);
+        Assert.Equal("Проверить перед загрузкой", DesktopUploadSectionText.PreUploadCheckButton);
+        Assert.Equal("Проверяется...", DesktopUploadSectionText.PreUploadCheckBusyButton);
+        Assert.Equal("Имя файла", DesktopUploadSectionText.PreUploadCheckFileNameLabel);
+        Assert.Equal("Размер", DesktopUploadSectionText.PreUploadCheckFileSizeLabel);
+        Assert.Equal("Тип содержимого", DesktopUploadSectionText.PreUploadCheckContentTypeLabel);
+        Assert.Equal("SHA-256", DesktopUploadSectionText.PreUploadCheckSha256Label);
+        Assert.Equal("businessObjectKey", DesktopUploadSectionText.PreUploadCheckBusinessObjectKeyLabel);
+        Assert.Equal("capturedAtUtc", DesktopUploadSectionText.PreUploadCheckCapturedAtUtcLabel);
+        Assert.Equal("Решение", DesktopUploadSectionText.PreUploadCheckDecisionLabel);
+        Assert.Equal(
+            "Следующий шаг отложен: direct site upload boundary будет добавлен отдельным approved desktop slice.",
             DesktopUploadSectionText.NextStepDeferredMessage);
     }
 
@@ -99,9 +124,13 @@ public sealed class DesktopUploadSectionTests
             Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "FakeDesktopVideoHashService.cs"),
             Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "DesktopVideoHashService.cs"),
             Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "DesktopUploadBusinessObjectKey.cs"),
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "DesktopPreUploadCheck.cs"),
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "DisabledDesktopPreUploadCheckClient.cs"),
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "FakeDesktopPreUploadCheckClient.cs"),
             Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "WpfDesktopVideoFilePicker.cs"),
             Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Boundaries", "DesktopVideoFilePickerBoundary.cs"),
-            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Boundaries", "DesktopVideoHashBoundary.cs")
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Boundaries", "DesktopVideoHashBoundary.cs"),
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Boundaries", "DesktopPreUploadCheckBoundary.cs")
         ];
 
         foreach (string sourceFile in sourceFiles)
@@ -127,12 +156,16 @@ public sealed class DesktopUploadSectionTests
         Assert.False(DesktopUploadSectionOptions.Disabled.IsDevFakeUploadFileEnabled);
         Assert.False(DesktopUploadSectionOptions.Disabled.IsDevFakeUploadHashEnabled);
         Assert.False(DesktopUploadSectionOptions.Disabled.IsDevFakeBusinessObjectKeyEnabled);
+        Assert.False(DesktopUploadSectionOptions.Disabled.IsDevFakePreUploadCheckEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue(null).IsDevFakeUploadFileEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue(null).IsDevFakeUploadHashEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue(null).IsDevFakeBusinessObjectKeyEnabled);
+        Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue(null).IsDevFakePreUploadCheckEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("false").IsDevFakeUploadFileEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("false", "false").IsDevFakeUploadHashEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "false").IsDevFakeBusinessObjectKeyEnabled);
+        Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "false", "false")
+            .IsDevFakePreUploadCheckEnabled);
 
 #if DEBUG
         Assert.True(DesktopUploadSectionOptions.FromEnvironmentValue("true").IsDevFakeUploadFileEnabled);
@@ -140,12 +173,20 @@ public sealed class DesktopUploadSectionTests
         Assert.True(DesktopUploadSectionOptions.FromEnvironmentValue("true", "true").IsDevFakeUploadHashEnabled);
         Assert.True(DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "true").IsDevFakeBusinessObjectKeyEnabled);
         Assert.True(DesktopUploadSectionOptions.FromEnvironmentValue("true", "true", "true").IsDevFakeBusinessObjectKeyEnabled);
+        Assert.True(DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "false", "true")
+            .IsDevFakePreUploadCheckEnabled);
+        Assert.True(DesktopUploadSectionOptions.FromEnvironmentValue("true", "true", "true", "true")
+            .IsDevFakePreUploadCheckEnabled);
 #else
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("true").IsDevFakeUploadFileEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("false", "true").IsDevFakeUploadHashEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("true", "true").IsDevFakeUploadHashEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "true").IsDevFakeBusinessObjectKeyEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("true", "true", "true").IsDevFakeBusinessObjectKeyEnabled);
+        Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "false", "true")
+            .IsDevFakePreUploadCheckEnabled);
+        Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("true", "true", "true", "true")
+            .IsDevFakePreUploadCheckEnabled);
 #endif
     }
 
@@ -433,6 +474,160 @@ public sealed class DesktopUploadSectionTests
     }
 
     [Fact]
+    public async Task PreUploadCheckRequestPreviewRequiresSelectedFileSha256AndBusinessObjectKey()
+    {
+        var viewModel = CreateViewModel(new FakeDesktopVideoFilePicker());
+
+        Assert.Null(viewModel.PreUploadCheckRequestPreview);
+        Assert.False(viewModel.HasPreUploadCheckRequestPreview);
+        Assert.False(viewModel.CanRequestPreUploadCheck);
+
+        _ = await viewModel.SelectVideoFileAsync(CancellationToken.None);
+
+        Assert.Null(viewModel.PreUploadCheckRequestPreview);
+        Assert.Equal(DesktopUploadSectionText.PreUploadCheckNotReadyMessage, viewModel.PreUploadCheckStatusMessage);
+
+        _ = await viewModel.CalculateSha256Async(CancellationToken.None);
+
+        Assert.Null(viewModel.PreUploadCheckRequestPreview);
+        Assert.Equal(DesktopUploadSectionText.PreUploadCheckNotReadyMessage, viewModel.PreUploadCheckStatusMessage);
+
+        viewModel.BusinessObjectKeyInput = "report-draft-001";
+        _ = viewModel.ApplyBusinessObjectKey();
+
+        Assert.NotNull(viewModel.PreUploadCheckRequestPreview);
+        Assert.True(viewModel.HasPreUploadCheckRequestPreview);
+        Assert.True(viewModel.CanRequestPreUploadCheck);
+        Assert.Equal(DesktopUploadSectionText.PreUploadCheckReadyMessage, viewModel.PreUploadCheckStatusMessage);
+    }
+
+    [Fact]
+    public async Task PreUploadCheckRequestPreviewShowsOnlySafeFields()
+    {
+        var viewModel = CreateViewModel(new StaticDesktopVideoFilePicker(
+            DesktopVideoFilePickerResult.Selected(
+                Path.Combine("private-folder", "nested", "safe-preview.mp4"),
+                42,
+                "video/mp4",
+                DesktopVideoHashSource.VisualSmoke)));
+
+        _ = await PreparePreUploadCheckPreviewAsync(viewModel, " report-draft-001 ");
+
+        DesktopPreUploadCheckRequestPreview preview =
+            viewModel.PreUploadCheckRequestPreview ?? throw new InvalidOperationException("Preview was not created.");
+
+        Assert.Equal("safe-preview.mp4", preview.FileName);
+        Assert.Equal(42, preview.SizeBytes);
+        Assert.Equal("video/mp4", preview.ContentType);
+        Assert.Equal(FakeDesktopVideoHashService.VisualSmokeSha256Hex, preview.Sha256Hex);
+        Assert.Equal("report-draft-001", preview.BusinessObjectKeyPreview);
+        Assert.Equal(DesktopPreUploadCheckRequestPreview.CapturedAtUtcPlaceholder, preview.CapturedAtUtc);
+    }
+
+    [Fact]
+    public async Task PreUploadCheckRequestPreviewDoesNotShowFullLocalPath()
+    {
+        string privateFolder = "operator-private-preupload-source";
+        string localPath = Path.Combine(Path.GetTempPath(), privateFolder, "safe-preview.mp4");
+        var viewModel = CreateViewModel(new StaticDesktopVideoFilePicker(
+            DesktopVideoFilePickerResult.Selected(
+                localPath,
+                42,
+                "video/mp4",
+                DesktopVideoHashSource.VisualSmoke)));
+
+        DesktopPreUploadCheckRequestPreview preview = await PreparePreUploadCheckPreviewAsync(
+            viewModel,
+            "report-draft-001");
+
+        string visibleState = preview.ToString()
+            + " "
+            + viewModel.PreUploadCheckStatusMessage
+            + " "
+            + (viewModel.PreUploadCheckDecisionPreview ?? string.Empty);
+
+        Assert.Equal("safe-preview.mp4", preview.FileName);
+        Assert.DoesNotContain(Path.GetTempPath(), visibleState, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(privateFolder, visibleState, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(@"\", preview.FileName, StringComparison.Ordinal);
+        Assert.DoesNotContain("/", preview.FileName, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task DisabledPreUploadCheckShowsSafeDeferredMessageAndDoesNotCallBoundary()
+    {
+        var preUploadCheckClient = new ThrowingDesktopPreUploadCheckClient();
+        var viewModel = CreateViewModel(
+            new FakeDesktopVideoFilePicker(),
+            new FakeDesktopVideoHashService(),
+            preUploadCheckClient,
+            DesktopUploadSectionOptions.Disabled);
+
+        _ = await PreparePreUploadCheckPreviewAsync(viewModel, "report-draft-001");
+
+        DesktopPreUploadCheckResult? result = await viewModel.CheckPreUploadAsync(CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal(DesktopPreUploadCheckStatus.Deferred, result.Status);
+        Assert.Null(result.Decision);
+        Assert.Null(viewModel.PreUploadCheckDecisionPreview);
+        Assert.Equal(DesktopUploadSectionText.PreUploadCheckDeferredMessage, viewModel.PreUploadCheckStatusMessage);
+        Assert.Equal(0, preUploadCheckClient.CallCount);
+    }
+
+    [Fact]
+    public async Task EnabledPreUploadCheckShowsFakeAllowDecision()
+    {
+        var viewModel = CreateViewModel(
+            new FakeDesktopVideoFilePicker(),
+            new FakeDesktopVideoHashService(),
+            new FakeDesktopPreUploadCheckClient(),
+            DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "false", "true"));
+
+        _ = await PreparePreUploadCheckPreviewAsync(viewModel, "report-draft-001");
+
+        DesktopPreUploadCheckResult? result = await viewModel.CheckPreUploadAsync(CancellationToken.None);
+
+#if DEBUG
+        Assert.NotNull(result);
+        Assert.Equal(DesktopPreUploadCheckStatus.Allowed, result.Status);
+        Assert.Equal(DesktopPreUploadCheckDecision.Allow, result.Decision);
+        Assert.Equal("ALLOW", result.DecisionPreview);
+        Assert.True(viewModel.HasPreUploadCheckDecision);
+        Assert.Equal("ALLOW", viewModel.PreUploadCheckDecisionPreview);
+        Assert.Equal(DesktopUploadSectionText.PreUploadCheckAllowedDevMessage, viewModel.PreUploadCheckStatusMessage);
+#else
+        Assert.NotNull(result);
+        Assert.Equal(DesktopPreUploadCheckStatus.Deferred, result.Status);
+        Assert.Null(viewModel.PreUploadCheckDecisionPreview);
+        Assert.Equal(DesktopUploadSectionText.PreUploadCheckDeferredMessage, viewModel.PreUploadCheckStatusMessage);
+#endif
+    }
+
+    [Theory]
+    [InlineData(DesktopPreUploadCheckDecision.Allow, "ALLOW")]
+    [InlineData(DesktopPreUploadCheckDecision.AllowWithReview, "ALLOW_WITH_REVIEW")]
+    [InlineData(DesktopPreUploadCheckDecision.BlockHardDuplicate, "BLOCK_HARD_DUPLICATE")]
+    [InlineData(DesktopPreUploadCheckDecision.BlockPossibleFalsification, "BLOCK_POSSIBLE_FALSIFICATION")]
+    public async Task FakePreUploadCheckSupportsExpectedDevDecisionNames(
+        DesktopPreUploadCheckDecision decision,
+        string expectedDecisionPreview)
+    {
+        DesktopPreUploadCheckRequestPreview requestPreview =
+            DesktopPreUploadCheckRequestPreview.TryCreate(
+                DesktopUploadSelectedFile.VisualSmokeFile,
+                FakeDesktopVideoHashService.VisualSmokeSha256Hex,
+                new DesktopUploadBusinessObjectKey(DesktopUploadBusinessObjectKey.VisualSmokeValue))
+            ?? throw new InvalidOperationException("Preview was not created.");
+        var client = new FakeDesktopPreUploadCheckClient(decision);
+
+        DesktopPreUploadCheckResult result = await client.CheckAsync(requestPreview, CancellationToken.None);
+
+        Assert.Equal(decision, result.Decision);
+        Assert.Equal(expectedDecisionPreview, result.DecisionPreview);
+    }
+
+    [Fact]
     public async Task RealHashBoundaryComputesLowercaseSha256ForSelectedLocalFile()
     {
         string tempDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
@@ -495,6 +690,7 @@ public sealed class DesktopUploadSectionTests
         _ = await viewModel.CalculateSha256Async(CancellationToken.None);
         viewModel.BusinessObjectKeyInput = "report-draft-001";
         _ = viewModel.ApplyBusinessObjectKey();
+        _ = await viewModel.CheckPreUploadAsync(CancellationToken.None);
 
         viewModel.ResetForSignedOutState();
 
@@ -509,6 +705,10 @@ public sealed class DesktopUploadSectionTests
         Assert.Null(viewModel.BusinessObjectKeyPreview);
         Assert.Equal(string.Empty, viewModel.BusinessObjectKeyInput);
         Assert.Equal(DesktopUploadSectionText.BusinessObjectKeyEmptyValidationMessage, viewModel.BusinessObjectKeyStatusMessage);
+        Assert.Null(viewModel.PreUploadCheckRequestPreview);
+        Assert.Null(viewModel.PreUploadCheckResult);
+        Assert.Null(viewModel.PreUploadCheckDecisionPreview);
+        Assert.Equal(DesktopUploadSectionText.PreUploadCheckNotReadyMessage, viewModel.PreUploadCheckStatusMessage);
     }
 
     [Fact]
@@ -521,6 +721,7 @@ public sealed class DesktopUploadSectionTests
         _ = await viewModel.CalculateSha256Async(CancellationToken.None);
         viewModel.BusinessObjectKeyInput = "report-draft-001";
         _ = viewModel.ApplyBusinessObjectKey();
+        _ = await viewModel.CheckPreUploadAsync(CancellationToken.None);
 
         viewModel.BackToWorkspace();
 
@@ -535,6 +736,10 @@ public sealed class DesktopUploadSectionTests
         Assert.Null(viewModel.BusinessObjectKeyPreview);
         Assert.Equal(string.Empty, viewModel.BusinessObjectKeyInput);
         Assert.Equal(DesktopUploadSectionText.BusinessObjectKeyEmptyValidationMessage, viewModel.BusinessObjectKeyStatusMessage);
+        Assert.Null(viewModel.PreUploadCheckRequestPreview);
+        Assert.Null(viewModel.PreUploadCheckResult);
+        Assert.Null(viewModel.PreUploadCheckDecisionPreview);
+        Assert.Equal(DesktopUploadSectionText.PreUploadCheckNotReadyMessage, viewModel.PreUploadCheckStatusMessage);
     }
 
     [Fact]
@@ -578,11 +783,35 @@ public sealed class DesktopUploadSectionTests
             DesktopUploadSectionText.BusinessObjectKeySecretValidationMessage,
             DesktopUploadSectionText.BusinessObjectKeyAcceptedMessage,
             DesktopUploadSectionText.BusinessObjectKeyPreviewLabel,
+            DesktopUploadSectionText.StepFourTitle,
+            DesktopUploadSectionText.PreUploadCheckNotReadyMessage,
+            DesktopUploadSectionText.PreUploadCheckReadyMessage,
+            DesktopUploadSectionText.PreUploadCheckInProgressMessage,
+            DesktopUploadSectionText.PreUploadCheckDeferredMessage,
+            DesktopUploadSectionText.PreUploadCheckAllowedDevMessage,
+            DesktopUploadSectionText.PreUploadCheckAllowWithReviewDevMessage,
+            DesktopUploadSectionText.PreUploadCheckBlockHardDuplicateDevMessage,
+            DesktopUploadSectionText.PreUploadCheckBlockPossibleFalsificationDevMessage,
+            DesktopUploadSectionText.PreUploadCheckCanceledMessage,
+            DesktopUploadSectionText.PreUploadCheckButton,
+            DesktopUploadSectionText.PreUploadCheckBusyButton,
+            DesktopUploadSectionText.PreUploadCheckFileNameLabel,
+            DesktopUploadSectionText.PreUploadCheckFileSizeLabel,
+            DesktopUploadSectionText.PreUploadCheckContentTypeLabel,
+            DesktopUploadSectionText.PreUploadCheckSha256Label,
+            DesktopUploadSectionText.PreUploadCheckBusinessObjectKeyLabel,
+            DesktopUploadSectionText.PreUploadCheckCapturedAtUtcLabel,
+            DesktopUploadSectionText.PreUploadCheckDecisionLabel,
             DesktopUploadSectionText.NextStepDeferredMessage,
             DesktopUploadSelectedFile.VisualSmokeFileName,
             DesktopUploadSelectedFile.VisualSmokeContentType,
             FakeDesktopVideoHashService.VisualSmokeSha256Hex,
-            DesktopUploadBusinessObjectKey.VisualSmokeValue
+            DesktopUploadBusinessObjectKey.VisualSmokeValue,
+            DesktopPreUploadCheckRequestPreview.CapturedAtUtcPlaceholder,
+            DesktopPreUploadCheckResult.FromFakeDecision(DesktopPreUploadCheckDecision.Allow).DecisionPreview ?? string.Empty,
+            DesktopPreUploadCheckResult.FromFakeDecision(DesktopPreUploadCheckDecision.AllowWithReview).DecisionPreview ?? string.Empty,
+            DesktopPreUploadCheckResult.FromFakeDecision(DesktopPreUploadCheckDecision.BlockHardDuplicate).DecisionPreview ?? string.Empty,
+            DesktopPreUploadCheckResult.FromFakeDecision(DesktopPreUploadCheckDecision.BlockPossibleFalsification).DecisionPreview ?? string.Empty
         ];
 
         foreach (string visibleString in visibleStrings)
@@ -613,7 +842,37 @@ public sealed class DesktopUploadSectionTests
         IDesktopVideoHashService videoHashService,
         DesktopUploadSectionOptions uploadSectionOptions)
     {
-        return new DesktopUploadSectionViewModel(videoFilePicker, videoHashService, uploadSectionOptions);
+        return CreateViewModel(
+            videoFilePicker,
+            videoHashService,
+            new DisabledDesktopPreUploadCheckClient(),
+            uploadSectionOptions);
+    }
+
+    private static DesktopUploadSectionViewModel CreateViewModel(
+        IDesktopVideoFilePicker videoFilePicker,
+        IDesktopVideoHashService videoHashService,
+        IDesktopPreUploadCheckClient preUploadCheckClient,
+        DesktopUploadSectionOptions uploadSectionOptions)
+    {
+        return new DesktopUploadSectionViewModel(
+            videoFilePicker,
+            videoHashService,
+            preUploadCheckClient,
+            uploadSectionOptions);
+    }
+
+    private static async Task<DesktopPreUploadCheckRequestPreview> PreparePreUploadCheckPreviewAsync(
+        DesktopUploadSectionViewModel viewModel,
+        string businessObjectKey)
+    {
+        _ = await viewModel.SelectVideoFileAsync(CancellationToken.None);
+        _ = await viewModel.CalculateSha256Async(CancellationToken.None);
+        viewModel.BusinessObjectKeyInput = businessObjectKey;
+        _ = viewModel.ApplyBusinessObjectKey();
+
+        return viewModel.PreUploadCheckRequestPreview
+            ?? throw new InvalidOperationException("PreUploadCheck preview was not created.");
     }
 
     private sealed class CancelingDesktopVideoFilePicker : IDesktopVideoFilePicker
@@ -631,6 +890,19 @@ public sealed class DesktopUploadSectionTests
         {
             cancellationToken.ThrowIfCancellationRequested();
             return ValueTask.FromResult(result);
+        }
+    }
+
+    private sealed class ThrowingDesktopPreUploadCheckClient : IDesktopPreUploadCheckClient
+    {
+        public int CallCount { get; private set; }
+
+        public ValueTask<DesktopPreUploadCheckResult> CheckAsync(
+            DesktopPreUploadCheckRequestPreview requestPreview,
+            CancellationToken cancellationToken)
+        {
+            CallCount++;
+            throw new InvalidOperationException("Disabled fake PreUploadCheck boundary should not be called.");
         }
     }
 


### PR DESCRIPTION
## Coder
Coder 1 acting as Coder 2 / Desktop Client

## Task ID
S2-64 Desktop Upload PreUploadCheck Request Preview / Fake Decision Boundary

## Module
App.Desktop / upload PreUploadCheck request preview and fake decision boundary

## Scope
Adds the next narrow desktop upload UI slice only: safe PreUploadCheck request preview plus an App.Desktop-local fake/dev decision boundary for visual smoke.

## Changed areas
- `docs/task-cards/S2-64_desktop-preuploadcheck-request-preview-task-card.txt`
- `src/App.Desktop/Boundaries/DesktopPreUploadCheckBoundary.cs`
- `src/App.Desktop/Boundaries/DesktopSignInBoundary.cs`
- `src/App.Desktop/Components/DesktopShell.razor`
- `src/App.Desktop/Composition/DesktopCompositionRoot.cs`
- `src/App.Desktop/Services/Upload/DesktopPreUploadCheck.cs`
- `src/App.Desktop/Services/Upload/DesktopUploadSectionOptions.cs`
- `src/App.Desktop/Services/Upload/DesktopUploadSectionViewModel.cs`
- `src/App.Desktop/Services/Upload/DisabledDesktopPreUploadCheckClient.cs`
- `src/App.Desktop/Services/Upload/FakeDesktopPreUploadCheckClient.cs`
- `src/App.Desktop/wwwroot/app.css`
- `tests/Unit/App.Desktop.Tests/DesktopCompositionRootTests.cs`
- `tests/Unit/App.Desktop.Tests/DesktopSignInServiceTests.cs`
- `tests/Unit/App.Desktop.Tests/DesktopUploadSectionTests.cs`

## Base main SHA
`80576a63765771fc691cb7a7dabf0e3e6ab68f84`

## Coordination log entries reviewed
TEAM COORDINATION LOG issue #89 reviewed, including merged desktop entries:
- #127 S2-58 Desktop Visual Smoke Fake Auth Harness
- #128 S2-59 Desktop Signed-in Shell Navigation Placeholder
- #129 S2-60 Desktop Upload Section File Selection Placeholder
- #130 S2-61 Desktop Upload File Picker Boundary
- #131 S2-62 Desktop Upload SHA-256 Boundary
- #132 S2-63 Desktop Upload Business Object Key Placeholder

## Handoff/task cards reviewed
- `docs/task-cards/S2-58_desktop-visual-smoke-fake-auth-task-card.txt`
- `docs/task-cards/S2-59_desktop-signed-in-shell-navigation-task-card.txt`
- `docs/task-cards/S2-60_desktop-upload-section-file-selection-placeholder-task-card.txt`
- `docs/task-cards/S2-61_desktop-upload-file-picker-boundary-task-card.txt`
- `docs/task-cards/S2-62_desktop-upload-sha256-boundary-task-card.txt`
- `docs/task-cards/S2-63_desktop-upload-business-object-key-placeholder-task-card.txt`

## Contracts
None. No backend DTO/shared contract/API request/response changes.

## Migrations
None.

## Feature flags/env guard
Existing visual-smoke guards remain:
- `AA_DESKTOP_DEV_FAKE_AUTH_ENABLED=true`
- `AA_DESKTOP_DEV_FAKE_UPLOAD_FILE_ENABLED=true`
- `AA_DESKTOP_DEV_FAKE_UPLOAD_HASH_ENABLED=true`
- `AA_DESKTOP_DEV_FAKE_BUSINESS_OBJECT_KEY_ENABLED=true`

New S2-64 visual-smoke-only guard:
- `AA_DESKTOP_DEV_FAKE_PREUPLOAD_CHECK_ENABLED=true`

Fake PreUploadCheck remains disabled by default.

## API impact
No real App.Api PreUploadCheck call is implemented. App.Api remains the control plane; video bytes do not go through App.Api.

## Web impact
None. No App.Web changes.

## Android impact
None. No App.Mobile.Android changes.

## Offline behavior
None.

## Rollback
Revert the S2-64 PR.

## Validation
- `git diff --check` passed
- `dotnet restore AnalyticsAutomation-Core.sln -nologo` passed
- `dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore` passed after applying whitespace formatter
- `dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal` passed with 0 warnings/errors
- `dotnet build AnalyticsAutomation-Core.sln -nologo -v minimal` passed; existing non-S2-64 analyzer warnings remain elsewhere
- `dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal` passed: 121 tests
- Hidden/control Unicode scan over changed text files passed
- App.Desktop fake-auth/fake-picker/fake-hash/fake-businessObjectKey/fake-PreUploadCheck visual smoke passed

## Visual smoke screenshot folder/files
Folder: `C:\CODEX\Temp\S2-64_DESKTOP_PREUPLOADCHECK_PREVIEW_VISUAL_SMOKE_20260501_090526\`

Files:
- `01_baseline_signin.png`
- `02_signed_in_shell.png`
- `03_upload_section_before_preuploadcheck.png`
- `04_preuploadcheck_request_preview.png`
- `05_after_fake_preuploadcheck_allow.png`
- `06_after_sign_out.png`

Screenshots/runtime artifacts are not committed.

## Handoff docs/task card
Created `docs/task-cards/S2-64_desktop-preuploadcheck-request-preview-task-card.txt`.

## Next step
Approved later slice: real App.Api PreUploadCheck client after backend-approved business object/report-draft binding is agreed.

## NO-GO / Deferred
- No real App.Api PreUploadCheck call
- No backend DTO/contract changes
- No production source-of-truth claim for manual businessObjectKey
- No direct site upload
- No UploadReceipt
- No offline queue
- No GroupTree/report draft runtime
- No App.Api/App.Web/App.Mobile.Android changes
- No migrations/deploy changes