### PR TITLE
[codex] S2-65 Desktop Direct Site Upload Boundary

### DIFF
--- a/docs/task-cards/S2-65_desktop-direct-site-upload-boundary-task-card.txt
+++ b/docs/task-cards/S2-65_desktop-direct-site-upload-boundary-task-card.txt
@@ -1,0 +1,123 @@
+Title:
+S2-65 Desktop Direct Site Upload Boundary / Fake Site Upload Result
+
+Module:
+App.Desktop / direct site upload boundary fake result
+
+Owner:
+Coder 1 acting as Coder 2 / Desktop Client
+
+Client form:
+desktop standalone
+
+Type:
+narrow runtime desktop UI slice after S2-64 PreUploadCheck preview/fake decision
+
+Status:
+Runtime task card created with implementation.
+
+Goal:
+Add a safe App.Desktop-local direct site upload request preview and a dev/fake direct-site upload boundary for visual smoke only.
+
+Scope:
+- Keep the Russian SignIn UI and signed-in shell from S2-58 through S2-64.
+- Keep upload Step 1 file metadata, Step 2 SHA-256, Step 3 businessObjectKey placeholder, and Step 4 PreUploadCheck request preview/fake decision.
+- Add Step 5 direct site upload request preview built only from safe fields:
+  - file name without full local path;
+  - size;
+  - content type;
+  - SHA-256;
+  - businessObjectKey preview;
+  - PreUploadCheck decision;
+  - capturedAtUtc preview when available.
+- Add the "Загрузить на сайт" action in the Russian UI.
+- When AA_DESKTOP_DEV_FAKE_SITE_UPLOAD_ENABLED is not true, show the safe deferred Russian message and do not call App.Api, read file contents, or send bytes.
+- When AA_DESKTOP_DEV_FAKE_SITE_UPLOAD_ENABLED=true, call only the App.Desktop-local fake boundary and show SUCCESS with:
+  - externalVideoId: visual-smoke-external-video-001
+  - siteStorageKey: visual-smoke/site/video-001
+
+Allowed changed areas:
+- docs/task-cards/S2-65_desktop-direct-site-upload-boundary-task-card.txt
+- src/App.Desktop/**
+- tests/Unit/App.Desktop.Tests/**
+
+Forbidden changed areas:
+- src/App.Api/**
+- src/App.Worker/**
+- src/App.Web/**
+- src/App.Mobile.Android/**
+- src/App.UI.Shared/**
+- src/BuildingBlocks.Contracts/**
+- src/Modules/**
+- DB migrations
+- .github/workflows/**
+- deploy scripts
+- docs/ops/**
+- committed screenshots or runtime artifacts
+
+Contracts:
+none
+
+Migrations:
+none
+
+Feature flags/env guard:
+- Existing fake auth visual-smoke guard:
+  AA_DESKTOP_DEV_FAKE_AUTH_ENABLED=true
+- Existing fake picker visual-smoke guard:
+  AA_DESKTOP_DEV_FAKE_UPLOAD_FILE_ENABLED=true
+- Existing fake hash visual-smoke guard:
+  AA_DESKTOP_DEV_FAKE_UPLOAD_HASH_ENABLED=true
+- Existing fake businessObjectKey visual-smoke guard:
+  AA_DESKTOP_DEV_FAKE_BUSINESS_OBJECT_KEY_ENABLED=true
+- Existing fake PreUploadCheck visual-smoke guard:
+  AA_DESKTOP_DEV_FAKE_PREUPLOAD_CHECK_ENABLED=true
+- New fake site upload visual-smoke guard:
+  AA_DESKTOP_DEV_FAKE_SITE_UPLOAD_ENABLED=true
+
+Events:
+none
+
+Offline behavior:
+none
+
+Security guardrails:
+- App.Api remains control plane.
+- Do not send video bytes through App.Api.
+- Do not call App.Api for direct site upload in S2-65.
+- Do not read file contents for site upload in S2-65.
+- Do not send video bytes anywhere in S2-65.
+- Do not add backend DTOs, shared contracts, API routes, migrations, deploy changes, App.Web changes, or App.Mobile.Android changes.
+- Do not display full local file paths, password, accessToken, refreshToken, Authorization, raw session id, raw response body, or token-like values.
+- Screenshots and runtime artifacts stay under C:\CODEX\Temp and are not committed.
+
+Deferred:
+Real site provider and UploadReceipt are not implemented in S2-65. Production direct-site provider and UploadReceipt remain separate approved slices.
+
+Rollback:
+revert S2-65 PR
+
+Validation:
+- git diff --check
+- dotnet restore AnalyticsAutomation-Core.sln -nologo
+- dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore
+- dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal
+- dotnet build AnalyticsAutomation-Core.sln -nologo -v minimal
+- dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal
+- hidden/control Unicode scan over changed text files
+- App.Desktop fake-auth/fake-picker/fake-hash/fake-businessObjectKey/fake-PreUploadCheck/fake-site-upload visual smoke with screenshots
+
+Definition of done:
+- Step 5 "Загрузка на сайт" is visible in the upload section.
+- Direct-site upload request preview appears only after selected file, SHA-256, businessObjectKey, and ALLOW or ALLOW_WITH_REVIEW PreUploadCheck decision.
+- Preview shows only safe file name, size, content type, SHA-256, businessObjectKey, PreUploadCheck decision, and capturedAtUtc preview.
+- Preview never shows a full local path.
+- Fake site upload is disabled by default.
+- Fake site upload is enabled only by AA_DESKTOP_DEV_FAKE_SITE_UPLOAD_ENABLED=true in debug/dev-test visual smoke.
+- Disabled fake site upload shows the safe deferred Russian message and does not call App.Api, read files, or send bytes.
+- Enabled fake site upload shows SUCCESS, externalVideoId visual-smoke-external-video-001, and siteStorageKey visual-smoke/site/video-001.
+- BLOCK_HARD_DUPLICATE and BLOCK_POSSIBLE_FALSIFICATION decisions do not allow site upload action.
+- Back/sign-out clear direct-site upload preview/result state.
+- No real site upload, App.Api upload, UploadReceipt, backend contract, migration, deploy, App.Web, or App.Mobile.Android change is introduced.
+- Automated App.Desktop tests cover env guard behavior, safe preview, fake result, blocked decisions, reset behavior, forbidden call patterns, and visible-string safety.
+- Required visual-smoke screenshots are saved under C:\CODEX\Temp and kept out of git.

--- a/src/App.Desktop/Boundaries/DesktopDirectSiteUploadBoundary.cs
+++ b/src/App.Desktop/Boundaries/DesktopDirectSiteUploadBoundary.cs
@@ -1,0 +1,10 @@
+using App.Desktop.Services.Upload;
+
+namespace App.Desktop.Boundaries;
+
+public interface IDesktopDirectSiteUploadClient
+{
+    ValueTask<DesktopSiteUploadResult> UploadAsync(
+        DesktopSiteUploadRequestPreview requestPreview,
+        CancellationToken cancellationToken);
+}

--- a/src/App.Desktop/Boundaries/DesktopSignInBoundary.cs
+++ b/src/App.Desktop/Boundaries/DesktopSignInBoundary.cs
@@ -201,8 +201,34 @@ public static class DesktopUploadSectionText
     public const string PreUploadCheckBusinessObjectKeyLabel = "businessObjectKey";
     public const string PreUploadCheckCapturedAtUtcLabel = "capturedAtUtc";
     public const string PreUploadCheckDecisionLabel = "Решение";
+    public const string StepFiveTitle = "Шаг 5. Загрузка на сайт";
+    public const string SiteUploadNotReadyMessage =
+        "Нужны выбранный файл, SHA-256, businessObjectKey и решение ALLOW или ALLOW_WITH_REVIEW.";
+    public const string SiteUploadReadyMessage =
+        "Preview загрузки на сайт готов. В этом slice доступен только desktop-local dev boundary.";
+    public const string SiteUploadBlockedByPreUploadCheckMessage =
+        "Загрузка на сайт недоступна для блокирующего решения предварительной проверки.";
+    public const string SiteUploadInProgressMessage =
+        "Выполняется загрузка на сайт в desktop-local dev boundary.";
+    public const string SiteUploadDeferredMessage =
+        "Загрузка на сайт пока доступна только в dev-smoke режиме. Реальный provider будет добавлен отдельным approved slice.";
+    public const string SiteUploadSuccessDevMessage =
+        "Загрузка на сайт выполнена в dev-smoke режиме.";
+    public const string SiteUploadCanceledMessage = "Загрузка на сайт отменена.";
+    public const string SiteUploadButton = "Загрузить на сайт";
+    public const string SiteUploadBusyButton = "Загружается...";
+    public const string SiteUploadFileNameLabel = "Имя файла";
+    public const string SiteUploadFileSizeLabel = "Размер";
+    public const string SiteUploadContentTypeLabel = "Тип содержимого";
+    public const string SiteUploadSha256Label = "SHA-256";
+    public const string SiteUploadBusinessObjectKeyLabel = "businessObjectKey";
+    public const string SiteUploadPreUploadCheckDecisionLabel = "Решение PreUploadCheck";
+    public const string SiteUploadCapturedAtUtcLabel = "capturedAtUtc";
+    public const string SiteUploadResultStatusLabel = "status";
+    public const string SiteUploadExternalVideoIdLabel = "externalVideoId";
+    public const string SiteUploadSiteStorageKeyLabel = "siteStorageKey";
     public const string NextStepDeferredMessage =
-        "Следующий шаг отложен: direct site upload boundary будет добавлен отдельным approved desktop slice.";
+        "Следующий шаг отложен: UploadReceipt будет добавлен отдельным approved desktop slice.";
 }
 
 public sealed record DesktopUploadSelectedFile(

--- a/src/App.Desktop/Components/DesktopShell.razor
+++ b/src/App.Desktop/Components/DesktopShell.razor
@@ -230,6 +230,79 @@
                                     </div>
                                 </dl>
                             }
+                        </div>
+
+                        <div class="desktop-upload__step">
+                            <h3>@DesktopUploadSectionText.StepFiveTitle</h3>
+                            <p
+                                id="desktop-upload-site-upload-status"
+                                class="desktop-upload__message"
+                                role="status"
+                                aria-live="polite">
+                                @UploadSectionViewModel.SiteUploadStatusMessage
+                            </p>
+
+                            @if (UploadSectionViewModel.SiteUploadRequestPreview is { } siteUploadPreview)
+                            {
+                                <dl class="desktop-upload__site-upload-preview">
+                                    <div>
+                                        <dt>@DesktopUploadSectionText.SiteUploadFileNameLabel</dt>
+                                        <dd>@siteUploadPreview.FileName</dd>
+                                    </div>
+                                    <div>
+                                        <dt>@DesktopUploadSectionText.SiteUploadFileSizeLabel</dt>
+                                        <dd>@siteUploadPreview.SizeBytes</dd>
+                                    </div>
+                                    <div>
+                                        <dt>@DesktopUploadSectionText.SiteUploadContentTypeLabel</dt>
+                                        <dd>@siteUploadPreview.ContentType</dd>
+                                    </div>
+                                    <div>
+                                        <dt>@DesktopUploadSectionText.SiteUploadSha256Label</dt>
+                                        <dd>@siteUploadPreview.Sha256Hex</dd>
+                                    </div>
+                                    <div>
+                                        <dt>@DesktopUploadSectionText.SiteUploadBusinessObjectKeyLabel</dt>
+                                        <dd>@siteUploadPreview.BusinessObjectKeyPreview</dd>
+                                    </div>
+                                    <div>
+                                        <dt>@DesktopUploadSectionText.SiteUploadPreUploadCheckDecisionLabel</dt>
+                                        <dd>@siteUploadPreview.PreUploadCheckDecisionPreview</dd>
+                                    </div>
+                                    <div>
+                                        <dt>@DesktopUploadSectionText.SiteUploadCapturedAtUtcLabel</dt>
+                                        <dd>@siteUploadPreview.CapturedAtUtc</dd>
+                                    </div>
+                                </dl>
+                            }
+
+                            <button
+                                class="desktop-upload__site-upload"
+                                type="button"
+                                disabled="@(SignInViewModel.IsBusy || !UploadSectionViewModel.CanUploadToSite)"
+                                @onclick="UploadToSiteAsync">
+                                @(UploadSectionViewModel.IsUploadingToSite
+                                    ? DesktopUploadSectionText.SiteUploadBusyButton
+                                    : DesktopUploadSectionText.SiteUploadButton)
+                            </button>
+
+                            @if (UploadSectionViewModel.HasSiteUploadResult)
+                            {
+                                <dl class="desktop-upload__site-upload-result">
+                                    <div>
+                                        <dt>@DesktopUploadSectionText.SiteUploadResultStatusLabel</dt>
+                                        <dd>@UploadSectionViewModel.SiteUploadStatusPreview</dd>
+                                    </div>
+                                    <div>
+                                        <dt>@DesktopUploadSectionText.SiteUploadExternalVideoIdLabel</dt>
+                                        <dd>@UploadSectionViewModel.SiteUploadExternalVideoId</dd>
+                                    </div>
+                                    <div>
+                                        <dt>@DesktopUploadSectionText.SiteUploadSiteStorageKeyLabel</dt>
+                                        <dd>@UploadSectionViewModel.SiteUploadSiteStorageKey</dd>
+                                    </div>
+                                </dl>
+                            }
 
                             <p class="desktop-upload__deferred">
                                 @DesktopUploadSectionText.NextStepDeferredMessage
@@ -400,6 +473,17 @@
         StateHasChanged();
 
         await checkAttempt;
+
+        StateHasChanged();
+    }
+
+    private async Task UploadToSiteAsync()
+    {
+        ValueTask<DesktopSiteUploadResult?> uploadAttempt =
+            UploadSectionViewModel.UploadToSiteAsync(CancellationToken.None);
+        StateHasChanged();
+
+        await uploadAttempt;
 
         StateHasChanged();
     }

--- a/src/App.Desktop/Composition/DesktopCompositionRoot.cs
+++ b/src/App.Desktop/Composition/DesktopCompositionRoot.cs
@@ -99,6 +99,15 @@ public static class DesktopCompositionRoot
             services.AddSingleton<IDesktopPreUploadCheckClient, DisabledDesktopPreUploadCheckClient>();
         }
 
+        if (uploadSectionOptions.IsDevFakeSiteUploadEnabled)
+        {
+            services.AddSingleton<IDesktopDirectSiteUploadClient, FakeDesktopDirectSiteUploadClient>();
+        }
+        else
+        {
+            services.AddSingleton<IDesktopDirectSiteUploadClient, DisabledDesktopDirectSiteUploadClient>();
+        }
+
         services.AddSingleton<IDesktopFilePicker, PlaceholderDesktopFilePicker>();
         services.AddSingleton<ILocalFileMetadataService, PlaceholderLocalFileMetadataService>();
         services.AddSingleton<IControlPlaneApiClient, PlaceholderControlPlaneApiClient>();

--- a/src/App.Desktop/Services/Upload/DesktopSiteUpload.cs
+++ b/src/App.Desktop/Services/Upload/DesktopSiteUpload.cs
@@ -1,0 +1,145 @@
+using App.Desktop.Boundaries;
+
+namespace App.Desktop.Services.Upload;
+
+public sealed class DesktopSiteUploadRequestPreview
+{
+    private DesktopSiteUploadRequestPreview(
+        string fileName,
+        long sizeBytes,
+        string contentType,
+        string sha256Hex,
+        string businessObjectKeyPreview,
+        string preUploadCheckDecisionPreview,
+        string capturedAtUtc)
+    {
+        FileName = fileName;
+        SizeBytes = sizeBytes;
+        ContentType = contentType;
+        Sha256Hex = sha256Hex;
+        BusinessObjectKeyPreview = businessObjectKeyPreview;
+        PreUploadCheckDecisionPreview = preUploadCheckDecisionPreview;
+        CapturedAtUtc = capturedAtUtc;
+    }
+
+    public string FileName { get; }
+
+    public long SizeBytes { get; }
+
+    public string ContentType { get; }
+
+    public string Sha256Hex { get; }
+
+    public string BusinessObjectKeyPreview { get; }
+
+    public string PreUploadCheckDecisionPreview { get; }
+
+    public string CapturedAtUtc { get; }
+
+    public static DesktopSiteUploadRequestPreview? TryCreate(
+        DesktopPreUploadCheckRequestPreview? preUploadCheckRequestPreview,
+        DesktopPreUploadCheckResult? preUploadCheckResult)
+    {
+        if (preUploadCheckRequestPreview is null || preUploadCheckResult?.Decision is null)
+        {
+            return null;
+        }
+
+        DesktopPreUploadCheckDecision decision = preUploadCheckResult.Decision.Value;
+        if (!IsAllowedSiteUploadDecision(decision))
+        {
+            return null;
+        }
+
+        string? decisionPreview = preUploadCheckResult.DecisionPreview;
+        if (string.IsNullOrWhiteSpace(decisionPreview))
+        {
+            return null;
+        }
+
+        return new DesktopSiteUploadRequestPreview(
+            preUploadCheckRequestPreview.FileName,
+            preUploadCheckRequestPreview.SizeBytes,
+            preUploadCheckRequestPreview.ContentType,
+            preUploadCheckRequestPreview.Sha256Hex,
+            preUploadCheckRequestPreview.BusinessObjectKeyPreview,
+            decisionPreview,
+            preUploadCheckRequestPreview.CapturedAtUtc);
+    }
+
+    public override string ToString()
+    {
+        return $"{nameof(DesktopSiteUploadRequestPreview)} {{ FileName = {FileName}, "
+            + $"SizeBytes = {SizeBytes}, ContentType = {ContentType}, HasSha256 = {Sha256Hex.Length == 64}, "
+            + $"BusinessObjectKeyPreview = {BusinessObjectKeyPreview}, "
+            + $"PreUploadCheckDecisionPreview = {PreUploadCheckDecisionPreview}, "
+            + $"CapturedAtUtc = {CapturedAtUtc} }}";
+    }
+
+    private static bool IsAllowedSiteUploadDecision(DesktopPreUploadCheckDecision decision)
+    {
+        return decision is DesktopPreUploadCheckDecision.Allow
+            or DesktopPreUploadCheckDecision.AllowWithReview;
+    }
+}
+
+public sealed class DesktopSiteUploadResult
+{
+    private DesktopSiteUploadResult(
+        DesktopSiteUploadStatus status,
+        string message,
+        string? externalVideoId,
+        string? siteStorageKey)
+    {
+        Status = status;
+        Message = message;
+        ExternalVideoId = externalVideoId;
+        SiteStorageKey = siteStorageKey;
+    }
+
+    public DesktopSiteUploadStatus Status { get; }
+
+    public string? StatusPreview => Status switch
+    {
+        DesktopSiteUploadStatus.Succeeded => "SUCCESS",
+        _ => null
+    };
+
+    public string Message { get; }
+
+    public string? ExternalVideoId { get; }
+
+    public string? SiteStorageKey { get; }
+
+    public static DesktopSiteUploadResult Deferred { get; } = new(
+        DesktopSiteUploadStatus.Deferred,
+        DesktopUploadSectionText.SiteUploadDeferredMessage,
+        externalVideoId: null,
+        siteStorageKey: null);
+
+    public static DesktopSiteUploadResult Canceled { get; } = new(
+        DesktopSiteUploadStatus.Canceled,
+        DesktopUploadSectionText.SiteUploadCanceledMessage,
+        externalVideoId: null,
+        siteStorageKey: null);
+
+    public static DesktopSiteUploadResult FakeSuccess { get; } = new(
+        DesktopSiteUploadStatus.Succeeded,
+        DesktopUploadSectionText.SiteUploadSuccessDevMessage,
+        externalVideoId: "visual-smoke-external-video-001",
+        siteStorageKey: "visual-smoke/site/video-001");
+
+    public override string ToString()
+    {
+        return $"{nameof(DesktopSiteUploadResult)} {{ Status = {StatusPreview ?? Status.ToString()}, "
+            + $"HasExternalVideoId = {ExternalVideoId is not null}, HasSiteStorageKey = {SiteStorageKey is not null}, "
+            + $"Message = {Message} }}";
+    }
+}
+
+public enum DesktopSiteUploadStatus
+{
+    Deferred,
+    Succeeded,
+    Canceled
+}

--- a/src/App.Desktop/Services/Upload/DesktopUploadSectionOptions.cs
+++ b/src/App.Desktop/Services/Upload/DesktopUploadSectionOptions.cs
@@ -14,48 +14,65 @@ public sealed class DesktopUploadSectionOptions
     public const string DevFakePreUploadCheckEnabledEnvironmentVariable =
         "AA_DESKTOP_DEV_FAKE_PREUPLOAD_CHECK_ENABLED";
 
+    public const string DevFakeSiteUploadEnabledEnvironmentVariable =
+        "AA_DESKTOP_DEV_FAKE_SITE_UPLOAD_ENABLED";
+
     private DesktopUploadSectionOptions(
         bool isDevFakeUploadFileEnabled,
         bool isDevFakeUploadHashEnabled,
         bool isDevFakeBusinessObjectKeyEnabled,
-        bool isDevFakePreUploadCheckEnabled)
+        bool isDevFakePreUploadCheckEnabled,
+        bool isDevFakeSiteUploadEnabled)
     {
         IsDevFakeUploadFileEnabled = isDevFakeUploadFileEnabled;
         IsDevFakeUploadHashEnabled = isDevFakeUploadHashEnabled;
         IsDevFakeBusinessObjectKeyEnabled = isDevFakeBusinessObjectKeyEnabled;
         IsDevFakePreUploadCheckEnabled = isDevFakePreUploadCheckEnabled;
+        IsDevFakeSiteUploadEnabled = isDevFakeSiteUploadEnabled;
     }
 
     public static DesktopUploadSectionOptions Disabled { get; } = new(
         isDevFakeUploadFileEnabled: false,
         isDevFakeUploadHashEnabled: false,
         isDevFakeBusinessObjectKeyEnabled: false,
-        isDevFakePreUploadCheckEnabled: false);
+        isDevFakePreUploadCheckEnabled: false,
+        isDevFakeSiteUploadEnabled: false);
 
 #if DEBUG
     public static DesktopUploadSectionOptions EnabledForDevFakeFileSelection { get; } = new(
         isDevFakeUploadFileEnabled: true,
         isDevFakeUploadHashEnabled: false,
         isDevFakeBusinessObjectKeyEnabled: false,
-        isDevFakePreUploadCheckEnabled: false);
+        isDevFakePreUploadCheckEnabled: false,
+        isDevFakeSiteUploadEnabled: false);
 
     public static DesktopUploadSectionOptions EnabledForDevFakeFileSelectionAndHash { get; } = new(
         isDevFakeUploadFileEnabled: true,
         isDevFakeUploadHashEnabled: true,
         isDevFakeBusinessObjectKeyEnabled: false,
-        isDevFakePreUploadCheckEnabled: false);
+        isDevFakePreUploadCheckEnabled: false,
+        isDevFakeSiteUploadEnabled: false);
 
     public static DesktopUploadSectionOptions EnabledForDevFakeBusinessObjectKey { get; } = new(
         isDevFakeUploadFileEnabled: false,
         isDevFakeUploadHashEnabled: false,
         isDevFakeBusinessObjectKeyEnabled: true,
-        isDevFakePreUploadCheckEnabled: false);
+        isDevFakePreUploadCheckEnabled: false,
+        isDevFakeSiteUploadEnabled: false);
 
     public static DesktopUploadSectionOptions EnabledForDevFakePreUploadCheck { get; } = new(
         isDevFakeUploadFileEnabled: false,
         isDevFakeUploadHashEnabled: false,
         isDevFakeBusinessObjectKeyEnabled: false,
-        isDevFakePreUploadCheckEnabled: true);
+        isDevFakePreUploadCheckEnabled: true,
+        isDevFakeSiteUploadEnabled: false);
+
+    public static DesktopUploadSectionOptions EnabledForDevFakeSiteUpload { get; } = new(
+        isDevFakeUploadFileEnabled: false,
+        isDevFakeUploadHashEnabled: false,
+        isDevFakeBusinessObjectKeyEnabled: false,
+        isDevFakePreUploadCheckEnabled: false,
+        isDevFakeSiteUploadEnabled: true);
 #else
     public static DesktopUploadSectionOptions EnabledForDevFakeFileSelection => Disabled;
 
@@ -64,6 +81,8 @@ public sealed class DesktopUploadSectionOptions
     public static DesktopUploadSectionOptions EnabledForDevFakeBusinessObjectKey => Disabled;
 
     public static DesktopUploadSectionOptions EnabledForDevFakePreUploadCheck => Disabled;
+
+    public static DesktopUploadSectionOptions EnabledForDevFakeSiteUpload => Disabled;
 #endif
 
     public bool IsDevFakeUploadFileEnabled { get; }
@@ -74,13 +93,16 @@ public sealed class DesktopUploadSectionOptions
 
     public bool IsDevFakePreUploadCheckEnabled { get; }
 
+    public bool IsDevFakeSiteUploadEnabled { get; }
+
     public static DesktopUploadSectionOptions FromEnvironment()
     {
         return FromEnvironmentValue(
             Environment.GetEnvironmentVariable(DevFakeUploadFileEnabledEnvironmentVariable),
             Environment.GetEnvironmentVariable(DevFakeUploadHashEnabledEnvironmentVariable),
             Environment.GetEnvironmentVariable(DevFakeBusinessObjectKeyEnabledEnvironmentVariable),
-            Environment.GetEnvironmentVariable(DevFakePreUploadCheckEnabledEnvironmentVariable));
+            Environment.GetEnvironmentVariable(DevFakePreUploadCheckEnabledEnvironmentVariable),
+            Environment.GetEnvironmentVariable(DevFakeSiteUploadEnabledEnvironmentVariable));
     }
 
     public static DesktopUploadSectionOptions FromEnvironmentValue(string? devFakeUploadFileEnabled)
@@ -118,18 +140,35 @@ public sealed class DesktopUploadSectionOptions
         string? devFakeBusinessObjectKeyEnabled,
         string? devFakePreUploadCheckEnabled)
     {
+        return FromEnvironmentValue(
+            devFakeUploadFileEnabled,
+            devFakeUploadHashEnabled,
+            devFakeBusinessObjectKeyEnabled,
+            devFakePreUploadCheckEnabled,
+            devFakeSiteUploadEnabled: null);
+    }
+
+    public static DesktopUploadSectionOptions FromEnvironmentValue(
+        string? devFakeUploadFileEnabled,
+        string? devFakeUploadHashEnabled,
+        string? devFakeBusinessObjectKeyEnabled,
+        string? devFakePreUploadCheckEnabled,
+        string? devFakeSiteUploadEnabled)
+    {
 #if DEBUG
         bool isFakeFileEnabled = IsDevFakeUploadFileEnabledValue(devFakeUploadFileEnabled);
         bool isFakeHashEnabled = IsDevFakeUploadHashEnabledValue(devFakeUploadHashEnabled);
         bool isFakeBusinessObjectKeyEnabled =
             IsDevFakeBusinessObjectKeyEnabledValue(devFakeBusinessObjectKeyEnabled);
         bool isFakePreUploadCheckEnabled = IsDevFakePreUploadCheckEnabledValue(devFakePreUploadCheckEnabled);
+        bool isFakeSiteUploadEnabled = IsDevFakeSiteUploadEnabledValue(devFakeSiteUploadEnabled);
 
         return new DesktopUploadSectionOptions(
             isFakeFileEnabled,
             isFakeHashEnabled,
             isFakeBusinessObjectKeyEnabled,
-            isFakePreUploadCheckEnabled);
+            isFakePreUploadCheckEnabled,
+            isFakeSiteUploadEnabled);
 #else
         return Disabled;
 #endif
@@ -140,7 +179,8 @@ public sealed class DesktopUploadSectionOptions
         return $"{nameof(DesktopUploadSectionOptions)} {{ IsDevFakeUploadFileEnabled = {IsDevFakeUploadFileEnabled}, "
             + $"IsDevFakeUploadHashEnabled = {IsDevFakeUploadHashEnabled}, "
             + $"IsDevFakeBusinessObjectKeyEnabled = {IsDevFakeBusinessObjectKeyEnabled}, "
-            + $"IsDevFakePreUploadCheckEnabled = {IsDevFakePreUploadCheckEnabled} }}";
+            + $"IsDevFakePreUploadCheckEnabled = {IsDevFakePreUploadCheckEnabled}, "
+            + $"IsDevFakeSiteUploadEnabled = {IsDevFakeSiteUploadEnabled} }}";
     }
 
     private static bool IsDevFakeUploadFileEnabledValue(string? value)
@@ -159,6 +199,11 @@ public sealed class DesktopUploadSectionOptions
     }
 
     private static bool IsDevFakePreUploadCheckEnabledValue(string? value)
+    {
+        return string.Equals(value?.Trim(), "true", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsDevFakeSiteUploadEnabledValue(string? value)
     {
         return string.Equals(value?.Trim(), "true", StringComparison.OrdinalIgnoreCase);
     }

--- a/src/App.Desktop/Services/Upload/DesktopUploadSectionViewModel.cs
+++ b/src/App.Desktop/Services/Upload/DesktopUploadSectionViewModel.cs
@@ -6,6 +6,7 @@ public sealed class DesktopUploadSectionViewModel(
     IDesktopVideoFilePicker videoFilePicker,
     IDesktopVideoHashService videoHashService,
     IDesktopPreUploadCheckClient preUploadCheckClient,
+    IDesktopDirectSiteUploadClient directSiteUploadClient,
     DesktopUploadSectionOptions uploadSectionOptions)
 {
     public DesktopUploadSectionViewModel(
@@ -15,6 +16,7 @@ public sealed class DesktopUploadSectionViewModel(
             videoFilePicker,
             videoHashService,
             new DisabledDesktopPreUploadCheckClient(),
+            new DisabledDesktopDirectSiteUploadClient(),
             DesktopUploadSectionOptions.Disabled)
     {
     }
@@ -27,6 +29,7 @@ public sealed class DesktopUploadSectionViewModel(
             videoFilePicker,
             videoHashService,
             new DisabledDesktopPreUploadCheckClient(),
+            new DisabledDesktopDirectSiteUploadClient(),
             uploadSectionOptions)
     {
     }
@@ -37,6 +40,8 @@ public sealed class DesktopUploadSectionViewModel(
         videoHashService ?? throw new ArgumentNullException(nameof(videoHashService));
     private readonly IDesktopPreUploadCheckClient _preUploadCheckClient =
         preUploadCheckClient ?? throw new ArgumentNullException(nameof(preUploadCheckClient));
+    private readonly IDesktopDirectSiteUploadClient _directSiteUploadClient =
+        directSiteUploadClient ?? throw new ArgumentNullException(nameof(directSiteUploadClient));
     private readonly DesktopUploadSectionOptions _uploadSectionOptions =
         uploadSectionOptions ?? throw new ArgumentNullException(nameof(uploadSectionOptions));
 
@@ -51,6 +56,8 @@ public sealed class DesktopUploadSectionViewModel(
     public bool IsHashing { get; private set; }
 
     public bool IsCheckingPreUpload { get; private set; }
+
+    public bool IsUploadingToSite { get; private set; }
 
     public bool CanCalculateHash => SelectedFile is not null && !IsSelectingFile && !IsHashing;
 
@@ -71,6 +78,9 @@ public sealed class DesktopUploadSectionViewModel(
 
     public bool IsDevFakePreUploadCheckEnabled =>
         _uploadSectionOptions.IsDevFakePreUploadCheckEnabled;
+
+    public bool IsDevFakeSiteUploadEnabled =>
+        _uploadSectionOptions.IsDevFakeSiteUploadEnabled;
 
     public string BusinessObjectKeyInput { get; set; } = string.Empty;
 
@@ -99,6 +109,31 @@ public sealed class DesktopUploadSectionViewModel(
 
     public string PreUploadCheckStatusMessage { get; private set; } =
         DesktopUploadSectionText.PreUploadCheckNotReadyMessage;
+
+    public DesktopSiteUploadRequestPreview? SiteUploadRequestPreview =>
+        DesktopSiteUploadRequestPreview.TryCreate(PreUploadCheckRequestPreview, PreUploadCheckResult);
+
+    public bool HasSiteUploadRequestPreview => SiteUploadRequestPreview is not null;
+
+    public bool CanUploadToSite =>
+        HasSiteUploadRequestPreview
+        && !IsSelectingFile
+        && !IsHashing
+        && !IsCheckingPreUpload
+        && !IsUploadingToSite;
+
+    public DesktopSiteUploadResult? SiteUploadResult { get; private set; }
+
+    public bool HasSiteUploadResult => SiteUploadResult?.Status == DesktopSiteUploadStatus.Succeeded;
+
+    public string? SiteUploadStatusPreview => SiteUploadResult?.StatusPreview;
+
+    public string? SiteUploadExternalVideoId => SiteUploadResult?.ExternalVideoId;
+
+    public string? SiteUploadSiteStorageKey => SiteUploadResult?.SiteStorageKey;
+
+    public string SiteUploadStatusMessage { get; private set; } =
+        DesktopUploadSectionText.SiteUploadNotReadyMessage;
 
     public void OpenUploadSection()
     {
@@ -129,6 +164,7 @@ public sealed class DesktopUploadSectionViewModel(
         ResetSelectedFileHashState();
         ResetBusinessObjectKeyState();
         ResetPreUploadCheckState();
+        ResetSiteUploadState();
 
         try
         {
@@ -170,6 +206,7 @@ public sealed class DesktopUploadSectionViewModel(
         Sha256Hex = null;
         HashStatusMessage = DesktopUploadSectionText.HashInProgressMessage;
         ResetPreUploadCheckState();
+        ResetSiteUploadState();
 
         try
         {
@@ -220,6 +257,7 @@ public sealed class DesktopUploadSectionViewModel(
         BusinessObjectKey = validation.BusinessObjectKey;
         BusinessObjectKeyStatusMessage = validation.Message;
         ResetPreUploadCheckDecision();
+        ResetSiteUploadState();
         RefreshPreUploadCheckReadiness();
 
         return validation;
@@ -247,6 +285,7 @@ public sealed class DesktopUploadSectionViewModel(
         if (requestPreview is null)
         {
             PreUploadCheckStatusMessage = DesktopUploadSectionText.PreUploadCheckNotReadyMessage;
+            ResetSiteUploadState();
             return null;
         }
 
@@ -254,28 +293,75 @@ public sealed class DesktopUploadSectionViewModel(
         {
             PreUploadCheckResult = DesktopPreUploadCheckResult.Deferred;
             PreUploadCheckStatusMessage = DesktopUploadSectionText.PreUploadCheckDeferredMessage;
+            RefreshSiteUploadReadiness();
             return PreUploadCheckResult;
         }
 
         IsCheckingPreUpload = true;
         PreUploadCheckResult = null;
         PreUploadCheckStatusMessage = DesktopUploadSectionText.PreUploadCheckInProgressMessage;
+        ResetSiteUploadState();
 
         try
         {
             PreUploadCheckResult = await _preUploadCheckClient.CheckAsync(requestPreview, cancellationToken);
             PreUploadCheckStatusMessage = PreUploadCheckResult.Message;
+            RefreshSiteUploadReadiness();
             return PreUploadCheckResult;
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             PreUploadCheckResult = DesktopPreUploadCheckResult.Canceled;
             PreUploadCheckStatusMessage = DesktopUploadSectionText.PreUploadCheckCanceledMessage;
+            RefreshSiteUploadReadiness();
             return PreUploadCheckResult;
         }
         finally
         {
             IsCheckingPreUpload = false;
+        }
+    }
+
+    public async ValueTask<DesktopSiteUploadResult?> UploadToSiteAsync(CancellationToken cancellationToken)
+    {
+        if (IsUploadingToSite)
+        {
+            return SiteUploadResult;
+        }
+
+        DesktopSiteUploadRequestPreview? requestPreview = SiteUploadRequestPreview;
+        if (requestPreview is null)
+        {
+            SiteUploadStatusMessage = GetSiteUploadNotReadyMessage();
+            return null;
+        }
+
+        if (!IsDevFakeSiteUploadEnabled)
+        {
+            SiteUploadResult = DesktopSiteUploadResult.Deferred;
+            SiteUploadStatusMessage = DesktopUploadSectionText.SiteUploadDeferredMessage;
+            return SiteUploadResult;
+        }
+
+        IsUploadingToSite = true;
+        SiteUploadResult = null;
+        SiteUploadStatusMessage = DesktopUploadSectionText.SiteUploadInProgressMessage;
+
+        try
+        {
+            SiteUploadResult = await _directSiteUploadClient.UploadAsync(requestPreview, cancellationToken);
+            SiteUploadStatusMessage = SiteUploadResult.Message;
+            return SiteUploadResult;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            SiteUploadResult = DesktopSiteUploadResult.Canceled;
+            SiteUploadStatusMessage = DesktopUploadSectionText.SiteUploadCanceledMessage;
+            return SiteUploadResult;
+        }
+        finally
+        {
+            IsUploadingToSite = false;
         }
     }
 
@@ -303,6 +389,7 @@ public sealed class DesktopUploadSectionViewModel(
         BusinessObjectKey = null;
         BusinessObjectKeyStatusMessage = DesktopUploadSectionText.BusinessObjectKeyEmptyValidationMessage;
         ResetPreUploadCheckState();
+        ResetSiteUploadState();
     }
 
     private void ResetPreUploadCheckState()
@@ -310,12 +397,14 @@ public sealed class DesktopUploadSectionViewModel(
         IsCheckingPreUpload = false;
         PreUploadCheckResult = null;
         PreUploadCheckStatusMessage = DesktopUploadSectionText.PreUploadCheckNotReadyMessage;
+        ResetSiteUploadState();
     }
 
     private void ResetPreUploadCheckDecision()
     {
         IsCheckingPreUpload = false;
         PreUploadCheckResult = null;
+        ResetSiteUploadState();
     }
 
     private void RefreshPreUploadCheckReadiness()
@@ -328,5 +417,32 @@ public sealed class DesktopUploadSectionViewModel(
         PreUploadCheckStatusMessage = HasPreUploadCheckRequestPreview
             ? DesktopUploadSectionText.PreUploadCheckReadyMessage
             : DesktopUploadSectionText.PreUploadCheckNotReadyMessage;
+    }
+
+    private void ResetSiteUploadState()
+    {
+        IsUploadingToSite = false;
+        SiteUploadResult = null;
+        SiteUploadStatusMessage = DesktopUploadSectionText.SiteUploadNotReadyMessage;
+    }
+
+    private void RefreshSiteUploadReadiness()
+    {
+        if (IsUploadingToSite)
+        {
+            return;
+        }
+
+        SiteUploadStatusMessage = SiteUploadRequestPreview is not null
+            ? DesktopUploadSectionText.SiteUploadReadyMessage
+            : GetSiteUploadNotReadyMessage();
+    }
+
+    private string GetSiteUploadNotReadyMessage()
+    {
+        return PreUploadCheckResult?.Decision is DesktopPreUploadCheckDecision.BlockHardDuplicate
+            or DesktopPreUploadCheckDecision.BlockPossibleFalsification
+            ? DesktopUploadSectionText.SiteUploadBlockedByPreUploadCheckMessage
+            : DesktopUploadSectionText.SiteUploadNotReadyMessage;
     }
 }

--- a/src/App.Desktop/Services/Upload/DisabledDesktopDirectSiteUploadClient.cs
+++ b/src/App.Desktop/Services/Upload/DisabledDesktopDirectSiteUploadClient.cs
@@ -1,0 +1,16 @@
+using App.Desktop.Boundaries;
+
+namespace App.Desktop.Services.Upload;
+
+public sealed class DisabledDesktopDirectSiteUploadClient : IDesktopDirectSiteUploadClient
+{
+    public ValueTask<DesktopSiteUploadResult> UploadAsync(
+        DesktopSiteUploadRequestPreview requestPreview,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(requestPreview);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return ValueTask.FromResult(DesktopSiteUploadResult.Deferred);
+    }
+}

--- a/src/App.Desktop/Services/Upload/FakeDesktopDirectSiteUploadClient.cs
+++ b/src/App.Desktop/Services/Upload/FakeDesktopDirectSiteUploadClient.cs
@@ -1,0 +1,16 @@
+using App.Desktop.Boundaries;
+
+namespace App.Desktop.Services.Upload;
+
+public sealed class FakeDesktopDirectSiteUploadClient : IDesktopDirectSiteUploadClient
+{
+    public ValueTask<DesktopSiteUploadResult> UploadAsync(
+        DesktopSiteUploadRequestPreview requestPreview,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(requestPreview);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return ValueTask.FromResult(DesktopSiteUploadResult.FakeSuccess);
+    }
+}

--- a/src/App.Desktop/wwwroot/app.css
+++ b/src/App.Desktop/wwwroot/app.css
@@ -282,7 +282,8 @@ body {
 .desktop-upload__select,
 .desktop-upload__hash,
 .desktop-upload__key,
-.desktop-upload__preupload {
+.desktop-upload__preupload,
+.desktop-upload__site-upload {
     min-height: 38px;
     padding: 0 16px;
     border-radius: 6px;
@@ -301,7 +302,8 @@ body {
 .desktop-upload__select,
 .desktop-upload__hash,
 .desktop-upload__key,
-.desktop-upload__preupload {
+.desktop-upload__preupload,
+.desktop-upload__site-upload {
     width: fit-content;
     border: 1px solid #18406b;
     background: #18406b;
@@ -312,7 +314,8 @@ body {
 .desktop-upload__select:disabled,
 .desktop-upload__hash:disabled,
 .desktop-upload__key:disabled,
-.desktop-upload__preupload:disabled {
+.desktop-upload__preupload:disabled,
+.desktop-upload__site-upload:disabled {
     color: #687789;
     border-color: #b9c3cf;
     background: #eef1f5;
@@ -386,7 +389,9 @@ body {
 .desktop-upload__hash-result,
 .desktop-upload__business-object-key,
 .desktop-upload__preupload-preview,
-.desktop-upload__preupload-decision {
+.desktop-upload__preupload-decision,
+.desktop-upload__site-upload-preview,
+.desktop-upload__site-upload-result {
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 12px;
@@ -405,15 +410,25 @@ body {
     grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
+.desktop-upload__site-upload-preview {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
 .desktop-upload__preupload-decision {
     grid-template-columns: minmax(0, 1fr);
+}
+
+.desktop-upload__site-upload-result {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
 .desktop-upload__selection div,
 .desktop-upload__hash-result div,
 .desktop-upload__business-object-key div,
 .desktop-upload__preupload-preview div,
-.desktop-upload__preupload-decision div {
+.desktop-upload__preupload-decision div,
+.desktop-upload__site-upload-preview div,
+.desktop-upload__site-upload-result div {
     min-width: 0;
     padding: 12px;
     border: 1px solid #d7dde5;
@@ -425,7 +440,9 @@ body {
 .desktop-upload__hash-result dt,
 .desktop-upload__business-object-key dt,
 .desktop-upload__preupload-preview dt,
-.desktop-upload__preupload-decision dt {
+.desktop-upload__preupload-decision dt,
+.desktop-upload__site-upload-preview dt,
+.desktop-upload__site-upload-result dt {
     margin: 0 0 4px;
     color: #52616f;
     font-size: 0.78rem;
@@ -436,7 +453,9 @@ body {
 .desktop-upload__hash-result dd,
 .desktop-upload__business-object-key dd,
 .desktop-upload__preupload-preview dd,
-.desktop-upload__preupload-decision dd {
+.desktop-upload__preupload-decision dd,
+.desktop-upload__site-upload-preview dd,
+.desktop-upload__site-upload-result dd {
     margin: 0;
     color: #18212f;
     font-size: 0.9rem;
@@ -468,7 +487,8 @@ body {
     .desktop-upload__select,
     .desktop-upload__hash,
     .desktop-upload__key,
-    .desktop-upload__preupload {
+    .desktop-upload__preupload,
+    .desktop-upload__site-upload {
         width: 100%;
     }
 
@@ -476,7 +496,9 @@ body {
     .desktop-upload__hash-result,
     .desktop-upload__business-object-key,
     .desktop-upload__preupload-preview,
-    .desktop-upload__preupload-decision {
+    .desktop-upload__preupload-decision,
+    .desktop-upload__site-upload-preview,
+    .desktop-upload__site-upload-result {
         grid-template-columns: 1fr;
     }
 

--- a/tests/Unit/App.Desktop.Tests/DesktopCompositionRootTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopCompositionRootTests.cs
@@ -24,10 +24,13 @@ public sealed class DesktopCompositionRootTests
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeSiteUploadEnabled);
         Assert.IsType<WpfDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
         Assert.IsType<DesktopVideoHashService>(services.GetRequiredService<IDesktopVideoHashService>());
         Assert.IsType<DisabledDesktopPreUploadCheckClient>(
             services.GetRequiredService<IDesktopPreUploadCheckClient>());
+        Assert.IsType<DisabledDesktopDirectSiteUploadClient>(
+            services.GetRequiredService<IDesktopDirectSiteUploadClient>());
     }
 
     [Fact]
@@ -39,7 +42,8 @@ public sealed class DesktopCompositionRootTests
             .Set(DesktopUploadSectionOptions.DevFakeUploadFileEnabledEnvironmentVariable, null)
             .Set(DesktopUploadSectionOptions.DevFakeUploadHashEnabledEnvironmentVariable, null)
             .Set(DesktopUploadSectionOptions.DevFakeBusinessObjectKeyEnabledEnvironmentVariable, null)
-            .Set(DesktopUploadSectionOptions.DevFakePreUploadCheckEnabledEnvironmentVariable, null);
+            .Set(DesktopUploadSectionOptions.DevFakePreUploadCheckEnabledEnvironmentVariable, null)
+            .Set(DesktopUploadSectionOptions.DevFakeSiteUploadEnabledEnvironmentVariable, null);
 
         using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
 
@@ -48,11 +52,14 @@ public sealed class DesktopCompositionRootTests
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeSiteUploadEnabled);
         Assert.IsType<UnavailableDesktopAuthClient>(services.GetRequiredService<IDesktopAuthClient>());
         Assert.IsType<WpfDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
         Assert.IsType<DesktopVideoHashService>(services.GetRequiredService<IDesktopVideoHashService>());
         Assert.IsType<DisabledDesktopPreUploadCheckClient>(
             services.GetRequiredService<IDesktopPreUploadCheckClient>());
+        Assert.IsType<DisabledDesktopDirectSiteUploadClient>(
+            services.GetRequiredService<IDesktopDirectSiteUploadClient>());
     }
 
     [Fact]
@@ -64,7 +71,8 @@ public sealed class DesktopCompositionRootTests
             .Set(DesktopUploadSectionOptions.DevFakeUploadFileEnabledEnvironmentVariable, "true")
             .Set(DesktopUploadSectionOptions.DevFakeUploadHashEnabledEnvironmentVariable, null)
             .Set(DesktopUploadSectionOptions.DevFakeBusinessObjectKeyEnabledEnvironmentVariable, null)
-            .Set(DesktopUploadSectionOptions.DevFakePreUploadCheckEnabledEnvironmentVariable, null);
+            .Set(DesktopUploadSectionOptions.DevFakePreUploadCheckEnabledEnvironmentVariable, null)
+            .Set(DesktopUploadSectionOptions.DevFakeSiteUploadEnabledEnvironmentVariable, null);
 
         using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
 
@@ -73,19 +81,25 @@ public sealed class DesktopCompositionRootTests
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeSiteUploadEnabled);
         Assert.IsType<FakeDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
         Assert.IsType<DesktopVideoHashService>(services.GetRequiredService<IDesktopVideoHashService>());
         Assert.IsType<DisabledDesktopPreUploadCheckClient>(
             services.GetRequiredService<IDesktopPreUploadCheckClient>());
+        Assert.IsType<DisabledDesktopDirectSiteUploadClient>(
+            services.GetRequiredService<IDesktopDirectSiteUploadClient>());
 #else
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeSiteUploadEnabled);
         Assert.IsType<WpfDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
         Assert.IsType<DesktopVideoHashService>(services.GetRequiredService<IDesktopVideoHashService>());
         Assert.IsType<DisabledDesktopPreUploadCheckClient>(
             services.GetRequiredService<IDesktopPreUploadCheckClient>());
+        Assert.IsType<DisabledDesktopDirectSiteUploadClient>(
+            services.GetRequiredService<IDesktopDirectSiteUploadClient>());
 #endif
     }
 
@@ -98,7 +112,8 @@ public sealed class DesktopCompositionRootTests
             .Set(DesktopUploadSectionOptions.DevFakeUploadFileEnabledEnvironmentVariable, null)
             .Set(DesktopUploadSectionOptions.DevFakeUploadHashEnabledEnvironmentVariable, "true")
             .Set(DesktopUploadSectionOptions.DevFakeBusinessObjectKeyEnabledEnvironmentVariable, null)
-            .Set(DesktopUploadSectionOptions.DevFakePreUploadCheckEnabledEnvironmentVariable, null);
+            .Set(DesktopUploadSectionOptions.DevFakePreUploadCheckEnabledEnvironmentVariable, null)
+            .Set(DesktopUploadSectionOptions.DevFakeSiteUploadEnabledEnvironmentVariable, null);
 
         using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
 
@@ -107,19 +122,25 @@ public sealed class DesktopCompositionRootTests
         Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeSiteUploadEnabled);
         Assert.IsType<WpfDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
         Assert.IsType<FakeDesktopVideoHashService>(services.GetRequiredService<IDesktopVideoHashService>());
         Assert.IsType<DisabledDesktopPreUploadCheckClient>(
             services.GetRequiredService<IDesktopPreUploadCheckClient>());
+        Assert.IsType<DisabledDesktopDirectSiteUploadClient>(
+            services.GetRequiredService<IDesktopDirectSiteUploadClient>());
 #else
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeSiteUploadEnabled);
         Assert.IsType<WpfDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
         Assert.IsType<DesktopVideoHashService>(services.GetRequiredService<IDesktopVideoHashService>());
         Assert.IsType<DisabledDesktopPreUploadCheckClient>(
             services.GetRequiredService<IDesktopPreUploadCheckClient>());
+        Assert.IsType<DisabledDesktopDirectSiteUploadClient>(
+            services.GetRequiredService<IDesktopDirectSiteUploadClient>());
 #endif
     }
 
@@ -132,7 +153,8 @@ public sealed class DesktopCompositionRootTests
             .Set(DesktopUploadSectionOptions.DevFakeUploadFileEnabledEnvironmentVariable, "true")
             .Set(DesktopUploadSectionOptions.DevFakeUploadHashEnabledEnvironmentVariable, "true")
             .Set(DesktopUploadSectionOptions.DevFakeBusinessObjectKeyEnabledEnvironmentVariable, null)
-            .Set(DesktopUploadSectionOptions.DevFakePreUploadCheckEnabledEnvironmentVariable, null);
+            .Set(DesktopUploadSectionOptions.DevFakePreUploadCheckEnabledEnvironmentVariable, null)
+            .Set(DesktopUploadSectionOptions.DevFakeSiteUploadEnabledEnvironmentVariable, null);
 
         using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
 
@@ -141,19 +163,25 @@ public sealed class DesktopCompositionRootTests
         Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeSiteUploadEnabled);
         Assert.IsType<FakeDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
         Assert.IsType<FakeDesktopVideoHashService>(services.GetRequiredService<IDesktopVideoHashService>());
         Assert.IsType<DisabledDesktopPreUploadCheckClient>(
             services.GetRequiredService<IDesktopPreUploadCheckClient>());
+        Assert.IsType<DisabledDesktopDirectSiteUploadClient>(
+            services.GetRequiredService<IDesktopDirectSiteUploadClient>());
 #else
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeSiteUploadEnabled);
         Assert.IsType<WpfDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
         Assert.IsType<DesktopVideoHashService>(services.GetRequiredService<IDesktopVideoHashService>());
         Assert.IsType<DisabledDesktopPreUploadCheckClient>(
             services.GetRequiredService<IDesktopPreUploadCheckClient>());
+        Assert.IsType<DisabledDesktopDirectSiteUploadClient>(
+            services.GetRequiredService<IDesktopDirectSiteUploadClient>());
 #endif
     }
 
@@ -166,7 +194,8 @@ public sealed class DesktopCompositionRootTests
             .Set(DesktopUploadSectionOptions.DevFakeUploadFileEnabledEnvironmentVariable, null)
             .Set(DesktopUploadSectionOptions.DevFakeUploadHashEnabledEnvironmentVariable, null)
             .Set(DesktopUploadSectionOptions.DevFakeBusinessObjectKeyEnabledEnvironmentVariable, "true")
-            .Set(DesktopUploadSectionOptions.DevFakePreUploadCheckEnabledEnvironmentVariable, null);
+            .Set(DesktopUploadSectionOptions.DevFakePreUploadCheckEnabledEnvironmentVariable, null)
+            .Set(DesktopUploadSectionOptions.DevFakeSiteUploadEnabledEnvironmentVariable, null);
 
         using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
 
@@ -175,19 +204,27 @@ public sealed class DesktopCompositionRootTests
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
         Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeSiteUploadEnabled);
         Assert.True(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakeBusinessObjectKeyEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakePreUploadCheckEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakeSiteUploadEnabled);
         Assert.IsType<DisabledDesktopPreUploadCheckClient>(
             services.GetRequiredService<IDesktopPreUploadCheckClient>());
+        Assert.IsType<DisabledDesktopDirectSiteUploadClient>(
+            services.GetRequiredService<IDesktopDirectSiteUploadClient>());
 #else
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeSiteUploadEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakeBusinessObjectKeyEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakePreUploadCheckEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakeSiteUploadEnabled);
         Assert.IsType<DisabledDesktopPreUploadCheckClient>(
             services.GetRequiredService<IDesktopPreUploadCheckClient>());
+        Assert.IsType<DisabledDesktopDirectSiteUploadClient>(
+            services.GetRequiredService<IDesktopDirectSiteUploadClient>());
 #endif
     }
 
@@ -200,7 +237,8 @@ public sealed class DesktopCompositionRootTests
             .Set(DesktopUploadSectionOptions.DevFakeUploadFileEnabledEnvironmentVariable, null)
             .Set(DesktopUploadSectionOptions.DevFakeUploadHashEnabledEnvironmentVariable, null)
             .Set(DesktopUploadSectionOptions.DevFakeBusinessObjectKeyEnabledEnvironmentVariable, null)
-            .Set(DesktopUploadSectionOptions.DevFakePreUploadCheckEnabledEnvironmentVariable, "true");
+            .Set(DesktopUploadSectionOptions.DevFakePreUploadCheckEnabledEnvironmentVariable, "true")
+            .Set(DesktopUploadSectionOptions.DevFakeSiteUploadEnabledEnvironmentVariable, null);
 
         using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
 
@@ -209,22 +247,70 @@ public sealed class DesktopCompositionRootTests
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
         Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeSiteUploadEnabled);
         Assert.True(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakePreUploadCheckEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakeSiteUploadEnabled);
         Assert.IsType<FakeDesktopPreUploadCheckClient>(
             services.GetRequiredService<IDesktopPreUploadCheckClient>());
+        Assert.IsType<DisabledDesktopDirectSiteUploadClient>(
+            services.GetRequiredService<IDesktopDirectSiteUploadClient>());
 #else
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeSiteUploadEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakePreUploadCheckEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakeSiteUploadEnabled);
         Assert.IsType<DisabledDesktopPreUploadCheckClient>(
             services.GetRequiredService<IDesktopPreUploadCheckClient>());
+        Assert.IsType<DisabledDesktopDirectSiteUploadClient>(
+            services.GetRequiredService<IDesktopDirectSiteUploadClient>());
 #endif
     }
 
     [Fact]
-    public void EnvironmentOptionsEnableFakeUploadFileHashAndBusinessObjectKeyTogetherForVisualSmoke()
+    public void EnvironmentOptionsEnableFakeSiteUploadOnlyWhenExplicitlyRequested()
+    {
+        using var environment = new EnvironmentVariableScope()
+            .Set(DesktopAuthOptions.ControlPlaneBaseAddressEnvironmentVariable, null)
+            .Set(DesktopAuthOptions.DevFakeAuthEnabledEnvironmentVariable, null)
+            .Set(DesktopUploadSectionOptions.DevFakeUploadFileEnabledEnvironmentVariable, null)
+            .Set(DesktopUploadSectionOptions.DevFakeUploadHashEnabledEnvironmentVariable, null)
+            .Set(DesktopUploadSectionOptions.DevFakeBusinessObjectKeyEnabledEnvironmentVariable, null)
+            .Set(DesktopUploadSectionOptions.DevFakePreUploadCheckEnabledEnvironmentVariable, null)
+            .Set(DesktopUploadSectionOptions.DevFakeSiteUploadEnabledEnvironmentVariable, "true");
+
+        using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
+
+#if DEBUG
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
+        Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeSiteUploadEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakePreUploadCheckEnabled);
+        Assert.True(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakeSiteUploadEnabled);
+        Assert.IsType<DisabledDesktopPreUploadCheckClient>(
+            services.GetRequiredService<IDesktopPreUploadCheckClient>());
+        Assert.IsType<FakeDesktopDirectSiteUploadClient>(
+            services.GetRequiredService<IDesktopDirectSiteUploadClient>());
+#else
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeSiteUploadEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakeSiteUploadEnabled);
+        Assert.IsType<DisabledDesktopPreUploadCheckClient>(
+            services.GetRequiredService<IDesktopPreUploadCheckClient>());
+        Assert.IsType<DisabledDesktopDirectSiteUploadClient>(
+            services.GetRequiredService<IDesktopDirectSiteUploadClient>());
+#endif
+    }
+
+    [Fact]
+    public void EnvironmentOptionsEnableFakeUploadFileHashBusinessObjectKeyPreUploadCheckAndSiteUploadTogetherForVisualSmoke()
     {
         using var environment = new EnvironmentVariableScope()
             .Set(DesktopAuthOptions.ControlPlaneBaseAddressEnvironmentVariable, null)
@@ -232,7 +318,8 @@ public sealed class DesktopCompositionRootTests
             .Set(DesktopUploadSectionOptions.DevFakeUploadFileEnabledEnvironmentVariable, "true")
             .Set(DesktopUploadSectionOptions.DevFakeUploadHashEnabledEnvironmentVariable, "true")
             .Set(DesktopUploadSectionOptions.DevFakeBusinessObjectKeyEnabledEnvironmentVariable, "true")
-            .Set(DesktopUploadSectionOptions.DevFakePreUploadCheckEnabledEnvironmentVariable, "true");
+            .Set(DesktopUploadSectionOptions.DevFakePreUploadCheckEnabledEnvironmentVariable, "true")
+            .Set(DesktopUploadSectionOptions.DevFakeSiteUploadEnabledEnvironmentVariable, "true");
 
         using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
 
@@ -242,24 +329,31 @@ public sealed class DesktopCompositionRootTests
         Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
         Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
         Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
+        Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeSiteUploadEnabled);
         Assert.IsType<FakeDesktopAuthClient>(services.GetRequiredService<IDesktopAuthClient>());
         Assert.IsType<FakeDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
         Assert.IsType<FakeDesktopVideoHashService>(services.GetRequiredService<IDesktopVideoHashService>());
         Assert.True(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakeBusinessObjectKeyEnabled);
         Assert.True(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakePreUploadCheckEnabled);
+        Assert.True(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakeSiteUploadEnabled);
         Assert.IsType<FakeDesktopPreUploadCheckClient>(
             services.GetRequiredService<IDesktopPreUploadCheckClient>());
+        Assert.IsType<FakeDesktopDirectSiteUploadClient>(
+            services.GetRequiredService<IDesktopDirectSiteUploadClient>());
 #else
         Assert.False(services.GetRequiredService<DesktopAuthOptions>().IsDevFakeAuthEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeSiteUploadEnabled);
         Assert.IsType<UnavailableDesktopAuthClient>(services.GetRequiredService<IDesktopAuthClient>());
         Assert.IsType<WpfDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
         Assert.IsType<DesktopVideoHashService>(services.GetRequiredService<IDesktopVideoHashService>());
         Assert.IsType<DisabledDesktopPreUploadCheckClient>(
             services.GetRequiredService<IDesktopPreUploadCheckClient>());
+        Assert.IsType<DisabledDesktopDirectSiteUploadClient>(
+            services.GetRequiredService<IDesktopDirectSiteUploadClient>());
 #endif
     }
 

--- a/tests/Unit/App.Desktop.Tests/DesktopSignInServiceTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopSignInServiceTests.cs
@@ -271,6 +271,9 @@ public sealed class DesktopSignInServiceTests
         Assert.Contains("DesktopUploadSectionText.StepFourTitle", markup, StringComparison.Ordinal);
         Assert.Contains("UploadSectionViewModel.PreUploadCheckRequestPreview", markup, StringComparison.Ordinal);
         Assert.Contains("UploadSectionViewModel.CheckPreUploadAsync(CancellationToken.None)", markup, StringComparison.Ordinal);
+        Assert.Contains("DesktopUploadSectionText.StepFiveTitle", markup, StringComparison.Ordinal);
+        Assert.Contains("UploadSectionViewModel.SiteUploadRequestPreview", markup, StringComparison.Ordinal);
+        Assert.Contains("UploadSectionViewModel.UploadToSiteAsync(CancellationToken.None)", markup, StringComparison.Ordinal);
         Assert.DoesNotContain("<UploadPlaceholder", markup, StringComparison.Ordinal);
         Assert.DoesNotContain("IDesktopUploadOrchestrator", markup, StringComparison.Ordinal);
         Assert.DoesNotContain("IControlPlaneApiClient", markup, StringComparison.Ordinal);

--- a/tests/Unit/App.Desktop.Tests/DesktopUploadSectionTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopUploadSectionTests.cs
@@ -107,13 +107,45 @@ public sealed class DesktopUploadSectionTests
         Assert.Equal("businessObjectKey", DesktopUploadSectionText.PreUploadCheckBusinessObjectKeyLabel);
         Assert.Equal("capturedAtUtc", DesktopUploadSectionText.PreUploadCheckCapturedAtUtcLabel);
         Assert.Equal("Решение", DesktopUploadSectionText.PreUploadCheckDecisionLabel);
+        Assert.Equal("Шаг 5. Загрузка на сайт", DesktopUploadSectionText.StepFiveTitle);
         Assert.Equal(
-            "Следующий шаг отложен: direct site upload boundary будет добавлен отдельным approved desktop slice.",
+            "Нужны выбранный файл, SHA-256, businessObjectKey и решение ALLOW или ALLOW_WITH_REVIEW.",
+            DesktopUploadSectionText.SiteUploadNotReadyMessage);
+        Assert.Equal(
+            "Preview загрузки на сайт готов. В этом slice доступен только desktop-local dev boundary.",
+            DesktopUploadSectionText.SiteUploadReadyMessage);
+        Assert.Equal(
+            "Загрузка на сайт недоступна для блокирующего решения предварительной проверки.",
+            DesktopUploadSectionText.SiteUploadBlockedByPreUploadCheckMessage);
+        Assert.Equal(
+            "Выполняется загрузка на сайт в desktop-local dev boundary.",
+            DesktopUploadSectionText.SiteUploadInProgressMessage);
+        Assert.Equal(
+            "Загрузка на сайт пока доступна только в dev-smoke режиме. Реальный provider будет добавлен отдельным approved slice.",
+            DesktopUploadSectionText.SiteUploadDeferredMessage);
+        Assert.Equal(
+            "Загрузка на сайт выполнена в dev-smoke режиме.",
+            DesktopUploadSectionText.SiteUploadSuccessDevMessage);
+        Assert.Equal("Загрузка на сайт отменена.", DesktopUploadSectionText.SiteUploadCanceledMessage);
+        Assert.Equal("Загрузить на сайт", DesktopUploadSectionText.SiteUploadButton);
+        Assert.Equal("Загружается...", DesktopUploadSectionText.SiteUploadBusyButton);
+        Assert.Equal("Имя файла", DesktopUploadSectionText.SiteUploadFileNameLabel);
+        Assert.Equal("Размер", DesktopUploadSectionText.SiteUploadFileSizeLabel);
+        Assert.Equal("Тип содержимого", DesktopUploadSectionText.SiteUploadContentTypeLabel);
+        Assert.Equal("SHA-256", DesktopUploadSectionText.SiteUploadSha256Label);
+        Assert.Equal("businessObjectKey", DesktopUploadSectionText.SiteUploadBusinessObjectKeyLabel);
+        Assert.Equal("Решение PreUploadCheck", DesktopUploadSectionText.SiteUploadPreUploadCheckDecisionLabel);
+        Assert.Equal("capturedAtUtc", DesktopUploadSectionText.SiteUploadCapturedAtUtcLabel);
+        Assert.Equal("status", DesktopUploadSectionText.SiteUploadResultStatusLabel);
+        Assert.Equal("externalVideoId", DesktopUploadSectionText.SiteUploadExternalVideoIdLabel);
+        Assert.Equal("siteStorageKey", DesktopUploadSectionText.SiteUploadSiteStorageKeyLabel);
+        Assert.Equal(
+            "Следующий шаг отложен: UploadReceipt будет добавлен отдельным approved desktop slice.",
             DesktopUploadSectionText.NextStepDeferredMessage);
     }
 
     [Fact]
-    public void UploadSectionDoesNotReferenceApiOrUploadFlowBoundaries()
+    public void UploadSectionDoesNotReferenceApiUploadReceiptOrByteSendingBoundaries()
     {
         string[] sourceFiles =
         [
@@ -127,10 +159,14 @@ public sealed class DesktopUploadSectionTests
             Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "DesktopPreUploadCheck.cs"),
             Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "DisabledDesktopPreUploadCheckClient.cs"),
             Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "FakeDesktopPreUploadCheckClient.cs"),
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "DesktopSiteUpload.cs"),
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "DisabledDesktopDirectSiteUploadClient.cs"),
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "FakeDesktopDirectSiteUploadClient.cs"),
             Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "WpfDesktopVideoFilePicker.cs"),
             Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Boundaries", "DesktopVideoFilePickerBoundary.cs"),
             Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Boundaries", "DesktopVideoHashBoundary.cs"),
-            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Boundaries", "DesktopPreUploadCheckBoundary.cs")
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Boundaries", "DesktopPreUploadCheckBoundary.cs"),
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Boundaries", "DesktopDirectSiteUploadBoundary.cs")
         ];
 
         foreach (string sourceFile in sourceFiles)
@@ -144,28 +180,32 @@ public sealed class DesktopUploadSectionTests
             Assert.DoesNotContain("ControlPlanePreUploadCheckRequest", source, StringComparison.Ordinal);
             Assert.DoesNotContain("RecordUploadReceiptAsync", source, StringComparison.Ordinal);
             Assert.DoesNotContain("ControlPlaneUploadReceiptDraft", source, StringComparison.Ordinal);
-            Assert.DoesNotContain("DirectSiteUpload", source, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("UploadReceipt", source, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("ReadAllBytes", source, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("ReadAllBytesAsync", source, StringComparison.OrdinalIgnoreCase);
         }
     }
 
     [Fact]
-    public void FakeUploadFileSelectionHashAndBusinessObjectKeyAreDevOnlyAndDisabledByDefault()
+    public void FakeUploadFileSelectionHashBusinessObjectKeyPreUploadCheckAndSiteUploadAreDevOnlyAndDisabledByDefault()
     {
         Assert.False(DesktopUploadSectionOptions.Disabled.IsDevFakeUploadFileEnabled);
         Assert.False(DesktopUploadSectionOptions.Disabled.IsDevFakeUploadHashEnabled);
         Assert.False(DesktopUploadSectionOptions.Disabled.IsDevFakeBusinessObjectKeyEnabled);
         Assert.False(DesktopUploadSectionOptions.Disabled.IsDevFakePreUploadCheckEnabled);
+        Assert.False(DesktopUploadSectionOptions.Disabled.IsDevFakeSiteUploadEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue(null).IsDevFakeUploadFileEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue(null).IsDevFakeUploadHashEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue(null).IsDevFakeBusinessObjectKeyEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue(null).IsDevFakePreUploadCheckEnabled);
+        Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue(null).IsDevFakeSiteUploadEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("false").IsDevFakeUploadFileEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("false", "false").IsDevFakeUploadHashEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "false").IsDevFakeBusinessObjectKeyEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "false", "false")
             .IsDevFakePreUploadCheckEnabled);
+        Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "false", "false", "false")
+            .IsDevFakeSiteUploadEnabled);
 
 #if DEBUG
         Assert.True(DesktopUploadSectionOptions.FromEnvironmentValue("true").IsDevFakeUploadFileEnabled);
@@ -177,6 +217,10 @@ public sealed class DesktopUploadSectionTests
             .IsDevFakePreUploadCheckEnabled);
         Assert.True(DesktopUploadSectionOptions.FromEnvironmentValue("true", "true", "true", "true")
             .IsDevFakePreUploadCheckEnabled);
+        Assert.True(DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "false", "false", "true")
+            .IsDevFakeSiteUploadEnabled);
+        Assert.True(DesktopUploadSectionOptions.FromEnvironmentValue("true", "true", "true", "true", "true")
+            .IsDevFakeSiteUploadEnabled);
 #else
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("true").IsDevFakeUploadFileEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("false", "true").IsDevFakeUploadHashEnabled);
@@ -187,6 +231,10 @@ public sealed class DesktopUploadSectionTests
             .IsDevFakePreUploadCheckEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("true", "true", "true", "true")
             .IsDevFakePreUploadCheckEnabled);
+        Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "false", "false", "true")
+            .IsDevFakeSiteUploadEnabled);
+        Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("true", "true", "true", "true", "true")
+            .IsDevFakeSiteUploadEnabled);
 #endif
     }
 
@@ -628,6 +676,219 @@ public sealed class DesktopUploadSectionTests
     }
 
     [Fact]
+    public async Task SiteUploadActionRequiresSelectedFileSha256BusinessObjectKeyAndAllowedPreUploadCheckDecision()
+    {
+        var viewModel = CreateViewModel(
+            new FakeDesktopVideoFilePicker(),
+            new FakeDesktopVideoHashService(),
+            new FakeDesktopPreUploadCheckClient(),
+            DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "false", "true", "false"));
+
+        Assert.Null(viewModel.SiteUploadRequestPreview);
+        Assert.False(viewModel.HasSiteUploadRequestPreview);
+        Assert.False(viewModel.CanUploadToSite);
+
+        _ = await viewModel.SelectVideoFileAsync(CancellationToken.None);
+        _ = await viewModel.CalculateSha256Async(CancellationToken.None);
+        viewModel.BusinessObjectKeyInput = "report-draft-001";
+        _ = viewModel.ApplyBusinessObjectKey();
+
+        Assert.Null(viewModel.SiteUploadRequestPreview);
+        Assert.False(viewModel.CanUploadToSite);
+
+        _ = await viewModel.CheckPreUploadAsync(CancellationToken.None);
+
+#if DEBUG
+        Assert.NotNull(viewModel.SiteUploadRequestPreview);
+        Assert.True(viewModel.HasSiteUploadRequestPreview);
+        Assert.True(viewModel.CanUploadToSite);
+        Assert.Equal(DesktopUploadSectionText.SiteUploadReadyMessage, viewModel.SiteUploadStatusMessage);
+#else
+        Assert.Null(viewModel.SiteUploadRequestPreview);
+        Assert.False(viewModel.CanUploadToSite);
+#endif
+    }
+
+    [Fact]
+    public async Task SiteUploadRequestPreviewShowsOnlySafeFields()
+    {
+        var viewModel = CreateViewModel(new StaticDesktopVideoFilePicker(
+            DesktopVideoFilePickerResult.Selected(
+                Path.Combine("private-folder", "nested", "safe-preview.mp4"),
+                42,
+                "video/mp4",
+                DesktopVideoHashSource.VisualSmoke)),
+            new FakeDesktopVideoHashService(),
+            new FakeDesktopPreUploadCheckClient(),
+            DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "false", "true", "false"));
+
+        _ = await PreparePreUploadCheckPreviewAsync(viewModel, " report-draft-001 ");
+        _ = await viewModel.CheckPreUploadAsync(CancellationToken.None);
+
+#if DEBUG
+        DesktopSiteUploadRequestPreview preview =
+            viewModel.SiteUploadRequestPreview ?? throw new InvalidOperationException("Site upload preview was not created.");
+
+        Assert.Equal("safe-preview.mp4", preview.FileName);
+        Assert.Equal(42, preview.SizeBytes);
+        Assert.Equal("video/mp4", preview.ContentType);
+        Assert.Equal(FakeDesktopVideoHashService.VisualSmokeSha256Hex, preview.Sha256Hex);
+        Assert.Equal("report-draft-001", preview.BusinessObjectKeyPreview);
+        Assert.Equal("ALLOW", preview.PreUploadCheckDecisionPreview);
+        Assert.Equal(DesktopPreUploadCheckRequestPreview.CapturedAtUtcPlaceholder, preview.CapturedAtUtc);
+#else
+        Assert.Null(viewModel.SiteUploadRequestPreview);
+#endif
+    }
+
+    [Fact]
+    public async Task SiteUploadRequestPreviewDoesNotShowFullLocalPath()
+    {
+        string privateFolder = "operator-private-site-upload-source";
+        string localPath = Path.Combine(Path.GetTempPath(), privateFolder, "safe-preview.mp4");
+        var viewModel = CreateViewModel(new StaticDesktopVideoFilePicker(
+            DesktopVideoFilePickerResult.Selected(
+                localPath,
+                42,
+                "video/mp4",
+                DesktopVideoHashSource.VisualSmoke)),
+            new FakeDesktopVideoHashService(),
+            new FakeDesktopPreUploadCheckClient(),
+            DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "false", "true", "false"));
+
+        _ = await PreparePreUploadCheckPreviewAsync(viewModel, "report-draft-001");
+        _ = await viewModel.CheckPreUploadAsync(CancellationToken.None);
+
+#if DEBUG
+        DesktopSiteUploadRequestPreview preview =
+            viewModel.SiteUploadRequestPreview ?? throw new InvalidOperationException("Site upload preview was not created.");
+        string visibleState = preview.ToString()
+            + " "
+            + viewModel.SiteUploadStatusMessage
+            + " "
+            + (viewModel.SiteUploadStatusPreview ?? string.Empty);
+
+        Assert.Equal("safe-preview.mp4", preview.FileName);
+        Assert.DoesNotContain(Path.GetTempPath(), visibleState, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(privateFolder, visibleState, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(@"\", preview.FileName, StringComparison.Ordinal);
+        Assert.DoesNotContain("/", preview.FileName, StringComparison.Ordinal);
+#else
+        Assert.Null(viewModel.SiteUploadRequestPreview);
+#endif
+    }
+
+    [Fact]
+    public async Task DisabledSiteUploadShowsSafeDeferredMessageAndDoesNotCallBoundary()
+    {
+        var siteUploadClient = new ThrowingDesktopDirectSiteUploadClient();
+        var viewModel = CreateViewModel(
+            new FakeDesktopVideoFilePicker(),
+            new FakeDesktopVideoHashService(),
+            new FakeDesktopPreUploadCheckClient(),
+            siteUploadClient,
+            DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "false", "true", "false"));
+
+        _ = await PreparePreUploadCheckPreviewAsync(viewModel, "report-draft-001");
+        _ = await viewModel.CheckPreUploadAsync(CancellationToken.None);
+
+        DesktopSiteUploadResult? result = await viewModel.UploadToSiteAsync(CancellationToken.None);
+
+#if DEBUG
+        Assert.NotNull(result);
+        Assert.Equal(DesktopSiteUploadStatus.Deferred, result.Status);
+        Assert.Null(result.StatusPreview);
+        Assert.Null(result.ExternalVideoId);
+        Assert.Null(result.SiteStorageKey);
+        Assert.Equal(DesktopUploadSectionText.SiteUploadDeferredMessage, viewModel.SiteUploadStatusMessage);
+        Assert.Equal(0, siteUploadClient.CallCount);
+#else
+        Assert.Null(result);
+        Assert.Equal(0, siteUploadClient.CallCount);
+#endif
+    }
+
+    [Fact]
+    public async Task EnabledSiteUploadShowsFakeSuccessResult()
+    {
+        var viewModel = CreateViewModel(
+            new FakeDesktopVideoFilePicker(),
+            new FakeDesktopVideoHashService(),
+            new FakeDesktopPreUploadCheckClient(),
+            new FakeDesktopDirectSiteUploadClient(),
+            DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "false", "true", "true"));
+
+        _ = await PreparePreUploadCheckPreviewAsync(viewModel, "report-draft-001");
+        _ = await viewModel.CheckPreUploadAsync(CancellationToken.None);
+
+        DesktopSiteUploadResult? result = await viewModel.UploadToSiteAsync(CancellationToken.None);
+
+#if DEBUG
+        Assert.NotNull(result);
+        Assert.Equal(DesktopSiteUploadStatus.Succeeded, result.Status);
+        Assert.Equal("SUCCESS", result.StatusPreview);
+        Assert.Equal("visual-smoke-external-video-001", result.ExternalVideoId);
+        Assert.Equal("visual-smoke/site/video-001", result.SiteStorageKey);
+        Assert.True(viewModel.HasSiteUploadResult);
+        Assert.Equal("SUCCESS", viewModel.SiteUploadStatusPreview);
+        Assert.Equal("visual-smoke-external-video-001", viewModel.SiteUploadExternalVideoId);
+        Assert.Equal("visual-smoke/site/video-001", viewModel.SiteUploadSiteStorageKey);
+        Assert.Equal(DesktopUploadSectionText.SiteUploadSuccessDevMessage, viewModel.SiteUploadStatusMessage);
+#else
+        Assert.Null(result);
+        Assert.False(viewModel.HasSiteUploadResult);
+#endif
+    }
+
+    [Theory]
+    [InlineData(DesktopPreUploadCheckDecision.Allow, true, "ALLOW")]
+    [InlineData(DesktopPreUploadCheckDecision.AllowWithReview, true, "ALLOW_WITH_REVIEW")]
+    [InlineData(DesktopPreUploadCheckDecision.BlockHardDuplicate, false, "BLOCK_HARD_DUPLICATE")]
+    [InlineData(DesktopPreUploadCheckDecision.BlockPossibleFalsification, false, "BLOCK_POSSIBLE_FALSIFICATION")]
+    public async Task SiteUploadActionAllowsOnlyAllowedPreUploadCheckDecisions(
+        DesktopPreUploadCheckDecision decision,
+        bool expectedCanUpload,
+        string expectedDecisionPreview)
+    {
+        var siteUploadClient = new ThrowingDesktopDirectSiteUploadClient();
+        var viewModel = CreateViewModel(
+            new FakeDesktopVideoFilePicker(),
+            new FakeDesktopVideoHashService(),
+            new FakeDesktopPreUploadCheckClient(decision),
+            siteUploadClient,
+            DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "false", "true", "true"));
+
+        _ = await PreparePreUploadCheckPreviewAsync(viewModel, "report-draft-001");
+        _ = await viewModel.CheckPreUploadAsync(CancellationToken.None);
+
+#if DEBUG
+        Assert.Equal(expectedDecisionPreview, viewModel.PreUploadCheckDecisionPreview);
+        Assert.Equal(expectedCanUpload, viewModel.CanUploadToSite);
+
+        if (expectedCanUpload)
+        {
+            Assert.NotNull(viewModel.SiteUploadRequestPreview);
+            Assert.Equal(expectedDecisionPreview, viewModel.SiteUploadRequestPreview.PreUploadCheckDecisionPreview);
+            Assert.Equal(DesktopUploadSectionText.SiteUploadReadyMessage, viewModel.SiteUploadStatusMessage);
+        }
+        else
+        {
+            Assert.Null(viewModel.SiteUploadRequestPreview);
+            Assert.False(viewModel.HasSiteUploadRequestPreview);
+            Assert.Equal(
+                DesktopUploadSectionText.SiteUploadBlockedByPreUploadCheckMessage,
+                viewModel.SiteUploadStatusMessage);
+            DesktopSiteUploadResult? result = await viewModel.UploadToSiteAsync(CancellationToken.None);
+            Assert.Null(result);
+            Assert.Equal(0, siteUploadClient.CallCount);
+        }
+#else
+        Assert.Null(viewModel.SiteUploadRequestPreview);
+        Assert.False(viewModel.CanUploadToSite);
+#endif
+    }
+
+    [Fact]
     public async Task RealHashBoundaryComputesLowercaseSha256ForSelectedLocalFile()
     {
         string tempDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
@@ -683,7 +944,12 @@ public sealed class DesktopUploadSectionTests
     [Fact]
     public async Task SignOutResetReturnsUploadStateToWorkspace()
     {
-        var viewModel = CreateViewModel(new FakeDesktopVideoFilePicker());
+        var viewModel = CreateViewModel(
+            new FakeDesktopVideoFilePicker(),
+            new FakeDesktopVideoHashService(),
+            new FakeDesktopPreUploadCheckClient(),
+            new FakeDesktopDirectSiteUploadClient(),
+            DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "false", "true", "true"));
 
         viewModel.OpenUploadSection();
         _ = await viewModel.SelectVideoFileAsync(CancellationToken.None);
@@ -691,6 +957,12 @@ public sealed class DesktopUploadSectionTests
         viewModel.BusinessObjectKeyInput = "report-draft-001";
         _ = viewModel.ApplyBusinessObjectKey();
         _ = await viewModel.CheckPreUploadAsync(CancellationToken.None);
+        _ = await viewModel.UploadToSiteAsync(CancellationToken.None);
+
+#if DEBUG
+        Assert.NotNull(viewModel.SiteUploadRequestPreview);
+        Assert.True(viewModel.HasSiteUploadResult);
+#endif
 
         viewModel.ResetForSignedOutState();
 
@@ -709,12 +981,23 @@ public sealed class DesktopUploadSectionTests
         Assert.Null(viewModel.PreUploadCheckResult);
         Assert.Null(viewModel.PreUploadCheckDecisionPreview);
         Assert.Equal(DesktopUploadSectionText.PreUploadCheckNotReadyMessage, viewModel.PreUploadCheckStatusMessage);
+        Assert.Null(viewModel.SiteUploadRequestPreview);
+        Assert.Null(viewModel.SiteUploadResult);
+        Assert.Null(viewModel.SiteUploadStatusPreview);
+        Assert.Null(viewModel.SiteUploadExternalVideoId);
+        Assert.Null(viewModel.SiteUploadSiteStorageKey);
+        Assert.Equal(DesktopUploadSectionText.SiteUploadNotReadyMessage, viewModel.SiteUploadStatusMessage);
     }
 
     [Fact]
     public async Task BackToWorkspaceResetsSelectedFileState()
     {
-        var viewModel = CreateViewModel(new FakeDesktopVideoFilePicker());
+        var viewModel = CreateViewModel(
+            new FakeDesktopVideoFilePicker(),
+            new FakeDesktopVideoHashService(),
+            new FakeDesktopPreUploadCheckClient(),
+            new FakeDesktopDirectSiteUploadClient(),
+            DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "false", "true", "true"));
 
         viewModel.OpenUploadSection();
         _ = await viewModel.SelectVideoFileAsync(CancellationToken.None);
@@ -722,6 +1005,12 @@ public sealed class DesktopUploadSectionTests
         viewModel.BusinessObjectKeyInput = "report-draft-001";
         _ = viewModel.ApplyBusinessObjectKey();
         _ = await viewModel.CheckPreUploadAsync(CancellationToken.None);
+        _ = await viewModel.UploadToSiteAsync(CancellationToken.None);
+
+#if DEBUG
+        Assert.NotNull(viewModel.SiteUploadRequestPreview);
+        Assert.True(viewModel.HasSiteUploadResult);
+#endif
 
         viewModel.BackToWorkspace();
 
@@ -740,6 +1029,12 @@ public sealed class DesktopUploadSectionTests
         Assert.Null(viewModel.PreUploadCheckResult);
         Assert.Null(viewModel.PreUploadCheckDecisionPreview);
         Assert.Equal(DesktopUploadSectionText.PreUploadCheckNotReadyMessage, viewModel.PreUploadCheckStatusMessage);
+        Assert.Null(viewModel.SiteUploadRequestPreview);
+        Assert.Null(viewModel.SiteUploadResult);
+        Assert.Null(viewModel.SiteUploadStatusPreview);
+        Assert.Null(viewModel.SiteUploadExternalVideoId);
+        Assert.Null(viewModel.SiteUploadSiteStorageKey);
+        Assert.Equal(DesktopUploadSectionText.SiteUploadNotReadyMessage, viewModel.SiteUploadStatusMessage);
     }
 
     [Fact]
@@ -802,6 +1097,26 @@ public sealed class DesktopUploadSectionTests
             DesktopUploadSectionText.PreUploadCheckBusinessObjectKeyLabel,
             DesktopUploadSectionText.PreUploadCheckCapturedAtUtcLabel,
             DesktopUploadSectionText.PreUploadCheckDecisionLabel,
+            DesktopUploadSectionText.StepFiveTitle,
+            DesktopUploadSectionText.SiteUploadNotReadyMessage,
+            DesktopUploadSectionText.SiteUploadReadyMessage,
+            DesktopUploadSectionText.SiteUploadBlockedByPreUploadCheckMessage,
+            DesktopUploadSectionText.SiteUploadInProgressMessage,
+            DesktopUploadSectionText.SiteUploadDeferredMessage,
+            DesktopUploadSectionText.SiteUploadSuccessDevMessage,
+            DesktopUploadSectionText.SiteUploadCanceledMessage,
+            DesktopUploadSectionText.SiteUploadButton,
+            DesktopUploadSectionText.SiteUploadBusyButton,
+            DesktopUploadSectionText.SiteUploadFileNameLabel,
+            DesktopUploadSectionText.SiteUploadFileSizeLabel,
+            DesktopUploadSectionText.SiteUploadContentTypeLabel,
+            DesktopUploadSectionText.SiteUploadSha256Label,
+            DesktopUploadSectionText.SiteUploadBusinessObjectKeyLabel,
+            DesktopUploadSectionText.SiteUploadPreUploadCheckDecisionLabel,
+            DesktopUploadSectionText.SiteUploadCapturedAtUtcLabel,
+            DesktopUploadSectionText.SiteUploadResultStatusLabel,
+            DesktopUploadSectionText.SiteUploadExternalVideoIdLabel,
+            DesktopUploadSectionText.SiteUploadSiteStorageKeyLabel,
             DesktopUploadSectionText.NextStepDeferredMessage,
             DesktopUploadSelectedFile.VisualSmokeFileName,
             DesktopUploadSelectedFile.VisualSmokeContentType,
@@ -811,7 +1126,10 @@ public sealed class DesktopUploadSectionTests
             DesktopPreUploadCheckResult.FromFakeDecision(DesktopPreUploadCheckDecision.Allow).DecisionPreview ?? string.Empty,
             DesktopPreUploadCheckResult.FromFakeDecision(DesktopPreUploadCheckDecision.AllowWithReview).DecisionPreview ?? string.Empty,
             DesktopPreUploadCheckResult.FromFakeDecision(DesktopPreUploadCheckDecision.BlockHardDuplicate).DecisionPreview ?? string.Empty,
-            DesktopPreUploadCheckResult.FromFakeDecision(DesktopPreUploadCheckDecision.BlockPossibleFalsification).DecisionPreview ?? string.Empty
+            DesktopPreUploadCheckResult.FromFakeDecision(DesktopPreUploadCheckDecision.BlockPossibleFalsification).DecisionPreview ?? string.Empty,
+            DesktopSiteUploadResult.FakeSuccess.StatusPreview ?? string.Empty,
+            DesktopSiteUploadResult.FakeSuccess.ExternalVideoId ?? string.Empty,
+            DesktopSiteUploadResult.FakeSuccess.SiteStorageKey ?? string.Empty
         ];
 
         foreach (string visibleString in visibleStrings)
@@ -855,10 +1173,26 @@ public sealed class DesktopUploadSectionTests
         IDesktopPreUploadCheckClient preUploadCheckClient,
         DesktopUploadSectionOptions uploadSectionOptions)
     {
+        return CreateViewModel(
+            videoFilePicker,
+            videoHashService,
+            preUploadCheckClient,
+            new DisabledDesktopDirectSiteUploadClient(),
+            uploadSectionOptions);
+    }
+
+    private static DesktopUploadSectionViewModel CreateViewModel(
+        IDesktopVideoFilePicker videoFilePicker,
+        IDesktopVideoHashService videoHashService,
+        IDesktopPreUploadCheckClient preUploadCheckClient,
+        IDesktopDirectSiteUploadClient directSiteUploadClient,
+        DesktopUploadSectionOptions uploadSectionOptions)
+    {
         return new DesktopUploadSectionViewModel(
             videoFilePicker,
             videoHashService,
             preUploadCheckClient,
+            directSiteUploadClient,
             uploadSectionOptions);
     }
 
@@ -903,6 +1237,19 @@ public sealed class DesktopUploadSectionTests
         {
             CallCount++;
             throw new InvalidOperationException("Disabled fake PreUploadCheck boundary should not be called.");
+        }
+    }
+
+    private sealed class ThrowingDesktopDirectSiteUploadClient : IDesktopDirectSiteUploadClient
+    {
+        public int CallCount { get; private set; }
+
+        public ValueTask<DesktopSiteUploadResult> UploadAsync(
+            DesktopSiteUploadRequestPreview requestPreview,
+            CancellationToken cancellationToken)
+        {
+            CallCount++;
+            throw new InvalidOperationException("Disabled fake site upload boundary should not be called.");
         }
     }
 


### PR DESCRIPTION
## Coder
Codex, Coder 1 acting as Coder 2 / Desktop Client

## Task ID
S2-65 Desktop Direct Site Upload Boundary / Fake Site Upload Result

## Module
App.Desktop / direct site upload boundary fake result

## Scope
- Added upload Step 5: direct site upload request preview and fake/dev site upload result.
- Added App.Desktop-local `IDesktopDirectSiteUploadClient` boundary with disabled and fake implementations.
- Kept App.Api as control plane only; no video bytes are sent through App.Api.

## Changed areas
- `docs/task-cards/S2-65_desktop-direct-site-upload-boundary-task-card.txt`
- `src/App.Desktop/**`
- `tests/Unit/App.Desktop.Tests/**`

## Base main SHA
`4e54ffd0fcfbe53724ff8dca096e6a7015667d30`

## Coordination log entries reviewed
- TEAM COORDINATION LOG issue #89 metadata: open, title `TEAM COORDINATION LOG — AnalyticsAutomation-Core`, updated 2026-05-01T06:29:00Z.
- Issue #89 merge records reviewed for #127 S2-58 through #133 S2-64.
- Latest reviewed desktop base: #133 / S2-64 merged at `4e54ffd0fcfbe53724ff8dca096e6a7015667d30`.

## Handoff/task cards reviewed
- `docs/task-cards/S2-58_desktop-visual-smoke-fake-auth-task-card.txt`
- `docs/task-cards/S2-59_desktop-signed-in-shell-navigation-task-card.txt`
- `docs/task-cards/S2-60_desktop-upload-section-file-selection-placeholder-task-card.txt`
- `docs/task-cards/S2-61_desktop-upload-file-picker-boundary-task-card.txt`
- `docs/task-cards/S2-62_desktop-upload-sha256-boundary-task-card.txt`
- `docs/task-cards/S2-63_desktop-upload-business-object-key-placeholder-task-card.txt`
- `docs/task-cards/S2-64_desktop-preuploadcheck-request-preview-task-card.txt`

## Contracts
None. No backend DTO/shared contract/API request/response changes.

## Migrations
None.

## Feature flags / env guard
Uses existing visual-smoke guards:
- `AA_DESKTOP_DEV_FAKE_AUTH_ENABLED=true`
- `AA_DESKTOP_DEV_FAKE_UPLOAD_FILE_ENABLED=true`
- `AA_DESKTOP_DEV_FAKE_UPLOAD_HASH_ENABLED=true`
- `AA_DESKTOP_DEV_FAKE_BUSINESS_OBJECT_KEY_ENABLED=true`
- `AA_DESKTOP_DEV_FAKE_PREUPLOAD_CHECK_ENABLED=true`

Adds S2-65 visual-smoke guard:
- `AA_DESKTOP_DEV_FAKE_SITE_UPLOAD_ENABLED=true`

Fake site upload is disabled by default and enabled only by the new env guard in debug/dev-test flow.

## API impact
None. No App.Api changes, no App.Api direct upload call, no App.Api video-byte transfer.

## Web impact
None. No App.Web changes.

## Android impact
None. No App.Mobile.Android changes.

## Offline behavior
None.

## Rollback
Revert the S2-65 PR.

## Validation
- PASS: `git diff --check`
- PASS: `dotnet restore AnalyticsAutomation-Core.sln -nologo`
- PASS: `dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore`
- PASS: `dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal`
- PASS: `dotnet build AnalyticsAutomation-Core.sln -nologo -v minimal` (existing analyzer warnings outside S2-65 scope)
- PASS: `dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal` (131 passed)
- PASS: hidden/control Unicode scan over changed text files
- PASS: App.Desktop fake-auth/fake-picker/fake-hash/fake-businessObjectKey/fake-PreUploadCheck/fake-site-upload visual smoke

## Visual smoke screenshot folder/files
Folder:
`C:\CODEX\Temp\S2-65_DESKTOP_DIRECT_SITE_UPLOAD_VISUAL_SMOKE_20260501_105414\`

Files:
- `01_baseline_signin.png`
- `02_signed_in_shell.png`
- `03_upload_section_after_preuploadcheck_allow.png`
- `04_direct_site_upload_request_preview.png`
- `05_after_fake_site_upload_success.png`
- `06_after_sign_out.png`

## Handoff docs/task card
- `docs/task-cards/S2-65_desktop-direct-site-upload-boundary-task-card.txt`

## Next step
Approved later slice: real direct-site provider and UploadReceipt.

## NO-GO / Deferred
- No real site upload.
- No file-content read for site upload.
- No byte sending.
- No App.Api upload.
- No UploadReceipt.
- No backend contracts/DTOs/API routes/migrations/deploy.
- No App.Web or App.Mobile.Android changes.