### PR TITLE
[codex] S2-66 Desktop UploadReceipt Boundary

### DIFF
--- a/docs/task-cards/S2-66_desktop-upload-receipt-boundary-task-card.txt
+++ b/docs/task-cards/S2-66_desktop-upload-receipt-boundary-task-card.txt
@@ -1,0 +1,131 @@
+Title:
+S2-66 Desktop UploadReceipt Request Preview / Fake Control-Plane Receipt Boundary
+
+Module:
+App.Desktop / UploadReceipt request preview fake boundary
+
+Owner:
+Coder 1 acting as Coder 2 / Desktop Client
+
+Client form:
+desktop standalone
+
+Type:
+narrow runtime desktop UI slice after S2-65 direct site upload fake result
+
+Status:
+Runtime task card created with implementation.
+
+Goal:
+Add a safe App.Desktop-local UploadReceipt request preview and a dev/fake UploadReceipt boundary for visual smoke only.
+
+Scope:
+- Keep the Russian SignIn UI and signed-in shell from S2-58 through S2-65.
+- Keep upload Step 1 file metadata, Step 2 SHA-256, Step 3 businessObjectKey placeholder, Step 4 PreUploadCheck preview/fake decision, and Step 5 direct site upload preview/fake result.
+- Add Step 6 "Квитанция загрузки".
+- Show UploadReceipt request preview built only from safe fields:
+  - file name without full local path;
+  - size;
+  - content type;
+  - SHA-256;
+  - businessObjectKey preview;
+  - PreUploadCheck decision;
+  - externalVideoId;
+  - siteStorageKey;
+  - site upload status;
+  - capturedAtUtc preview when available.
+- Add "Сформировать квитанцию".
+- When AA_DESKTOP_DEV_FAKE_UPLOAD_RECEIPT_ENABLED is not true, show the safe deferred Russian message and do not call App.Api.
+- When AA_DESKTOP_DEV_FAKE_UPLOAD_RECEIPT_ENABLED=true, call only the App.Desktop-local fake boundary and show ACCEPTED with:
+  - receiptId: visual-smoke-upload-receipt-001
+  - serverCorrelationId: visual-smoke-correlation-001
+
+Allowed changed areas:
+- docs/task-cards/S2-66_desktop-upload-receipt-boundary-task-card.txt
+- src/App.Desktop/**
+- tests/Unit/App.Desktop.Tests/**
+
+Forbidden changed areas:
+- src/App.Api/**
+- src/App.Worker/**
+- src/App.Web/**
+- src/App.Mobile.Android/**
+- src/App.UI.Shared/**
+- src/BuildingBlocks.Contracts/**
+- src/Modules/**
+- DB migrations
+- .github/workflows/**
+- deploy scripts
+- docs/ops/**
+- committed screenshots or runtime artifacts
+
+Contracts:
+none
+
+Migrations:
+none
+
+Feature flags/env guard:
+- Existing fake auth visual-smoke guard:
+  AA_DESKTOP_DEV_FAKE_AUTH_ENABLED=true
+- Existing fake picker visual-smoke guard:
+  AA_DESKTOP_DEV_FAKE_UPLOAD_FILE_ENABLED=true
+- Existing fake hash visual-smoke guard:
+  AA_DESKTOP_DEV_FAKE_UPLOAD_HASH_ENABLED=true
+- Existing fake businessObjectKey visual-smoke guard:
+  AA_DESKTOP_DEV_FAKE_BUSINESS_OBJECT_KEY_ENABLED=true
+- Existing fake PreUploadCheck visual-smoke guard:
+  AA_DESKTOP_DEV_FAKE_PREUPLOAD_CHECK_ENABLED=true
+- Existing fake site upload visual-smoke guard:
+  AA_DESKTOP_DEV_FAKE_SITE_UPLOAD_ENABLED=true
+- New fake UploadReceipt visual-smoke guard:
+  AA_DESKTOP_DEV_FAKE_UPLOAD_RECEIPT_ENABLED=true
+
+Events:
+none
+
+Offline behavior:
+none
+
+Security guardrails:
+- App.Api remains control plane.
+- Do not send video bytes through App.Api.
+- Do not call App.Api for UploadReceipt in S2-66.
+- Do not create a server receipt in S2-66.
+- Do not read file contents for upload in S2-66.
+- Do not send video bytes anywhere in S2-66.
+- Do not add backend DTOs, shared contracts, API routes, migrations, deploy changes, App.Web changes, or App.Mobile.Android changes.
+- Do not display full local file paths, password, accessToken, refreshToken, Authorization, raw session id, raw response body, or token-like values.
+- Screenshots and runtime artifacts stay under C:\CODEX\Temp and are not committed.
+
+Deferred:
+Real App.Api UploadReceipt integration is not implemented in S2-66. The real control-plane UploadReceipt client remains a separate approved slice after request/DTO reuse and backend binding are agreed.
+
+Rollback:
+revert S2-66 PR
+
+Validation:
+- git diff --check
+- dotnet restore AnalyticsAutomation-Core.sln -nologo
+- dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore
+- dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal
+- dotnet build AnalyticsAutomation-Core.sln -nologo -v minimal
+- dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal
+- hidden/control Unicode scan over changed text files
+- App.Desktop fake-auth/fake-picker/fake-hash/fake-businessObjectKey/fake-PreUploadCheck/fake-site-upload/fake-UploadReceipt visual smoke with screenshots
+
+Definition of done:
+- Step 6 "Квитанция загрузки" is visible in the upload section.
+- UploadReceipt request preview appears only after selected file, SHA-256, businessObjectKey, ALLOW or ALLOW_WITH_REVIEW PreUploadCheck decision, and successful site upload result.
+- Preview shows only safe file name, size, content type, SHA-256, businessObjectKey, PreUploadCheck decision, externalVideoId, siteStorageKey, site upload status, and capturedAtUtc preview.
+- Preview never shows a full local path.
+- Fake UploadReceipt is disabled by default.
+- Fake UploadReceipt is enabled only by AA_DESKTOP_DEV_FAKE_UPLOAD_RECEIPT_ENABLED=true in debug/dev-test visual smoke.
+- Disabled fake UploadReceipt shows the safe deferred Russian message and does not call App.Api.
+- Enabled fake UploadReceipt shows ACCEPTED, receiptId visual-smoke-upload-receipt-001, and serverCorrelationId visual-smoke-correlation-001.
+- BLOCK_HARD_DUPLICATE and BLOCK_POSSIBLE_FALSIFICATION decisions do not allow the receipt action.
+- Missing or failed site upload does not allow the receipt action.
+- Back/sign-out clear UploadReceipt preview/result state.
+- No real App.Api UploadReceipt call, server receipt creation, backend contract, migration, deploy, App.Web, or App.Mobile.Android change is introduced.
+- Automated App.Desktop tests cover env guard behavior, safe preview, fake result, blocked decisions, reset behavior, forbidden call patterns, and visible-string safety.
+- Required visual-smoke screenshots are saved under C:\CODEX\Temp and kept out of git.

--- a/src/App.Desktop/Boundaries/DesktopSignInBoundary.cs
+++ b/src/App.Desktop/Boundaries/DesktopSignInBoundary.cs
@@ -227,8 +227,35 @@ public static class DesktopUploadSectionText
     public const string SiteUploadResultStatusLabel = "status";
     public const string SiteUploadExternalVideoIdLabel = "externalVideoId";
     public const string SiteUploadSiteStorageKeyLabel = "siteStorageKey";
+    public const string StepSixTitle = "Шаг 6. Квитанция загрузки";
+    public const string UploadReceiptNotReadyMessage =
+        "Нужны выбранный файл, SHA-256, businessObjectKey, решение ALLOW или ALLOW_WITH_REVIEW и успешная загрузка на сайт.";
+    public const string UploadReceiptReadyMessage =
+        "Preview квитанции загрузки готов. В этом slice доступен только desktop-local dev boundary.";
+    public const string UploadReceiptInProgressMessage =
+        "Формируется квитанция загрузки в desktop-local dev boundary.";
+    public const string UploadReceiptDeferredMessage =
+        "Квитанция загрузки пока доступна только в dev-smoke режиме. Реальный вызов App.Api будет добавлен отдельным approved slice.";
+    public const string UploadReceiptAcceptedDevMessage =
+        "Квитанция загрузки сформирована в dev-smoke режиме.";
+    public const string UploadReceiptCanceledMessage = "Формирование квитанции загрузки отменено.";
+    public const string UploadReceiptButton = "Сформировать квитанцию";
+    public const string UploadReceiptBusyButton = "Формируется...";
+    public const string UploadReceiptFileNameLabel = "Имя файла";
+    public const string UploadReceiptFileSizeLabel = "Размер";
+    public const string UploadReceiptContentTypeLabel = "Тип содержимого";
+    public const string UploadReceiptSha256Label = "SHA-256";
+    public const string UploadReceiptBusinessObjectKeyLabel = "businessObjectKey";
+    public const string UploadReceiptPreUploadCheckDecisionLabel = "Решение PreUploadCheck";
+    public const string UploadReceiptExternalVideoIdLabel = "externalVideoId";
+    public const string UploadReceiptSiteStorageKeyLabel = "siteStorageKey";
+    public const string UploadReceiptSiteUploadStatusLabel = "status загрузки на сайт";
+    public const string UploadReceiptCapturedAtUtcLabel = "capturedAtUtc";
+    public const string UploadReceiptResultStatusLabel = "status";
+    public const string UploadReceiptResultReceiptIdLabel = "receiptId";
+    public const string UploadReceiptResultServerCorrelationIdLabel = "serverCorrelationId";
     public const string NextStepDeferredMessage =
-        "Следующий шаг отложен: UploadReceipt будет добавлен отдельным approved desktop slice.";
+        "Следующий шаг отложен: реальный control-plane UploadReceipt client будет добавлен отдельным approved desktop slice.";
 }
 
 public sealed record DesktopUploadSelectedFile(

--- a/src/App.Desktop/Boundaries/DesktopUploadReceiptBoundary.cs
+++ b/src/App.Desktop/Boundaries/DesktopUploadReceiptBoundary.cs
@@ -1,0 +1,10 @@
+using App.Desktop.Services.Upload;
+
+namespace App.Desktop.Boundaries;
+
+public interface IDesktopUploadReceiptClient
+{
+    ValueTask<DesktopUploadReceiptResult> CreateAsync(
+        DesktopUploadReceiptRequestPreview requestPreview,
+        CancellationToken cancellationToken);
+}

--- a/src/App.Desktop/Components/DesktopShell.razor
+++ b/src/App.Desktop/Components/DesktopShell.razor
@@ -304,6 +304,92 @@
                                 </dl>
                             }
 
+                        </div>
+
+                        <div class="desktop-upload__step">
+                            <h3>@DesktopUploadSectionText.StepSixTitle</h3>
+                            <p
+                                id="desktop-upload-receipt-status"
+                                class="desktop-upload__message"
+                                role="status"
+                                aria-live="polite">
+                                @UploadSectionViewModel.UploadReceiptStatusMessage
+                            </p>
+
+                            @if (UploadSectionViewModel.UploadReceiptRequestPreview is { } receiptPreview)
+                            {
+                                <dl class="desktop-upload__receipt-preview">
+                                    <div>
+                                        <dt>@DesktopUploadSectionText.UploadReceiptFileNameLabel</dt>
+                                        <dd>@receiptPreview.FileName</dd>
+                                    </div>
+                                    <div>
+                                        <dt>@DesktopUploadSectionText.UploadReceiptFileSizeLabel</dt>
+                                        <dd>@receiptPreview.SizeBytes</dd>
+                                    </div>
+                                    <div>
+                                        <dt>@DesktopUploadSectionText.UploadReceiptContentTypeLabel</dt>
+                                        <dd>@receiptPreview.ContentType</dd>
+                                    </div>
+                                    <div>
+                                        <dt>@DesktopUploadSectionText.UploadReceiptSha256Label</dt>
+                                        <dd>@receiptPreview.Sha256Hex</dd>
+                                    </div>
+                                    <div>
+                                        <dt>@DesktopUploadSectionText.UploadReceiptBusinessObjectKeyLabel</dt>
+                                        <dd>@receiptPreview.BusinessObjectKeyPreview</dd>
+                                    </div>
+                                    <div>
+                                        <dt>@DesktopUploadSectionText.UploadReceiptPreUploadCheckDecisionLabel</dt>
+                                        <dd>@receiptPreview.PreUploadCheckDecisionPreview</dd>
+                                    </div>
+                                    <div>
+                                        <dt>@DesktopUploadSectionText.UploadReceiptExternalVideoIdLabel</dt>
+                                        <dd>@receiptPreview.ExternalVideoId</dd>
+                                    </div>
+                                    <div>
+                                        <dt>@DesktopUploadSectionText.UploadReceiptSiteStorageKeyLabel</dt>
+                                        <dd>@receiptPreview.SiteStorageKey</dd>
+                                    </div>
+                                    <div>
+                                        <dt>@DesktopUploadSectionText.UploadReceiptSiteUploadStatusLabel</dt>
+                                        <dd>@receiptPreview.SiteUploadStatusPreview</dd>
+                                    </div>
+                                    <div>
+                                        <dt>@DesktopUploadSectionText.UploadReceiptCapturedAtUtcLabel</dt>
+                                        <dd>@receiptPreview.CapturedAtUtc</dd>
+                                    </div>
+                                </dl>
+                            }
+
+                            <button
+                                class="desktop-upload__receipt"
+                                type="button"
+                                disabled="@(SignInViewModel.IsBusy || !UploadSectionViewModel.CanCreateUploadReceipt)"
+                                @onclick="CreateUploadReceiptAsync">
+                                @(UploadSectionViewModel.IsCreatingUploadReceipt
+                                    ? DesktopUploadSectionText.UploadReceiptBusyButton
+                                    : DesktopUploadSectionText.UploadReceiptButton)
+                            </button>
+
+                            @if (UploadSectionViewModel.HasUploadReceiptResult)
+                            {
+                                <dl class="desktop-upload__receipt-result">
+                                    <div>
+                                        <dt>@DesktopUploadSectionText.UploadReceiptResultStatusLabel</dt>
+                                        <dd>@UploadSectionViewModel.UploadReceiptStatusPreview</dd>
+                                    </div>
+                                    <div>
+                                        <dt>@DesktopUploadSectionText.UploadReceiptResultReceiptIdLabel</dt>
+                                        <dd>@UploadSectionViewModel.UploadReceiptId</dd>
+                                    </div>
+                                    <div>
+                                        <dt>@DesktopUploadSectionText.UploadReceiptResultServerCorrelationIdLabel</dt>
+                                        <dd>@UploadSectionViewModel.UploadReceiptServerCorrelationId</dd>
+                                    </div>
+                                </dl>
+                            }
+
                             <p class="desktop-upload__deferred">
                                 @DesktopUploadSectionText.NextStepDeferredMessage
                             </p>
@@ -484,6 +570,17 @@
         StateHasChanged();
 
         await uploadAttempt;
+
+        StateHasChanged();
+    }
+
+    private async Task CreateUploadReceiptAsync()
+    {
+        ValueTask<DesktopUploadReceiptResult?> receiptAttempt =
+            UploadSectionViewModel.CreateUploadReceiptAsync(CancellationToken.None);
+        StateHasChanged();
+
+        await receiptAttempt;
 
         StateHasChanged();
     }

--- a/src/App.Desktop/Composition/DesktopCompositionRoot.cs
+++ b/src/App.Desktop/Composition/DesktopCompositionRoot.cs
@@ -108,6 +108,15 @@ public static class DesktopCompositionRoot
             services.AddSingleton<IDesktopDirectSiteUploadClient, DisabledDesktopDirectSiteUploadClient>();
         }
 
+        if (uploadSectionOptions.IsDevFakeUploadReceiptEnabled)
+        {
+            services.AddSingleton<IDesktopUploadReceiptClient, FakeDesktopUploadReceiptClient>();
+        }
+        else
+        {
+            services.AddSingleton<IDesktopUploadReceiptClient, DisabledDesktopUploadReceiptClient>();
+        }
+
         services.AddSingleton<IDesktopFilePicker, PlaceholderDesktopFilePicker>();
         services.AddSingleton<ILocalFileMetadataService, PlaceholderLocalFileMetadataService>();
         services.AddSingleton<IControlPlaneApiClient, PlaceholderControlPlaneApiClient>();

--- a/src/App.Desktop/Services/Upload/DesktopUploadReceipt.cs
+++ b/src/App.Desktop/Services/Upload/DesktopUploadReceipt.cs
@@ -1,0 +1,201 @@
+using System.IO;
+
+using App.Desktop.Boundaries;
+
+namespace App.Desktop.Services.Upload;
+
+public sealed class DesktopUploadReceiptRequestPreview
+{
+    private DesktopUploadReceiptRequestPreview(
+        string fileName,
+        long sizeBytes,
+        string contentType,
+        string sha256Hex,
+        string businessObjectKeyPreview,
+        string preUploadCheckDecisionPreview,
+        string externalVideoId,
+        string siteStorageKey,
+        string siteUploadStatusPreview,
+        string capturedAtUtc)
+    {
+        FileName = fileName;
+        SizeBytes = sizeBytes;
+        ContentType = contentType;
+        Sha256Hex = sha256Hex;
+        BusinessObjectKeyPreview = businessObjectKeyPreview;
+        PreUploadCheckDecisionPreview = preUploadCheckDecisionPreview;
+        ExternalVideoId = externalVideoId;
+        SiteStorageKey = siteStorageKey;
+        SiteUploadStatusPreview = siteUploadStatusPreview;
+        CapturedAtUtc = capturedAtUtc;
+    }
+
+    public string FileName { get; }
+
+    public long SizeBytes { get; }
+
+    public string ContentType { get; }
+
+    public string Sha256Hex { get; }
+
+    public string BusinessObjectKeyPreview { get; }
+
+    public string PreUploadCheckDecisionPreview { get; }
+
+    public string ExternalVideoId { get; }
+
+    public string SiteStorageKey { get; }
+
+    public string SiteUploadStatusPreview { get; }
+
+    public string CapturedAtUtc { get; }
+
+    public static DesktopUploadReceiptRequestPreview? TryCreate(
+        DesktopSiteUploadRequestPreview? siteUploadRequestPreview,
+        DesktopSiteUploadResult? siteUploadResult)
+    {
+        if (siteUploadRequestPreview is null
+            || siteUploadResult?.Status != DesktopSiteUploadStatus.Succeeded
+            || !TryCreateSafeReceiptValue(siteUploadResult.ExternalVideoId, allowSlash: false, out string externalVideoId)
+            || !TryCreateSafeReceiptValue(siteUploadResult.SiteStorageKey, allowSlash: true, out string siteStorageKey)
+            || !TryCreateSafeReceiptValue(siteUploadResult.StatusPreview, allowSlash: false, out string siteUploadStatusPreview))
+        {
+            return null;
+        }
+
+        return new DesktopUploadReceiptRequestPreview(
+            siteUploadRequestPreview.FileName,
+            siteUploadRequestPreview.SizeBytes,
+            siteUploadRequestPreview.ContentType,
+            siteUploadRequestPreview.Sha256Hex,
+            siteUploadRequestPreview.BusinessObjectKeyPreview,
+            siteUploadRequestPreview.PreUploadCheckDecisionPreview,
+            externalVideoId,
+            siteStorageKey,
+            siteUploadStatusPreview,
+            siteUploadRequestPreview.CapturedAtUtc);
+    }
+
+    public override string ToString()
+    {
+        return $"{nameof(DesktopUploadReceiptRequestPreview)} {{ FileName = {FileName}, "
+            + $"SizeBytes = {SizeBytes}, ContentType = {ContentType}, HasSha256 = {Sha256Hex.Length == 64}, "
+            + $"BusinessObjectKeyPreview = {BusinessObjectKeyPreview}, "
+            + $"PreUploadCheckDecisionPreview = {PreUploadCheckDecisionPreview}, "
+            + $"ExternalVideoId = {ExternalVideoId}, SiteStorageKey = {SiteStorageKey}, "
+            + $"SiteUploadStatusPreview = {SiteUploadStatusPreview}, CapturedAtUtc = {CapturedAtUtc} }}";
+    }
+
+    private static bool TryCreateSafeReceiptValue(string? value, bool allowSlash, out string safeValue)
+    {
+        safeValue = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        string trimmed = value.Trim();
+        if (trimmed.Length > 200)
+        {
+            return false;
+        }
+
+        string lower = trimmed.ToLowerInvariant();
+        string[] blockedFragments =
+        [
+            "authorization",
+            "bearer",
+            "password",
+            "token",
+            "sessionid",
+            "session_id",
+            "access_token",
+            "refreshtoken",
+            "refresh_token"
+        ];
+
+        foreach (string blockedFragment in blockedFragments)
+        {
+            if (lower.Contains(blockedFragment, StringComparison.Ordinal))
+            {
+                return false;
+            }
+        }
+
+        foreach (char character in trimmed)
+        {
+            if (char.IsControl(character)
+                || character == Path.DirectorySeparatorChar
+                || character == Path.VolumeSeparatorChar
+                || (!allowSlash && character == Path.AltDirectorySeparatorChar))
+            {
+                return false;
+            }
+        }
+
+        safeValue = trimmed;
+        return true;
+    }
+}
+
+public sealed class DesktopUploadReceiptResult
+{
+    private DesktopUploadReceiptResult(
+        DesktopUploadReceiptStatus status,
+        string message,
+        string? receiptId,
+        string? serverCorrelationId)
+    {
+        Status = status;
+        Message = message;
+        ReceiptId = receiptId;
+        ServerCorrelationId = serverCorrelationId;
+    }
+
+    public DesktopUploadReceiptStatus Status { get; }
+
+    public string? StatusPreview => Status switch
+    {
+        DesktopUploadReceiptStatus.Accepted => "ACCEPTED",
+        _ => null
+    };
+
+    public string Message { get; }
+
+    public string? ReceiptId { get; }
+
+    public string? ServerCorrelationId { get; }
+
+    public static DesktopUploadReceiptResult Deferred { get; } = new(
+        DesktopUploadReceiptStatus.Deferred,
+        DesktopUploadSectionText.UploadReceiptDeferredMessage,
+        receiptId: null,
+        serverCorrelationId: null);
+
+    public static DesktopUploadReceiptResult Canceled { get; } = new(
+        DesktopUploadReceiptStatus.Canceled,
+        DesktopUploadSectionText.UploadReceiptCanceledMessage,
+        receiptId: null,
+        serverCorrelationId: null);
+
+    public static DesktopUploadReceiptResult FakeAccepted { get; } = new(
+        DesktopUploadReceiptStatus.Accepted,
+        DesktopUploadSectionText.UploadReceiptAcceptedDevMessage,
+        receiptId: "visual-smoke-upload-receipt-001",
+        serverCorrelationId: "visual-smoke-correlation-001");
+
+    public override string ToString()
+    {
+        return $"{nameof(DesktopUploadReceiptResult)} {{ Status = {StatusPreview ?? Status.ToString()}, "
+            + $"HasReceiptId = {ReceiptId is not null}, HasServerCorrelationId = {ServerCorrelationId is not null}, "
+            + $"Message = {Message} }}";
+    }
+}
+
+public enum DesktopUploadReceiptStatus
+{
+    Deferred,
+    Accepted,
+    Canceled
+}

--- a/src/App.Desktop/Services/Upload/DesktopUploadSectionOptions.cs
+++ b/src/App.Desktop/Services/Upload/DesktopUploadSectionOptions.cs
@@ -17,18 +17,23 @@ public sealed class DesktopUploadSectionOptions
     public const string DevFakeSiteUploadEnabledEnvironmentVariable =
         "AA_DESKTOP_DEV_FAKE_SITE_UPLOAD_ENABLED";
 
+    public const string DevFakeUploadReceiptEnabledEnvironmentVariable =
+        "AA_DESKTOP_DEV_FAKE_UPLOAD_RECEIPT_ENABLED";
+
     private DesktopUploadSectionOptions(
         bool isDevFakeUploadFileEnabled,
         bool isDevFakeUploadHashEnabled,
         bool isDevFakeBusinessObjectKeyEnabled,
         bool isDevFakePreUploadCheckEnabled,
-        bool isDevFakeSiteUploadEnabled)
+        bool isDevFakeSiteUploadEnabled,
+        bool isDevFakeUploadReceiptEnabled)
     {
         IsDevFakeUploadFileEnabled = isDevFakeUploadFileEnabled;
         IsDevFakeUploadHashEnabled = isDevFakeUploadHashEnabled;
         IsDevFakeBusinessObjectKeyEnabled = isDevFakeBusinessObjectKeyEnabled;
         IsDevFakePreUploadCheckEnabled = isDevFakePreUploadCheckEnabled;
         IsDevFakeSiteUploadEnabled = isDevFakeSiteUploadEnabled;
+        IsDevFakeUploadReceiptEnabled = isDevFakeUploadReceiptEnabled;
     }
 
     public static DesktopUploadSectionOptions Disabled { get; } = new(
@@ -36,7 +41,8 @@ public sealed class DesktopUploadSectionOptions
         isDevFakeUploadHashEnabled: false,
         isDevFakeBusinessObjectKeyEnabled: false,
         isDevFakePreUploadCheckEnabled: false,
-        isDevFakeSiteUploadEnabled: false);
+        isDevFakeSiteUploadEnabled: false,
+        isDevFakeUploadReceiptEnabled: false);
 
 #if DEBUG
     public static DesktopUploadSectionOptions EnabledForDevFakeFileSelection { get; } = new(
@@ -44,35 +50,48 @@ public sealed class DesktopUploadSectionOptions
         isDevFakeUploadHashEnabled: false,
         isDevFakeBusinessObjectKeyEnabled: false,
         isDevFakePreUploadCheckEnabled: false,
-        isDevFakeSiteUploadEnabled: false);
+        isDevFakeSiteUploadEnabled: false,
+        isDevFakeUploadReceiptEnabled: false);
 
     public static DesktopUploadSectionOptions EnabledForDevFakeFileSelectionAndHash { get; } = new(
         isDevFakeUploadFileEnabled: true,
         isDevFakeUploadHashEnabled: true,
         isDevFakeBusinessObjectKeyEnabled: false,
         isDevFakePreUploadCheckEnabled: false,
-        isDevFakeSiteUploadEnabled: false);
+        isDevFakeSiteUploadEnabled: false,
+        isDevFakeUploadReceiptEnabled: false);
 
     public static DesktopUploadSectionOptions EnabledForDevFakeBusinessObjectKey { get; } = new(
         isDevFakeUploadFileEnabled: false,
         isDevFakeUploadHashEnabled: false,
         isDevFakeBusinessObjectKeyEnabled: true,
         isDevFakePreUploadCheckEnabled: false,
-        isDevFakeSiteUploadEnabled: false);
+        isDevFakeSiteUploadEnabled: false,
+        isDevFakeUploadReceiptEnabled: false);
 
     public static DesktopUploadSectionOptions EnabledForDevFakePreUploadCheck { get; } = new(
         isDevFakeUploadFileEnabled: false,
         isDevFakeUploadHashEnabled: false,
         isDevFakeBusinessObjectKeyEnabled: false,
         isDevFakePreUploadCheckEnabled: true,
-        isDevFakeSiteUploadEnabled: false);
+        isDevFakeSiteUploadEnabled: false,
+        isDevFakeUploadReceiptEnabled: false);
 
     public static DesktopUploadSectionOptions EnabledForDevFakeSiteUpload { get; } = new(
         isDevFakeUploadFileEnabled: false,
         isDevFakeUploadHashEnabled: false,
         isDevFakeBusinessObjectKeyEnabled: false,
         isDevFakePreUploadCheckEnabled: false,
-        isDevFakeSiteUploadEnabled: true);
+        isDevFakeSiteUploadEnabled: true,
+        isDevFakeUploadReceiptEnabled: false);
+
+    public static DesktopUploadSectionOptions EnabledForDevFakeUploadReceipt { get; } = new(
+        isDevFakeUploadFileEnabled: false,
+        isDevFakeUploadHashEnabled: false,
+        isDevFakeBusinessObjectKeyEnabled: false,
+        isDevFakePreUploadCheckEnabled: false,
+        isDevFakeSiteUploadEnabled: false,
+        isDevFakeUploadReceiptEnabled: true);
 #else
     public static DesktopUploadSectionOptions EnabledForDevFakeFileSelection => Disabled;
 
@@ -83,6 +102,8 @@ public sealed class DesktopUploadSectionOptions
     public static DesktopUploadSectionOptions EnabledForDevFakePreUploadCheck => Disabled;
 
     public static DesktopUploadSectionOptions EnabledForDevFakeSiteUpload => Disabled;
+
+    public static DesktopUploadSectionOptions EnabledForDevFakeUploadReceipt => Disabled;
 #endif
 
     public bool IsDevFakeUploadFileEnabled { get; }
@@ -95,6 +116,8 @@ public sealed class DesktopUploadSectionOptions
 
     public bool IsDevFakeSiteUploadEnabled { get; }
 
+    public bool IsDevFakeUploadReceiptEnabled { get; }
+
     public static DesktopUploadSectionOptions FromEnvironment()
     {
         return FromEnvironmentValue(
@@ -102,7 +125,8 @@ public sealed class DesktopUploadSectionOptions
             Environment.GetEnvironmentVariable(DevFakeUploadHashEnabledEnvironmentVariable),
             Environment.GetEnvironmentVariable(DevFakeBusinessObjectKeyEnabledEnvironmentVariable),
             Environment.GetEnvironmentVariable(DevFakePreUploadCheckEnabledEnvironmentVariable),
-            Environment.GetEnvironmentVariable(DevFakeSiteUploadEnabledEnvironmentVariable));
+            Environment.GetEnvironmentVariable(DevFakeSiteUploadEnabledEnvironmentVariable),
+            Environment.GetEnvironmentVariable(DevFakeUploadReceiptEnabledEnvironmentVariable));
     }
 
     public static DesktopUploadSectionOptions FromEnvironmentValue(string? devFakeUploadFileEnabled)
@@ -155,6 +179,23 @@ public sealed class DesktopUploadSectionOptions
         string? devFakePreUploadCheckEnabled,
         string? devFakeSiteUploadEnabled)
     {
+        return FromEnvironmentValue(
+            devFakeUploadFileEnabled,
+            devFakeUploadHashEnabled,
+            devFakeBusinessObjectKeyEnabled,
+            devFakePreUploadCheckEnabled,
+            devFakeSiteUploadEnabled,
+            devFakeUploadReceiptEnabled: null);
+    }
+
+    public static DesktopUploadSectionOptions FromEnvironmentValue(
+        string? devFakeUploadFileEnabled,
+        string? devFakeUploadHashEnabled,
+        string? devFakeBusinessObjectKeyEnabled,
+        string? devFakePreUploadCheckEnabled,
+        string? devFakeSiteUploadEnabled,
+        string? devFakeUploadReceiptEnabled)
+    {
 #if DEBUG
         bool isFakeFileEnabled = IsDevFakeUploadFileEnabledValue(devFakeUploadFileEnabled);
         bool isFakeHashEnabled = IsDevFakeUploadHashEnabledValue(devFakeUploadHashEnabled);
@@ -162,13 +203,15 @@ public sealed class DesktopUploadSectionOptions
             IsDevFakeBusinessObjectKeyEnabledValue(devFakeBusinessObjectKeyEnabled);
         bool isFakePreUploadCheckEnabled = IsDevFakePreUploadCheckEnabledValue(devFakePreUploadCheckEnabled);
         bool isFakeSiteUploadEnabled = IsDevFakeSiteUploadEnabledValue(devFakeSiteUploadEnabled);
+        bool isFakeUploadReceiptEnabled = IsDevFakeUploadReceiptEnabledValue(devFakeUploadReceiptEnabled);
 
         return new DesktopUploadSectionOptions(
             isFakeFileEnabled,
             isFakeHashEnabled,
             isFakeBusinessObjectKeyEnabled,
             isFakePreUploadCheckEnabled,
-            isFakeSiteUploadEnabled);
+            isFakeSiteUploadEnabled,
+            isFakeUploadReceiptEnabled);
 #else
         return Disabled;
 #endif
@@ -180,7 +223,8 @@ public sealed class DesktopUploadSectionOptions
             + $"IsDevFakeUploadHashEnabled = {IsDevFakeUploadHashEnabled}, "
             + $"IsDevFakeBusinessObjectKeyEnabled = {IsDevFakeBusinessObjectKeyEnabled}, "
             + $"IsDevFakePreUploadCheckEnabled = {IsDevFakePreUploadCheckEnabled}, "
-            + $"IsDevFakeSiteUploadEnabled = {IsDevFakeSiteUploadEnabled} }}";
+            + $"IsDevFakeSiteUploadEnabled = {IsDevFakeSiteUploadEnabled}, "
+            + $"IsDevFakeUploadReceiptEnabled = {IsDevFakeUploadReceiptEnabled} }}";
     }
 
     private static bool IsDevFakeUploadFileEnabledValue(string? value)
@@ -204,6 +248,11 @@ public sealed class DesktopUploadSectionOptions
     }
 
     private static bool IsDevFakeSiteUploadEnabledValue(string? value)
+    {
+        return string.Equals(value?.Trim(), "true", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsDevFakeUploadReceiptEnabledValue(string? value)
     {
         return string.Equals(value?.Trim(), "true", StringComparison.OrdinalIgnoreCase);
     }

--- a/src/App.Desktop/Services/Upload/DesktopUploadSectionViewModel.cs
+++ b/src/App.Desktop/Services/Upload/DesktopUploadSectionViewModel.cs
@@ -7,6 +7,7 @@ public sealed class DesktopUploadSectionViewModel(
     IDesktopVideoHashService videoHashService,
     IDesktopPreUploadCheckClient preUploadCheckClient,
     IDesktopDirectSiteUploadClient directSiteUploadClient,
+    IDesktopUploadReceiptClient uploadReceiptClient,
     DesktopUploadSectionOptions uploadSectionOptions)
 {
     public DesktopUploadSectionViewModel(
@@ -17,6 +18,7 @@ public sealed class DesktopUploadSectionViewModel(
             videoHashService,
             new DisabledDesktopPreUploadCheckClient(),
             new DisabledDesktopDirectSiteUploadClient(),
+            new DisabledDesktopUploadReceiptClient(),
             DesktopUploadSectionOptions.Disabled)
     {
     }
@@ -30,6 +32,23 @@ public sealed class DesktopUploadSectionViewModel(
             videoHashService,
             new DisabledDesktopPreUploadCheckClient(),
             new DisabledDesktopDirectSiteUploadClient(),
+            new DisabledDesktopUploadReceiptClient(),
+            uploadSectionOptions)
+    {
+    }
+
+    public DesktopUploadSectionViewModel(
+        IDesktopVideoFilePicker videoFilePicker,
+        IDesktopVideoHashService videoHashService,
+        IDesktopPreUploadCheckClient preUploadCheckClient,
+        IDesktopDirectSiteUploadClient directSiteUploadClient,
+        DesktopUploadSectionOptions uploadSectionOptions)
+        : this(
+            videoFilePicker,
+            videoHashService,
+            preUploadCheckClient,
+            directSiteUploadClient,
+            new DisabledDesktopUploadReceiptClient(),
             uploadSectionOptions)
     {
     }
@@ -42,6 +61,8 @@ public sealed class DesktopUploadSectionViewModel(
         preUploadCheckClient ?? throw new ArgumentNullException(nameof(preUploadCheckClient));
     private readonly IDesktopDirectSiteUploadClient _directSiteUploadClient =
         directSiteUploadClient ?? throw new ArgumentNullException(nameof(directSiteUploadClient));
+    private readonly IDesktopUploadReceiptClient _uploadReceiptClient =
+        uploadReceiptClient ?? throw new ArgumentNullException(nameof(uploadReceiptClient));
     private readonly DesktopUploadSectionOptions _uploadSectionOptions =
         uploadSectionOptions ?? throw new ArgumentNullException(nameof(uploadSectionOptions));
 
@@ -58,6 +79,8 @@ public sealed class DesktopUploadSectionViewModel(
     public bool IsCheckingPreUpload { get; private set; }
 
     public bool IsUploadingToSite { get; private set; }
+
+    public bool IsCreatingUploadReceipt { get; private set; }
 
     public bool CanCalculateHash => SelectedFile is not null && !IsSelectingFile && !IsHashing;
 
@@ -81,6 +104,9 @@ public sealed class DesktopUploadSectionViewModel(
 
     public bool IsDevFakeSiteUploadEnabled =>
         _uploadSectionOptions.IsDevFakeSiteUploadEnabled;
+
+    public bool IsDevFakeUploadReceiptEnabled =>
+        _uploadSectionOptions.IsDevFakeUploadReceiptEnabled;
 
     public string BusinessObjectKeyInput { get; set; } = string.Empty;
 
@@ -135,6 +161,32 @@ public sealed class DesktopUploadSectionViewModel(
     public string SiteUploadStatusMessage { get; private set; } =
         DesktopUploadSectionText.SiteUploadNotReadyMessage;
 
+    public DesktopUploadReceiptRequestPreview? UploadReceiptRequestPreview =>
+        DesktopUploadReceiptRequestPreview.TryCreate(SiteUploadRequestPreview, SiteUploadResult);
+
+    public bool HasUploadReceiptRequestPreview => UploadReceiptRequestPreview is not null;
+
+    public bool CanCreateUploadReceipt =>
+        HasUploadReceiptRequestPreview
+        && !IsSelectingFile
+        && !IsHashing
+        && !IsCheckingPreUpload
+        && !IsUploadingToSite
+        && !IsCreatingUploadReceipt;
+
+    public DesktopUploadReceiptResult? UploadReceiptResult { get; private set; }
+
+    public bool HasUploadReceiptResult => UploadReceiptResult?.Status == DesktopUploadReceiptStatus.Accepted;
+
+    public string? UploadReceiptStatusPreview => UploadReceiptResult?.StatusPreview;
+
+    public string? UploadReceiptId => UploadReceiptResult?.ReceiptId;
+
+    public string? UploadReceiptServerCorrelationId => UploadReceiptResult?.ServerCorrelationId;
+
+    public string UploadReceiptStatusMessage { get; private set; } =
+        DesktopUploadSectionText.UploadReceiptNotReadyMessage;
+
     public void OpenUploadSection()
     {
         CurrentSection = DesktopWorkspaceSection.Upload;
@@ -165,6 +217,7 @@ public sealed class DesktopUploadSectionViewModel(
         ResetBusinessObjectKeyState();
         ResetPreUploadCheckState();
         ResetSiteUploadState();
+        ResetUploadReceiptState();
 
         try
         {
@@ -207,6 +260,7 @@ public sealed class DesktopUploadSectionViewModel(
         HashStatusMessage = DesktopUploadSectionText.HashInProgressMessage;
         ResetPreUploadCheckState();
         ResetSiteUploadState();
+        ResetUploadReceiptState();
 
         try
         {
@@ -258,6 +312,7 @@ public sealed class DesktopUploadSectionViewModel(
         BusinessObjectKeyStatusMessage = validation.Message;
         ResetPreUploadCheckDecision();
         ResetSiteUploadState();
+        ResetUploadReceiptState();
         RefreshPreUploadCheckReadiness();
 
         return validation;
@@ -340,28 +395,75 @@ public sealed class DesktopUploadSectionViewModel(
         {
             SiteUploadResult = DesktopSiteUploadResult.Deferred;
             SiteUploadStatusMessage = DesktopUploadSectionText.SiteUploadDeferredMessage;
+            RefreshUploadReceiptReadiness();
             return SiteUploadResult;
         }
 
         IsUploadingToSite = true;
         SiteUploadResult = null;
         SiteUploadStatusMessage = DesktopUploadSectionText.SiteUploadInProgressMessage;
+        ResetUploadReceiptState();
 
         try
         {
             SiteUploadResult = await _directSiteUploadClient.UploadAsync(requestPreview, cancellationToken);
             SiteUploadStatusMessage = SiteUploadResult.Message;
+            RefreshUploadReceiptReadiness();
             return SiteUploadResult;
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             SiteUploadResult = DesktopSiteUploadResult.Canceled;
             SiteUploadStatusMessage = DesktopUploadSectionText.SiteUploadCanceledMessage;
+            RefreshUploadReceiptReadiness();
             return SiteUploadResult;
         }
         finally
         {
             IsUploadingToSite = false;
+        }
+    }
+
+    public async ValueTask<DesktopUploadReceiptResult?> CreateUploadReceiptAsync(CancellationToken cancellationToken)
+    {
+        if (IsCreatingUploadReceipt)
+        {
+            return UploadReceiptResult;
+        }
+
+        DesktopUploadReceiptRequestPreview? requestPreview = UploadReceiptRequestPreview;
+        if (requestPreview is null)
+        {
+            UploadReceiptStatusMessage = DesktopUploadSectionText.UploadReceiptNotReadyMessage;
+            return null;
+        }
+
+        if (!IsDevFakeUploadReceiptEnabled)
+        {
+            UploadReceiptResult = DesktopUploadReceiptResult.Deferred;
+            UploadReceiptStatusMessage = DesktopUploadSectionText.UploadReceiptDeferredMessage;
+            return UploadReceiptResult;
+        }
+
+        IsCreatingUploadReceipt = true;
+        UploadReceiptResult = null;
+        UploadReceiptStatusMessage = DesktopUploadSectionText.UploadReceiptInProgressMessage;
+
+        try
+        {
+            UploadReceiptResult = await _uploadReceiptClient.CreateAsync(requestPreview, cancellationToken);
+            UploadReceiptStatusMessage = UploadReceiptResult.Message;
+            return UploadReceiptResult;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            UploadReceiptResult = DesktopUploadReceiptResult.Canceled;
+            UploadReceiptStatusMessage = DesktopUploadSectionText.UploadReceiptCanceledMessage;
+            return UploadReceiptResult;
+        }
+        finally
+        {
+            IsCreatingUploadReceipt = false;
         }
     }
 
@@ -390,6 +492,7 @@ public sealed class DesktopUploadSectionViewModel(
         BusinessObjectKeyStatusMessage = DesktopUploadSectionText.BusinessObjectKeyEmptyValidationMessage;
         ResetPreUploadCheckState();
         ResetSiteUploadState();
+        ResetUploadReceiptState();
     }
 
     private void ResetPreUploadCheckState()
@@ -398,6 +501,7 @@ public sealed class DesktopUploadSectionViewModel(
         PreUploadCheckResult = null;
         PreUploadCheckStatusMessage = DesktopUploadSectionText.PreUploadCheckNotReadyMessage;
         ResetSiteUploadState();
+        ResetUploadReceiptState();
     }
 
     private void ResetPreUploadCheckDecision()
@@ -405,6 +509,7 @@ public sealed class DesktopUploadSectionViewModel(
         IsCheckingPreUpload = false;
         PreUploadCheckResult = null;
         ResetSiteUploadState();
+        ResetUploadReceiptState();
     }
 
     private void RefreshPreUploadCheckReadiness()
@@ -424,6 +529,7 @@ public sealed class DesktopUploadSectionViewModel(
         IsUploadingToSite = false;
         SiteUploadResult = null;
         SiteUploadStatusMessage = DesktopUploadSectionText.SiteUploadNotReadyMessage;
+        ResetUploadReceiptState();
     }
 
     private void RefreshSiteUploadReadiness()
@@ -436,6 +542,26 @@ public sealed class DesktopUploadSectionViewModel(
         SiteUploadStatusMessage = SiteUploadRequestPreview is not null
             ? DesktopUploadSectionText.SiteUploadReadyMessage
             : GetSiteUploadNotReadyMessage();
+        RefreshUploadReceiptReadiness();
+    }
+
+    private void ResetUploadReceiptState()
+    {
+        IsCreatingUploadReceipt = false;
+        UploadReceiptResult = null;
+        UploadReceiptStatusMessage = DesktopUploadSectionText.UploadReceiptNotReadyMessage;
+    }
+
+    private void RefreshUploadReceiptReadiness()
+    {
+        if (IsCreatingUploadReceipt)
+        {
+            return;
+        }
+
+        UploadReceiptStatusMessage = UploadReceiptRequestPreview is not null
+            ? DesktopUploadSectionText.UploadReceiptReadyMessage
+            : DesktopUploadSectionText.UploadReceiptNotReadyMessage;
     }
 
     private string GetSiteUploadNotReadyMessage()

--- a/src/App.Desktop/Services/Upload/DisabledDesktopUploadReceiptClient.cs
+++ b/src/App.Desktop/Services/Upload/DisabledDesktopUploadReceiptClient.cs
@@ -1,0 +1,16 @@
+using App.Desktop.Boundaries;
+
+namespace App.Desktop.Services.Upload;
+
+public sealed class DisabledDesktopUploadReceiptClient : IDesktopUploadReceiptClient
+{
+    public ValueTask<DesktopUploadReceiptResult> CreateAsync(
+        DesktopUploadReceiptRequestPreview requestPreview,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(requestPreview);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return ValueTask.FromResult(DesktopUploadReceiptResult.Deferred);
+    }
+}

--- a/src/App.Desktop/Services/Upload/FakeDesktopUploadReceiptClient.cs
+++ b/src/App.Desktop/Services/Upload/FakeDesktopUploadReceiptClient.cs
@@ -1,0 +1,16 @@
+using App.Desktop.Boundaries;
+
+namespace App.Desktop.Services.Upload;
+
+public sealed class FakeDesktopUploadReceiptClient : IDesktopUploadReceiptClient
+{
+    public ValueTask<DesktopUploadReceiptResult> CreateAsync(
+        DesktopUploadReceiptRequestPreview requestPreview,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(requestPreview);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return ValueTask.FromResult(DesktopUploadReceiptResult.FakeAccepted);
+    }
+}

--- a/src/App.Desktop/wwwroot/app.css
+++ b/src/App.Desktop/wwwroot/app.css
@@ -283,7 +283,8 @@ body {
 .desktop-upload__hash,
 .desktop-upload__key,
 .desktop-upload__preupload,
-.desktop-upload__site-upload {
+.desktop-upload__site-upload,
+.desktop-upload__receipt {
     min-height: 38px;
     padding: 0 16px;
     border-radius: 6px;
@@ -303,7 +304,8 @@ body {
 .desktop-upload__hash,
 .desktop-upload__key,
 .desktop-upload__preupload,
-.desktop-upload__site-upload {
+.desktop-upload__site-upload,
+.desktop-upload__receipt {
     width: fit-content;
     border: 1px solid #18406b;
     background: #18406b;
@@ -315,7 +317,8 @@ body {
 .desktop-upload__hash:disabled,
 .desktop-upload__key:disabled,
 .desktop-upload__preupload:disabled,
-.desktop-upload__site-upload:disabled {
+.desktop-upload__site-upload:disabled,
+.desktop-upload__receipt:disabled {
     color: #687789;
     border-color: #b9c3cf;
     background: #eef1f5;
@@ -391,7 +394,9 @@ body {
 .desktop-upload__preupload-preview,
 .desktop-upload__preupload-decision,
 .desktop-upload__site-upload-preview,
-.desktop-upload__site-upload-result {
+.desktop-upload__site-upload-result,
+.desktop-upload__receipt-preview,
+.desktop-upload__receipt-result {
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 12px;
@@ -414,11 +419,19 @@ body {
     grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
+.desktop-upload__receipt-preview {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
 .desktop-upload__preupload-decision {
     grid-template-columns: minmax(0, 1fr);
 }
 
 .desktop-upload__site-upload-result {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.desktop-upload__receipt-result {
     grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
@@ -428,7 +441,9 @@ body {
 .desktop-upload__preupload-preview div,
 .desktop-upload__preupload-decision div,
 .desktop-upload__site-upload-preview div,
-.desktop-upload__site-upload-result div {
+.desktop-upload__site-upload-result div,
+.desktop-upload__receipt-preview div,
+.desktop-upload__receipt-result div {
     min-width: 0;
     padding: 12px;
     border: 1px solid #d7dde5;
@@ -442,7 +457,9 @@ body {
 .desktop-upload__preupload-preview dt,
 .desktop-upload__preupload-decision dt,
 .desktop-upload__site-upload-preview dt,
-.desktop-upload__site-upload-result dt {
+.desktop-upload__site-upload-result dt,
+.desktop-upload__receipt-preview dt,
+.desktop-upload__receipt-result dt {
     margin: 0 0 4px;
     color: #52616f;
     font-size: 0.78rem;
@@ -455,7 +472,9 @@ body {
 .desktop-upload__preupload-preview dd,
 .desktop-upload__preupload-decision dd,
 .desktop-upload__site-upload-preview dd,
-.desktop-upload__site-upload-result dd {
+.desktop-upload__site-upload-result dd,
+.desktop-upload__receipt-preview dd,
+.desktop-upload__receipt-result dd {
     margin: 0;
     color: #18212f;
     font-size: 0.9rem;
@@ -488,7 +507,8 @@ body {
     .desktop-upload__hash,
     .desktop-upload__key,
     .desktop-upload__preupload,
-    .desktop-upload__site-upload {
+    .desktop-upload__site-upload,
+    .desktop-upload__receipt {
         width: 100%;
     }
 
@@ -498,7 +518,9 @@ body {
     .desktop-upload__preupload-preview,
     .desktop-upload__preupload-decision,
     .desktop-upload__site-upload-preview,
-    .desktop-upload__site-upload-result {
+    .desktop-upload__site-upload-result,
+    .desktop-upload__receipt-preview,
+    .desktop-upload__receipt-result {
         grid-template-columns: 1fr;
     }
 

--- a/tests/Unit/App.Desktop.Tests/DesktopCompositionRootTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopCompositionRootTests.cs
@@ -25,12 +25,15 @@ public sealed class DesktopCompositionRootTests
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeSiteUploadEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadReceiptEnabled);
         Assert.IsType<WpfDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
         Assert.IsType<DesktopVideoHashService>(services.GetRequiredService<IDesktopVideoHashService>());
         Assert.IsType<DisabledDesktopPreUploadCheckClient>(
             services.GetRequiredService<IDesktopPreUploadCheckClient>());
         Assert.IsType<DisabledDesktopDirectSiteUploadClient>(
             services.GetRequiredService<IDesktopDirectSiteUploadClient>());
+        Assert.IsType<DisabledDesktopUploadReceiptClient>(
+            services.GetRequiredService<IDesktopUploadReceiptClient>());
     }
 
     [Fact]
@@ -43,7 +46,8 @@ public sealed class DesktopCompositionRootTests
             .Set(DesktopUploadSectionOptions.DevFakeUploadHashEnabledEnvironmentVariable, null)
             .Set(DesktopUploadSectionOptions.DevFakeBusinessObjectKeyEnabledEnvironmentVariable, null)
             .Set(DesktopUploadSectionOptions.DevFakePreUploadCheckEnabledEnvironmentVariable, null)
-            .Set(DesktopUploadSectionOptions.DevFakeSiteUploadEnabledEnvironmentVariable, null);
+            .Set(DesktopUploadSectionOptions.DevFakeSiteUploadEnabledEnvironmentVariable, null)
+            .Set(DesktopUploadSectionOptions.DevFakeUploadReceiptEnabledEnvironmentVariable, null);
 
         using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
 
@@ -53,6 +57,7 @@ public sealed class DesktopCompositionRootTests
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeSiteUploadEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadReceiptEnabled);
         Assert.IsType<UnavailableDesktopAuthClient>(services.GetRequiredService<IDesktopAuthClient>());
         Assert.IsType<WpfDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
         Assert.IsType<DesktopVideoHashService>(services.GetRequiredService<IDesktopVideoHashService>());
@@ -60,6 +65,8 @@ public sealed class DesktopCompositionRootTests
             services.GetRequiredService<IDesktopPreUploadCheckClient>());
         Assert.IsType<DisabledDesktopDirectSiteUploadClient>(
             services.GetRequiredService<IDesktopDirectSiteUploadClient>());
+        Assert.IsType<DisabledDesktopUploadReceiptClient>(
+            services.GetRequiredService<IDesktopUploadReceiptClient>());
     }
 
     [Fact]
@@ -72,7 +79,8 @@ public sealed class DesktopCompositionRootTests
             .Set(DesktopUploadSectionOptions.DevFakeUploadHashEnabledEnvironmentVariable, null)
             .Set(DesktopUploadSectionOptions.DevFakeBusinessObjectKeyEnabledEnvironmentVariable, null)
             .Set(DesktopUploadSectionOptions.DevFakePreUploadCheckEnabledEnvironmentVariable, null)
-            .Set(DesktopUploadSectionOptions.DevFakeSiteUploadEnabledEnvironmentVariable, null);
+            .Set(DesktopUploadSectionOptions.DevFakeSiteUploadEnabledEnvironmentVariable, null)
+            .Set(DesktopUploadSectionOptions.DevFakeUploadReceiptEnabledEnvironmentVariable, null);
 
         using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
 
@@ -113,7 +121,8 @@ public sealed class DesktopCompositionRootTests
             .Set(DesktopUploadSectionOptions.DevFakeUploadHashEnabledEnvironmentVariable, "true")
             .Set(DesktopUploadSectionOptions.DevFakeBusinessObjectKeyEnabledEnvironmentVariable, null)
             .Set(DesktopUploadSectionOptions.DevFakePreUploadCheckEnabledEnvironmentVariable, null)
-            .Set(DesktopUploadSectionOptions.DevFakeSiteUploadEnabledEnvironmentVariable, null);
+            .Set(DesktopUploadSectionOptions.DevFakeSiteUploadEnabledEnvironmentVariable, null)
+            .Set(DesktopUploadSectionOptions.DevFakeUploadReceiptEnabledEnvironmentVariable, null);
 
         using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
 
@@ -154,7 +163,8 @@ public sealed class DesktopCompositionRootTests
             .Set(DesktopUploadSectionOptions.DevFakeUploadHashEnabledEnvironmentVariable, "true")
             .Set(DesktopUploadSectionOptions.DevFakeBusinessObjectKeyEnabledEnvironmentVariable, null)
             .Set(DesktopUploadSectionOptions.DevFakePreUploadCheckEnabledEnvironmentVariable, null)
-            .Set(DesktopUploadSectionOptions.DevFakeSiteUploadEnabledEnvironmentVariable, null);
+            .Set(DesktopUploadSectionOptions.DevFakeSiteUploadEnabledEnvironmentVariable, null)
+            .Set(DesktopUploadSectionOptions.DevFakeUploadReceiptEnabledEnvironmentVariable, null);
 
         using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
 
@@ -195,7 +205,8 @@ public sealed class DesktopCompositionRootTests
             .Set(DesktopUploadSectionOptions.DevFakeUploadHashEnabledEnvironmentVariable, null)
             .Set(DesktopUploadSectionOptions.DevFakeBusinessObjectKeyEnabledEnvironmentVariable, "true")
             .Set(DesktopUploadSectionOptions.DevFakePreUploadCheckEnabledEnvironmentVariable, null)
-            .Set(DesktopUploadSectionOptions.DevFakeSiteUploadEnabledEnvironmentVariable, null);
+            .Set(DesktopUploadSectionOptions.DevFakeSiteUploadEnabledEnvironmentVariable, null)
+            .Set(DesktopUploadSectionOptions.DevFakeUploadReceiptEnabledEnvironmentVariable, null);
 
         using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
 
@@ -238,7 +249,8 @@ public sealed class DesktopCompositionRootTests
             .Set(DesktopUploadSectionOptions.DevFakeUploadHashEnabledEnvironmentVariable, null)
             .Set(DesktopUploadSectionOptions.DevFakeBusinessObjectKeyEnabledEnvironmentVariable, null)
             .Set(DesktopUploadSectionOptions.DevFakePreUploadCheckEnabledEnvironmentVariable, "true")
-            .Set(DesktopUploadSectionOptions.DevFakeSiteUploadEnabledEnvironmentVariable, null);
+            .Set(DesktopUploadSectionOptions.DevFakeSiteUploadEnabledEnvironmentVariable, null)
+            .Set(DesktopUploadSectionOptions.DevFakeUploadReceiptEnabledEnvironmentVariable, null);
 
         using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
 
@@ -279,7 +291,8 @@ public sealed class DesktopCompositionRootTests
             .Set(DesktopUploadSectionOptions.DevFakeUploadHashEnabledEnvironmentVariable, null)
             .Set(DesktopUploadSectionOptions.DevFakeBusinessObjectKeyEnabledEnvironmentVariable, null)
             .Set(DesktopUploadSectionOptions.DevFakePreUploadCheckEnabledEnvironmentVariable, null)
-            .Set(DesktopUploadSectionOptions.DevFakeSiteUploadEnabledEnvironmentVariable, "true");
+            .Set(DesktopUploadSectionOptions.DevFakeSiteUploadEnabledEnvironmentVariable, "true")
+            .Set(DesktopUploadSectionOptions.DevFakeUploadReceiptEnabledEnvironmentVariable, null);
 
         using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
 
@@ -310,7 +323,54 @@ public sealed class DesktopCompositionRootTests
     }
 
     [Fact]
-    public void EnvironmentOptionsEnableFakeUploadFileHashBusinessObjectKeyPreUploadCheckAndSiteUploadTogetherForVisualSmoke()
+    public void EnvironmentOptionsEnableFakeUploadReceiptOnlyWhenExplicitlyRequested()
+    {
+        using var environment = new EnvironmentVariableScope()
+            .Set(DesktopAuthOptions.ControlPlaneBaseAddressEnvironmentVariable, null)
+            .Set(DesktopAuthOptions.DevFakeAuthEnabledEnvironmentVariable, null)
+            .Set(DesktopUploadSectionOptions.DevFakeUploadFileEnabledEnvironmentVariable, null)
+            .Set(DesktopUploadSectionOptions.DevFakeUploadHashEnabledEnvironmentVariable, null)
+            .Set(DesktopUploadSectionOptions.DevFakeBusinessObjectKeyEnabledEnvironmentVariable, null)
+            .Set(DesktopUploadSectionOptions.DevFakePreUploadCheckEnabledEnvironmentVariable, null)
+            .Set(DesktopUploadSectionOptions.DevFakeSiteUploadEnabledEnvironmentVariable, null)
+            .Set(DesktopUploadSectionOptions.DevFakeUploadReceiptEnabledEnvironmentVariable, "true");
+
+        using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
+
+#if DEBUG
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeSiteUploadEnabled);
+        Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadReceiptEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakeSiteUploadEnabled);
+        Assert.True(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakeUploadReceiptEnabled);
+        Assert.IsType<DisabledDesktopPreUploadCheckClient>(
+            services.GetRequiredService<IDesktopPreUploadCheckClient>());
+        Assert.IsType<DisabledDesktopDirectSiteUploadClient>(
+            services.GetRequiredService<IDesktopDirectSiteUploadClient>());
+        Assert.IsType<FakeDesktopUploadReceiptClient>(
+            services.GetRequiredService<IDesktopUploadReceiptClient>());
+#else
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeSiteUploadEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadReceiptEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakeUploadReceiptEnabled);
+        Assert.IsType<DisabledDesktopPreUploadCheckClient>(
+            services.GetRequiredService<IDesktopPreUploadCheckClient>());
+        Assert.IsType<DisabledDesktopDirectSiteUploadClient>(
+            services.GetRequiredService<IDesktopDirectSiteUploadClient>());
+        Assert.IsType<DisabledDesktopUploadReceiptClient>(
+            services.GetRequiredService<IDesktopUploadReceiptClient>());
+#endif
+    }
+
+    [Fact]
+    public void EnvironmentOptionsEnableFakeUploadFileHashBusinessObjectKeyPreUploadCheckSiteUploadAndUploadReceiptTogetherForVisualSmoke()
     {
         using var environment = new EnvironmentVariableScope()
             .Set(DesktopAuthOptions.ControlPlaneBaseAddressEnvironmentVariable, null)
@@ -319,7 +379,8 @@ public sealed class DesktopCompositionRootTests
             .Set(DesktopUploadSectionOptions.DevFakeUploadHashEnabledEnvironmentVariable, "true")
             .Set(DesktopUploadSectionOptions.DevFakeBusinessObjectKeyEnabledEnvironmentVariable, "true")
             .Set(DesktopUploadSectionOptions.DevFakePreUploadCheckEnabledEnvironmentVariable, "true")
-            .Set(DesktopUploadSectionOptions.DevFakeSiteUploadEnabledEnvironmentVariable, "true");
+            .Set(DesktopUploadSectionOptions.DevFakeSiteUploadEnabledEnvironmentVariable, "true")
+            .Set(DesktopUploadSectionOptions.DevFakeUploadReceiptEnabledEnvironmentVariable, "true");
 
         using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
 
@@ -330,16 +391,20 @@ public sealed class DesktopCompositionRootTests
         Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
         Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
         Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeSiteUploadEnabled);
+        Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadReceiptEnabled);
         Assert.IsType<FakeDesktopAuthClient>(services.GetRequiredService<IDesktopAuthClient>());
         Assert.IsType<FakeDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
         Assert.IsType<FakeDesktopVideoHashService>(services.GetRequiredService<IDesktopVideoHashService>());
         Assert.True(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakeBusinessObjectKeyEnabled);
         Assert.True(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakePreUploadCheckEnabled);
         Assert.True(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakeSiteUploadEnabled);
+        Assert.True(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakeUploadReceiptEnabled);
         Assert.IsType<FakeDesktopPreUploadCheckClient>(
             services.GetRequiredService<IDesktopPreUploadCheckClient>());
         Assert.IsType<FakeDesktopDirectSiteUploadClient>(
             services.GetRequiredService<IDesktopDirectSiteUploadClient>());
+        Assert.IsType<FakeDesktopUploadReceiptClient>(
+            services.GetRequiredService<IDesktopUploadReceiptClient>());
 #else
         Assert.False(services.GetRequiredService<DesktopAuthOptions>().IsDevFakeAuthEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
@@ -347,6 +412,7 @@ public sealed class DesktopCompositionRootTests
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeSiteUploadEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadReceiptEnabled);
         Assert.IsType<UnavailableDesktopAuthClient>(services.GetRequiredService<IDesktopAuthClient>());
         Assert.IsType<WpfDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
         Assert.IsType<DesktopVideoHashService>(services.GetRequiredService<IDesktopVideoHashService>());
@@ -354,6 +420,8 @@ public sealed class DesktopCompositionRootTests
             services.GetRequiredService<IDesktopPreUploadCheckClient>());
         Assert.IsType<DisabledDesktopDirectSiteUploadClient>(
             services.GetRequiredService<IDesktopDirectSiteUploadClient>());
+        Assert.IsType<DisabledDesktopUploadReceiptClient>(
+            services.GetRequiredService<IDesktopUploadReceiptClient>());
 #endif
     }
 

--- a/tests/Unit/App.Desktop.Tests/DesktopUploadSectionTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopUploadSectionTests.cs
@@ -139,13 +139,45 @@ public sealed class DesktopUploadSectionTests
         Assert.Equal("status", DesktopUploadSectionText.SiteUploadResultStatusLabel);
         Assert.Equal("externalVideoId", DesktopUploadSectionText.SiteUploadExternalVideoIdLabel);
         Assert.Equal("siteStorageKey", DesktopUploadSectionText.SiteUploadSiteStorageKeyLabel);
+        Assert.Equal("Шаг 6. Квитанция загрузки", DesktopUploadSectionText.StepSixTitle);
         Assert.Equal(
-            "Следующий шаг отложен: UploadReceipt будет добавлен отдельным approved desktop slice.",
+            "Нужны выбранный файл, SHA-256, businessObjectKey, решение ALLOW или ALLOW_WITH_REVIEW и успешная загрузка на сайт.",
+            DesktopUploadSectionText.UploadReceiptNotReadyMessage);
+        Assert.Equal(
+            "Preview квитанции загрузки готов. В этом slice доступен только desktop-local dev boundary.",
+            DesktopUploadSectionText.UploadReceiptReadyMessage);
+        Assert.Equal(
+            "Формируется квитанция загрузки в desktop-local dev boundary.",
+            DesktopUploadSectionText.UploadReceiptInProgressMessage);
+        Assert.Equal(
+            "Квитанция загрузки пока доступна только в dev-smoke режиме. Реальный вызов App.Api будет добавлен отдельным approved slice.",
+            DesktopUploadSectionText.UploadReceiptDeferredMessage);
+        Assert.Equal(
+            "Квитанция загрузки сформирована в dev-smoke режиме.",
+            DesktopUploadSectionText.UploadReceiptAcceptedDevMessage);
+        Assert.Equal("Формирование квитанции загрузки отменено.", DesktopUploadSectionText.UploadReceiptCanceledMessage);
+        Assert.Equal("Сформировать квитанцию", DesktopUploadSectionText.UploadReceiptButton);
+        Assert.Equal("Формируется...", DesktopUploadSectionText.UploadReceiptBusyButton);
+        Assert.Equal("Имя файла", DesktopUploadSectionText.UploadReceiptFileNameLabel);
+        Assert.Equal("Размер", DesktopUploadSectionText.UploadReceiptFileSizeLabel);
+        Assert.Equal("Тип содержимого", DesktopUploadSectionText.UploadReceiptContentTypeLabel);
+        Assert.Equal("SHA-256", DesktopUploadSectionText.UploadReceiptSha256Label);
+        Assert.Equal("businessObjectKey", DesktopUploadSectionText.UploadReceiptBusinessObjectKeyLabel);
+        Assert.Equal("Решение PreUploadCheck", DesktopUploadSectionText.UploadReceiptPreUploadCheckDecisionLabel);
+        Assert.Equal("externalVideoId", DesktopUploadSectionText.UploadReceiptExternalVideoIdLabel);
+        Assert.Equal("siteStorageKey", DesktopUploadSectionText.UploadReceiptSiteStorageKeyLabel);
+        Assert.Equal("status загрузки на сайт", DesktopUploadSectionText.UploadReceiptSiteUploadStatusLabel);
+        Assert.Equal("capturedAtUtc", DesktopUploadSectionText.UploadReceiptCapturedAtUtcLabel);
+        Assert.Equal("status", DesktopUploadSectionText.UploadReceiptResultStatusLabel);
+        Assert.Equal("receiptId", DesktopUploadSectionText.UploadReceiptResultReceiptIdLabel);
+        Assert.Equal("serverCorrelationId", DesktopUploadSectionText.UploadReceiptResultServerCorrelationIdLabel);
+        Assert.Equal(
+            "Следующий шаг отложен: реальный control-plane UploadReceipt client будет добавлен отдельным approved desktop slice.",
             DesktopUploadSectionText.NextStepDeferredMessage);
     }
 
     [Fact]
-    public void UploadSectionDoesNotReferenceApiUploadReceiptOrByteSendingBoundaries()
+    public void UploadSectionDoesNotReferenceRealAppApiReceiptUploadOrByteSendingBoundaries()
     {
         string[] sourceFiles =
         [
@@ -162,11 +194,15 @@ public sealed class DesktopUploadSectionTests
             Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "DesktopSiteUpload.cs"),
             Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "DisabledDesktopDirectSiteUploadClient.cs"),
             Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "FakeDesktopDirectSiteUploadClient.cs"),
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "DesktopUploadReceipt.cs"),
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "DisabledDesktopUploadReceiptClient.cs"),
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "FakeDesktopUploadReceiptClient.cs"),
             Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "WpfDesktopVideoFilePicker.cs"),
             Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Boundaries", "DesktopVideoFilePickerBoundary.cs"),
             Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Boundaries", "DesktopVideoHashBoundary.cs"),
             Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Boundaries", "DesktopPreUploadCheckBoundary.cs"),
-            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Boundaries", "DesktopDirectSiteUploadBoundary.cs")
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Boundaries", "DesktopDirectSiteUploadBoundary.cs"),
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Boundaries", "DesktopUploadReceiptBoundary.cs")
         ];
 
         foreach (string sourceFile in sourceFiles)
@@ -180,25 +216,29 @@ public sealed class DesktopUploadSectionTests
             Assert.DoesNotContain("ControlPlanePreUploadCheckRequest", source, StringComparison.Ordinal);
             Assert.DoesNotContain("RecordUploadReceiptAsync", source, StringComparison.Ordinal);
             Assert.DoesNotContain("ControlPlaneUploadReceiptDraft", source, StringComparison.Ordinal);
-            Assert.DoesNotContain("UploadReceipt", source, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("HttpDesktopUploadReceipt", source, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("PostAsync", source, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("SendAsync", source, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("ReadAllBytes", source, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("ReadAllBytesAsync", source, StringComparison.OrdinalIgnoreCase);
         }
     }
 
     [Fact]
-    public void FakeUploadFileSelectionHashBusinessObjectKeyPreUploadCheckAndSiteUploadAreDevOnlyAndDisabledByDefault()
+    public void FakeUploadFileSelectionHashBusinessObjectKeyPreUploadCheckSiteUploadAndUploadReceiptAreDevOnlyAndDisabledByDefault()
     {
         Assert.False(DesktopUploadSectionOptions.Disabled.IsDevFakeUploadFileEnabled);
         Assert.False(DesktopUploadSectionOptions.Disabled.IsDevFakeUploadHashEnabled);
         Assert.False(DesktopUploadSectionOptions.Disabled.IsDevFakeBusinessObjectKeyEnabled);
         Assert.False(DesktopUploadSectionOptions.Disabled.IsDevFakePreUploadCheckEnabled);
         Assert.False(DesktopUploadSectionOptions.Disabled.IsDevFakeSiteUploadEnabled);
+        Assert.False(DesktopUploadSectionOptions.Disabled.IsDevFakeUploadReceiptEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue(null).IsDevFakeUploadFileEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue(null).IsDevFakeUploadHashEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue(null).IsDevFakeBusinessObjectKeyEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue(null).IsDevFakePreUploadCheckEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue(null).IsDevFakeSiteUploadEnabled);
+        Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue(null).IsDevFakeUploadReceiptEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("false").IsDevFakeUploadFileEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("false", "false").IsDevFakeUploadHashEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "false").IsDevFakeBusinessObjectKeyEnabled);
@@ -206,6 +246,8 @@ public sealed class DesktopUploadSectionTests
             .IsDevFakePreUploadCheckEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "false", "false", "false")
             .IsDevFakeSiteUploadEnabled);
+        Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "false", "false", "false", "false")
+            .IsDevFakeUploadReceiptEnabled);
 
 #if DEBUG
         Assert.True(DesktopUploadSectionOptions.FromEnvironmentValue("true").IsDevFakeUploadFileEnabled);
@@ -221,6 +263,10 @@ public sealed class DesktopUploadSectionTests
             .IsDevFakeSiteUploadEnabled);
         Assert.True(DesktopUploadSectionOptions.FromEnvironmentValue("true", "true", "true", "true", "true")
             .IsDevFakeSiteUploadEnabled);
+        Assert.True(DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "false", "false", "false", "true")
+            .IsDevFakeUploadReceiptEnabled);
+        Assert.True(DesktopUploadSectionOptions.FromEnvironmentValue("true", "true", "true", "true", "true", "true")
+            .IsDevFakeUploadReceiptEnabled);
 #else
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("true").IsDevFakeUploadFileEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("false", "true").IsDevFakeUploadHashEnabled);
@@ -235,6 +281,10 @@ public sealed class DesktopUploadSectionTests
             .IsDevFakeSiteUploadEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("true", "true", "true", "true", "true")
             .IsDevFakeSiteUploadEnabled);
+        Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "false", "false", "false", "true")
+            .IsDevFakeUploadReceiptEnabled);
+        Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("true", "true", "true", "true", "true", "true")
+            .IsDevFakeUploadReceiptEnabled);
 #endif
     }
 
@@ -816,7 +866,8 @@ public sealed class DesktopUploadSectionTests
             new FakeDesktopVideoHashService(),
             new FakeDesktopPreUploadCheckClient(),
             new FakeDesktopDirectSiteUploadClient(),
-            DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "false", "true", "true"));
+            new FakeDesktopUploadReceiptClient(),
+            DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "false", "true", "true", "true"));
 
         _ = await PreparePreUploadCheckPreviewAsync(viewModel, "report-draft-001");
         _ = await viewModel.CheckPreUploadAsync(CancellationToken.None);
@@ -837,6 +888,268 @@ public sealed class DesktopUploadSectionTests
 #else
         Assert.Null(result);
         Assert.False(viewModel.HasSiteUploadResult);
+#endif
+    }
+
+    [Fact]
+    public async Task UploadReceiptActionRequiresSelectedFileSha256BusinessObjectKeyAllowedPreUploadCheckAndSuccessfulSiteUpload()
+    {
+        var viewModel = CreateViewModel(
+            new FakeDesktopVideoFilePicker(),
+            new FakeDesktopVideoHashService(),
+            new FakeDesktopPreUploadCheckClient(),
+            new FakeDesktopDirectSiteUploadClient(),
+            new FakeDesktopUploadReceiptClient(),
+            DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "false", "true", "true", "false"));
+
+        Assert.Null(viewModel.UploadReceiptRequestPreview);
+        Assert.False(viewModel.HasUploadReceiptRequestPreview);
+        Assert.False(viewModel.CanCreateUploadReceipt);
+
+        _ = await viewModel.SelectVideoFileAsync(CancellationToken.None);
+        _ = await viewModel.CalculateSha256Async(CancellationToken.None);
+        viewModel.BusinessObjectKeyInput = "report-draft-001";
+        _ = viewModel.ApplyBusinessObjectKey();
+        _ = await viewModel.CheckPreUploadAsync(CancellationToken.None);
+
+#if DEBUG
+        Assert.NotNull(viewModel.SiteUploadRequestPreview);
+        Assert.Null(viewModel.UploadReceiptRequestPreview);
+        Assert.False(viewModel.CanCreateUploadReceipt);
+
+        _ = await viewModel.UploadToSiteAsync(CancellationToken.None);
+
+        Assert.NotNull(viewModel.UploadReceiptRequestPreview);
+        Assert.True(viewModel.HasUploadReceiptRequestPreview);
+        Assert.True(viewModel.CanCreateUploadReceipt);
+        Assert.Equal(DesktopUploadSectionText.UploadReceiptReadyMessage, viewModel.UploadReceiptStatusMessage);
+#else
+        Assert.Null(viewModel.UploadReceiptRequestPreview);
+        Assert.False(viewModel.CanCreateUploadReceipt);
+#endif
+    }
+
+    [Fact]
+    public async Task UploadReceiptRequestPreviewShowsOnlySafeFields()
+    {
+        var viewModel = CreateViewModel(new StaticDesktopVideoFilePicker(
+            DesktopVideoFilePickerResult.Selected(
+                Path.Combine("private-folder", "nested", "safe-preview.mp4"),
+                42,
+                "video/mp4",
+                DesktopVideoHashSource.VisualSmoke)),
+            new FakeDesktopVideoHashService(),
+            new FakeDesktopPreUploadCheckClient(),
+            new FakeDesktopDirectSiteUploadClient(),
+            new DisabledDesktopUploadReceiptClient(),
+            DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "false", "true", "true", "false"));
+
+        _ = await PrepareSuccessfulSiteUploadAsync(viewModel, " report-draft-001 ");
+
+#if DEBUG
+        DesktopUploadReceiptRequestPreview preview =
+            viewModel.UploadReceiptRequestPreview ?? throw new InvalidOperationException("UploadReceipt preview was not created.");
+
+        Assert.Equal("safe-preview.mp4", preview.FileName);
+        Assert.Equal(42, preview.SizeBytes);
+        Assert.Equal("video/mp4", preview.ContentType);
+        Assert.Equal(FakeDesktopVideoHashService.VisualSmokeSha256Hex, preview.Sha256Hex);
+        Assert.Equal("report-draft-001", preview.BusinessObjectKeyPreview);
+        Assert.Equal("ALLOW", preview.PreUploadCheckDecisionPreview);
+        Assert.Equal("visual-smoke-external-video-001", preview.ExternalVideoId);
+        Assert.Equal("visual-smoke/site/video-001", preview.SiteStorageKey);
+        Assert.Equal("SUCCESS", preview.SiteUploadStatusPreview);
+        Assert.Equal(DesktopPreUploadCheckRequestPreview.CapturedAtUtcPlaceholder, preview.CapturedAtUtc);
+#else
+        Assert.Null(viewModel.UploadReceiptRequestPreview);
+#endif
+    }
+
+    [Fact]
+    public async Task UploadReceiptRequestPreviewDoesNotShowFullLocalPath()
+    {
+        string privateFolder = "operator-private-upload-receipt-source";
+        string localPath = Path.Combine(Path.GetTempPath(), privateFolder, "safe-preview.mp4");
+        var viewModel = CreateViewModel(new StaticDesktopVideoFilePicker(
+            DesktopVideoFilePickerResult.Selected(
+                localPath,
+                42,
+                "video/mp4",
+                DesktopVideoHashSource.VisualSmoke)),
+            new FakeDesktopVideoHashService(),
+            new FakeDesktopPreUploadCheckClient(),
+            new FakeDesktopDirectSiteUploadClient(),
+            new DisabledDesktopUploadReceiptClient(),
+            DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "false", "true", "true", "false"));
+
+        _ = await PrepareSuccessfulSiteUploadAsync(viewModel, "report-draft-001");
+
+#if DEBUG
+        DesktopUploadReceiptRequestPreview preview =
+            viewModel.UploadReceiptRequestPreview ?? throw new InvalidOperationException("UploadReceipt preview was not created.");
+        string visibleState = preview.ToString()
+            + " "
+            + viewModel.UploadReceiptStatusMessage
+            + " "
+            + (viewModel.UploadReceiptStatusPreview ?? string.Empty);
+
+        Assert.Equal("safe-preview.mp4", preview.FileName);
+        Assert.DoesNotContain(Path.GetTempPath(), visibleState, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(privateFolder, visibleState, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(@"\", preview.FileName, StringComparison.Ordinal);
+        Assert.DoesNotContain("/", preview.FileName, StringComparison.Ordinal);
+#else
+        Assert.Null(viewModel.UploadReceiptRequestPreview);
+#endif
+    }
+
+    [Fact]
+    public async Task DisabledUploadReceiptShowsSafeDeferredMessageAndDoesNotCallBoundary()
+    {
+        var uploadReceiptClient = new ThrowingDesktopUploadReceiptClient();
+        var viewModel = CreateViewModel(
+            new FakeDesktopVideoFilePicker(),
+            new FakeDesktopVideoHashService(),
+            new FakeDesktopPreUploadCheckClient(),
+            new FakeDesktopDirectSiteUploadClient(),
+            uploadReceiptClient,
+            DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "false", "true", "true", "false"));
+
+        _ = await PrepareSuccessfulSiteUploadAsync(viewModel, "report-draft-001");
+
+        DesktopUploadReceiptResult? result = await viewModel.CreateUploadReceiptAsync(CancellationToken.None);
+
+#if DEBUG
+        Assert.NotNull(result);
+        Assert.Equal(DesktopUploadReceiptStatus.Deferred, result.Status);
+        Assert.Null(result.StatusPreview);
+        Assert.Null(result.ReceiptId);
+        Assert.Null(result.ServerCorrelationId);
+        Assert.Equal(DesktopUploadSectionText.UploadReceiptDeferredMessage, viewModel.UploadReceiptStatusMessage);
+        Assert.Equal(0, uploadReceiptClient.CallCount);
+#else
+        Assert.Null(result);
+        Assert.Equal(0, uploadReceiptClient.CallCount);
+#endif
+    }
+
+    [Fact]
+    public async Task EnabledUploadReceiptShowsFakeAcceptedResult()
+    {
+        var viewModel = CreateViewModel(
+            new FakeDesktopVideoFilePicker(),
+            new FakeDesktopVideoHashService(),
+            new FakeDesktopPreUploadCheckClient(),
+            new FakeDesktopDirectSiteUploadClient(),
+            new FakeDesktopUploadReceiptClient(),
+            DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "false", "true", "true", "true"));
+
+        _ = await PrepareSuccessfulSiteUploadAsync(viewModel, "report-draft-001");
+
+        DesktopUploadReceiptResult? result = await viewModel.CreateUploadReceiptAsync(CancellationToken.None);
+
+#if DEBUG
+        Assert.NotNull(result);
+        Assert.Equal(DesktopUploadReceiptStatus.Accepted, result.Status);
+        Assert.Equal("ACCEPTED", result.StatusPreview);
+        Assert.Equal("visual-smoke-upload-receipt-001", result.ReceiptId);
+        Assert.Equal("visual-smoke-correlation-001", result.ServerCorrelationId);
+        Assert.True(viewModel.HasUploadReceiptResult);
+        Assert.Equal("ACCEPTED", viewModel.UploadReceiptStatusPreview);
+        Assert.Equal("visual-smoke-upload-receipt-001", viewModel.UploadReceiptId);
+        Assert.Equal("visual-smoke-correlation-001", viewModel.UploadReceiptServerCorrelationId);
+        Assert.Equal(DesktopUploadSectionText.UploadReceiptAcceptedDevMessage, viewModel.UploadReceiptStatusMessage);
+#else
+        Assert.Null(result);
+        Assert.False(viewModel.HasUploadReceiptResult);
+#endif
+    }
+
+    [Theory]
+    [InlineData(DesktopPreUploadCheckDecision.Allow, true, "ALLOW")]
+    [InlineData(DesktopPreUploadCheckDecision.AllowWithReview, true, "ALLOW_WITH_REVIEW")]
+    [InlineData(DesktopPreUploadCheckDecision.BlockHardDuplicate, false, "BLOCK_HARD_DUPLICATE")]
+    [InlineData(DesktopPreUploadCheckDecision.BlockPossibleFalsification, false, "BLOCK_POSSIBLE_FALSIFICATION")]
+    public async Task UploadReceiptActionAllowsOnlyAllowedPreUploadCheckDecisionsAndSuccessfulSiteUpload(
+        DesktopPreUploadCheckDecision decision,
+        bool expectedCanCreateReceipt,
+        string expectedDecisionPreview)
+    {
+        var uploadReceiptClient = new ThrowingDesktopUploadReceiptClient();
+        var viewModel = CreateViewModel(
+            new FakeDesktopVideoFilePicker(),
+            new FakeDesktopVideoHashService(),
+            new FakeDesktopPreUploadCheckClient(decision),
+            new FakeDesktopDirectSiteUploadClient(),
+            uploadReceiptClient,
+            DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "false", "true", "true", "true"));
+
+        _ = await PreparePreUploadCheckPreviewAsync(viewModel, "report-draft-001");
+        _ = await viewModel.CheckPreUploadAsync(CancellationToken.None);
+
+#if DEBUG
+        Assert.Equal(expectedDecisionPreview, viewModel.PreUploadCheckDecisionPreview);
+
+        if (expectedCanCreateReceipt)
+        {
+            _ = await viewModel.UploadToSiteAsync(CancellationToken.None);
+            Assert.True(viewModel.HasSiteUploadResult);
+            Assert.NotNull(viewModel.UploadReceiptRequestPreview);
+            Assert.Equal(expectedDecisionPreview, viewModel.UploadReceiptRequestPreview.PreUploadCheckDecisionPreview);
+            Assert.True(viewModel.CanCreateUploadReceipt);
+            Assert.Equal(DesktopUploadSectionText.UploadReceiptReadyMessage, viewModel.UploadReceiptStatusMessage);
+        }
+        else
+        {
+            Assert.False(viewModel.CanUploadToSite);
+            Assert.Null(viewModel.SiteUploadRequestPreview);
+            Assert.Null(viewModel.UploadReceiptRequestPreview);
+            Assert.False(viewModel.CanCreateUploadReceipt);
+            DesktopUploadReceiptResult? result = await viewModel.CreateUploadReceiptAsync(CancellationToken.None);
+            Assert.Null(result);
+            Assert.Equal(0, uploadReceiptClient.CallCount);
+            Assert.Equal(DesktopUploadSectionText.UploadReceiptNotReadyMessage, viewModel.UploadReceiptStatusMessage);
+        }
+#else
+        Assert.Null(viewModel.UploadReceiptRequestPreview);
+        Assert.False(viewModel.CanCreateUploadReceipt);
+#endif
+    }
+
+    [Fact]
+    public async Task MissingOrFailedSiteUploadDoesNotAllowUploadReceiptAction()
+    {
+        var uploadReceiptClient = new ThrowingDesktopUploadReceiptClient();
+        var viewModel = CreateViewModel(
+            new FakeDesktopVideoFilePicker(),
+            new FakeDesktopVideoHashService(),
+            new FakeDesktopPreUploadCheckClient(),
+            new DisabledDesktopDirectSiteUploadClient(),
+            uploadReceiptClient,
+            DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "false", "true", "false", "true"));
+
+        _ = await PreparePreUploadCheckPreviewAsync(viewModel, "report-draft-001");
+        _ = await viewModel.CheckPreUploadAsync(CancellationToken.None);
+
+#if DEBUG
+        Assert.NotNull(viewModel.SiteUploadRequestPreview);
+        Assert.False(viewModel.HasSiteUploadResult);
+        Assert.Null(viewModel.UploadReceiptRequestPreview);
+        Assert.False(viewModel.CanCreateUploadReceipt);
+
+        _ = await viewModel.UploadToSiteAsync(CancellationToken.None);
+
+        Assert.False(viewModel.HasSiteUploadResult);
+        Assert.Null(viewModel.UploadReceiptRequestPreview);
+        Assert.False(viewModel.CanCreateUploadReceipt);
+
+        DesktopUploadReceiptResult? result = await viewModel.CreateUploadReceiptAsync(CancellationToken.None);
+        Assert.Null(result);
+        Assert.Equal(0, uploadReceiptClient.CallCount);
+        Assert.Equal(DesktopUploadSectionText.UploadReceiptNotReadyMessage, viewModel.UploadReceiptStatusMessage);
+#else
+        Assert.Null(viewModel.UploadReceiptRequestPreview);
+        Assert.False(viewModel.CanCreateUploadReceipt);
 #endif
     }
 
@@ -949,7 +1262,8 @@ public sealed class DesktopUploadSectionTests
             new FakeDesktopVideoHashService(),
             new FakeDesktopPreUploadCheckClient(),
             new FakeDesktopDirectSiteUploadClient(),
-            DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "false", "true", "true"));
+            new FakeDesktopUploadReceiptClient(),
+            DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "false", "true", "true", "true"));
 
         viewModel.OpenUploadSection();
         _ = await viewModel.SelectVideoFileAsync(CancellationToken.None);
@@ -958,10 +1272,13 @@ public sealed class DesktopUploadSectionTests
         _ = viewModel.ApplyBusinessObjectKey();
         _ = await viewModel.CheckPreUploadAsync(CancellationToken.None);
         _ = await viewModel.UploadToSiteAsync(CancellationToken.None);
+        _ = await viewModel.CreateUploadReceiptAsync(CancellationToken.None);
 
 #if DEBUG
         Assert.NotNull(viewModel.SiteUploadRequestPreview);
         Assert.True(viewModel.HasSiteUploadResult);
+        Assert.NotNull(viewModel.UploadReceiptRequestPreview);
+        Assert.True(viewModel.HasUploadReceiptResult);
 #endif
 
         viewModel.ResetForSignedOutState();
@@ -987,6 +1304,12 @@ public sealed class DesktopUploadSectionTests
         Assert.Null(viewModel.SiteUploadExternalVideoId);
         Assert.Null(viewModel.SiteUploadSiteStorageKey);
         Assert.Equal(DesktopUploadSectionText.SiteUploadNotReadyMessage, viewModel.SiteUploadStatusMessage);
+        Assert.Null(viewModel.UploadReceiptRequestPreview);
+        Assert.Null(viewModel.UploadReceiptResult);
+        Assert.Null(viewModel.UploadReceiptStatusPreview);
+        Assert.Null(viewModel.UploadReceiptId);
+        Assert.Null(viewModel.UploadReceiptServerCorrelationId);
+        Assert.Equal(DesktopUploadSectionText.UploadReceiptNotReadyMessage, viewModel.UploadReceiptStatusMessage);
     }
 
     [Fact]
@@ -997,7 +1320,8 @@ public sealed class DesktopUploadSectionTests
             new FakeDesktopVideoHashService(),
             new FakeDesktopPreUploadCheckClient(),
             new FakeDesktopDirectSiteUploadClient(),
-            DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "false", "true", "true"));
+            new FakeDesktopUploadReceiptClient(),
+            DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "false", "true", "true", "true"));
 
         viewModel.OpenUploadSection();
         _ = await viewModel.SelectVideoFileAsync(CancellationToken.None);
@@ -1006,10 +1330,13 @@ public sealed class DesktopUploadSectionTests
         _ = viewModel.ApplyBusinessObjectKey();
         _ = await viewModel.CheckPreUploadAsync(CancellationToken.None);
         _ = await viewModel.UploadToSiteAsync(CancellationToken.None);
+        _ = await viewModel.CreateUploadReceiptAsync(CancellationToken.None);
 
 #if DEBUG
         Assert.NotNull(viewModel.SiteUploadRequestPreview);
         Assert.True(viewModel.HasSiteUploadResult);
+        Assert.NotNull(viewModel.UploadReceiptRequestPreview);
+        Assert.True(viewModel.HasUploadReceiptResult);
 #endif
 
         viewModel.BackToWorkspace();
@@ -1035,6 +1362,12 @@ public sealed class DesktopUploadSectionTests
         Assert.Null(viewModel.SiteUploadExternalVideoId);
         Assert.Null(viewModel.SiteUploadSiteStorageKey);
         Assert.Equal(DesktopUploadSectionText.SiteUploadNotReadyMessage, viewModel.SiteUploadStatusMessage);
+        Assert.Null(viewModel.UploadReceiptRequestPreview);
+        Assert.Null(viewModel.UploadReceiptResult);
+        Assert.Null(viewModel.UploadReceiptStatusPreview);
+        Assert.Null(viewModel.UploadReceiptId);
+        Assert.Null(viewModel.UploadReceiptServerCorrelationId);
+        Assert.Equal(DesktopUploadSectionText.UploadReceiptNotReadyMessage, viewModel.UploadReceiptStatusMessage);
     }
 
     [Fact]
@@ -1117,6 +1450,28 @@ public sealed class DesktopUploadSectionTests
             DesktopUploadSectionText.SiteUploadResultStatusLabel,
             DesktopUploadSectionText.SiteUploadExternalVideoIdLabel,
             DesktopUploadSectionText.SiteUploadSiteStorageKeyLabel,
+            DesktopUploadSectionText.StepSixTitle,
+            DesktopUploadSectionText.UploadReceiptNotReadyMessage,
+            DesktopUploadSectionText.UploadReceiptReadyMessage,
+            DesktopUploadSectionText.UploadReceiptInProgressMessage,
+            DesktopUploadSectionText.UploadReceiptDeferredMessage,
+            DesktopUploadSectionText.UploadReceiptAcceptedDevMessage,
+            DesktopUploadSectionText.UploadReceiptCanceledMessage,
+            DesktopUploadSectionText.UploadReceiptButton,
+            DesktopUploadSectionText.UploadReceiptBusyButton,
+            DesktopUploadSectionText.UploadReceiptFileNameLabel,
+            DesktopUploadSectionText.UploadReceiptFileSizeLabel,
+            DesktopUploadSectionText.UploadReceiptContentTypeLabel,
+            DesktopUploadSectionText.UploadReceiptSha256Label,
+            DesktopUploadSectionText.UploadReceiptBusinessObjectKeyLabel,
+            DesktopUploadSectionText.UploadReceiptPreUploadCheckDecisionLabel,
+            DesktopUploadSectionText.UploadReceiptExternalVideoIdLabel,
+            DesktopUploadSectionText.UploadReceiptSiteStorageKeyLabel,
+            DesktopUploadSectionText.UploadReceiptSiteUploadStatusLabel,
+            DesktopUploadSectionText.UploadReceiptCapturedAtUtcLabel,
+            DesktopUploadSectionText.UploadReceiptResultStatusLabel,
+            DesktopUploadSectionText.UploadReceiptResultReceiptIdLabel,
+            DesktopUploadSectionText.UploadReceiptResultServerCorrelationIdLabel,
             DesktopUploadSectionText.NextStepDeferredMessage,
             DesktopUploadSelectedFile.VisualSmokeFileName,
             DesktopUploadSelectedFile.VisualSmokeContentType,
@@ -1129,7 +1484,10 @@ public sealed class DesktopUploadSectionTests
             DesktopPreUploadCheckResult.FromFakeDecision(DesktopPreUploadCheckDecision.BlockPossibleFalsification).DecisionPreview ?? string.Empty,
             DesktopSiteUploadResult.FakeSuccess.StatusPreview ?? string.Empty,
             DesktopSiteUploadResult.FakeSuccess.ExternalVideoId ?? string.Empty,
-            DesktopSiteUploadResult.FakeSuccess.SiteStorageKey ?? string.Empty
+            DesktopSiteUploadResult.FakeSuccess.SiteStorageKey ?? string.Empty,
+            DesktopUploadReceiptResult.FakeAccepted.StatusPreview ?? string.Empty,
+            DesktopUploadReceiptResult.FakeAccepted.ReceiptId ?? string.Empty,
+            DesktopUploadReceiptResult.FakeAccepted.ServerCorrelationId ?? string.Empty
         ];
 
         foreach (string visibleString in visibleStrings)
@@ -1188,11 +1546,29 @@ public sealed class DesktopUploadSectionTests
         IDesktopDirectSiteUploadClient directSiteUploadClient,
         DesktopUploadSectionOptions uploadSectionOptions)
     {
+        return CreateViewModel(
+            videoFilePicker,
+            videoHashService,
+            preUploadCheckClient,
+            directSiteUploadClient,
+            new DisabledDesktopUploadReceiptClient(),
+            uploadSectionOptions);
+    }
+
+    private static DesktopUploadSectionViewModel CreateViewModel(
+        IDesktopVideoFilePicker videoFilePicker,
+        IDesktopVideoHashService videoHashService,
+        IDesktopPreUploadCheckClient preUploadCheckClient,
+        IDesktopDirectSiteUploadClient directSiteUploadClient,
+        IDesktopUploadReceiptClient uploadReceiptClient,
+        DesktopUploadSectionOptions uploadSectionOptions)
+    {
         return new DesktopUploadSectionViewModel(
             videoFilePicker,
             videoHashService,
             preUploadCheckClient,
             directSiteUploadClient,
+            uploadReceiptClient,
             uploadSectionOptions);
     }
 
@@ -1207,6 +1583,15 @@ public sealed class DesktopUploadSectionTests
 
         return viewModel.PreUploadCheckRequestPreview
             ?? throw new InvalidOperationException("PreUploadCheck preview was not created.");
+    }
+
+    private static async Task<DesktopSiteUploadResult?> PrepareSuccessfulSiteUploadAsync(
+        DesktopUploadSectionViewModel viewModel,
+        string businessObjectKey)
+    {
+        _ = await PreparePreUploadCheckPreviewAsync(viewModel, businessObjectKey);
+        _ = await viewModel.CheckPreUploadAsync(CancellationToken.None);
+        return await viewModel.UploadToSiteAsync(CancellationToken.None);
     }
 
     private sealed class CancelingDesktopVideoFilePicker : IDesktopVideoFilePicker
@@ -1250,6 +1635,19 @@ public sealed class DesktopUploadSectionTests
         {
             CallCount++;
             throw new InvalidOperationException("Disabled fake site upload boundary should not be called.");
+        }
+    }
+
+    private sealed class ThrowingDesktopUploadReceiptClient : IDesktopUploadReceiptClient
+    {
+        public int CallCount { get; private set; }
+
+        public ValueTask<DesktopUploadReceiptResult> CreateAsync(
+            DesktopUploadReceiptRequestPreview requestPreview,
+            CancellationToken cancellationToken)
+        {
+            CallCount++;
+            throw new InvalidOperationException("Disabled fake UploadReceipt boundary should not be called.");
         }
     }
 


### PR DESCRIPTION
## Coder
Coder 1 acting as Coder 2 / Desktop Client

## Task ID S2-66
Desktop UploadReceipt Request Preview / Fake Control-Plane Receipt Boundary

## Module
App.Desktop / UploadReceipt request preview fake boundary

## Scope
Adds Step 6 "Квитанция загрузки" to the desktop upload section with a safe UploadReceipt request preview and an App.Desktop-local fake/dev UploadReceipt boundary for visual smoke only.

## Changed areas
- docs/task-cards/S2-66_desktop-upload-receipt-boundary-task-card.txt
- src/App.Desktop/Boundaries/DesktopSignInBoundary.cs
- src/App.Desktop/Boundaries/DesktopUploadReceiptBoundary.cs
- src/App.Desktop/Components/DesktopShell.razor
- src/App.Desktop/Composition/DesktopCompositionRoot.cs
- src/App.Desktop/Services/Upload/DesktopUploadReceipt.cs
- src/App.Desktop/Services/Upload/DesktopUploadSectionOptions.cs
- src/App.Desktop/Services/Upload/DesktopUploadSectionViewModel.cs
- src/App.Desktop/Services/Upload/DisabledDesktopUploadReceiptClient.cs
- src/App.Desktop/Services/Upload/FakeDesktopUploadReceiptClient.cs
- src/App.Desktop/wwwroot/app.css
- tests/Unit/App.Desktop.Tests/DesktopCompositionRootTests.cs
- tests/Unit/App.Desktop.Tests/DesktopUploadSectionTests.cs

## Base main SHA
8eaac3d07dd8ba647054d2469ae6233d7b490930

## Coordination log entries reviewed
- TEAM COORDINATION LOG issue #89 metadata: open, updated 2026-05-01T08:34:06Z.
- Issue #89 merge records reviewed for S2-60 #129, S2-61 #130, S2-62 #131, S2-63 #132, S2-64 #133, S2-65 #134.

## Handoff/task cards reviewed
- docs/task-cards/S2-58_desktop-visual-smoke-fake-auth-task-card.txt
- docs/task-cards/S2-59_desktop-signed-in-shell-navigation-task-card.txt
- docs/task-cards/S2-60_desktop-upload-section-file-selection-placeholder-task-card.txt
- docs/task-cards/S2-61_desktop-upload-file-picker-boundary-task-card.txt
- docs/task-cards/S2-62_desktop-upload-sha256-boundary-task-card.txt
- docs/task-cards/S2-63_desktop-upload-business-object-key-placeholder-task-card.txt
- docs/task-cards/S2-64_desktop-preuploadcheck-request-preview-task-card.txt
- docs/task-cards/S2-65_desktop-direct-site-upload-boundary-task-card.txt

## Contracts
None. No backend DTO, shared contract, or App.Api contract changes.

## Migrations
None.

## Feature flags/env guard
Uses existing visual-smoke guards plus new `AA_DESKTOP_DEV_FAKE_UPLOAD_RECEIPT_ENABLED=true` for fake UploadReceipt only. Disabled by default and DEBUG/dev-test guarded through App.Desktop options.

## API impact
No real App.Api UploadReceipt call. No server receipt creation. App.Api remains control plane.

## Web impact
None. App.Web unchanged.

## Android impact
None. App.Mobile.Android unchanged.

## Offline behavior
None.

## Rollback
Revert S2-66 PR.

## Validation
- `git diff --check` passed.
- `dotnet restore AnalyticsAutomation-Core.sln -nologo` passed.
- `dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore` passed after whitespace format.
- `dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal` passed, 0 warnings/errors.
- `dotnet build AnalyticsAutomation-Core.sln -nologo -v minimal` passed, 0 errors; existing unrelated warnings remain in non-S2-66 projects.
- `dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal` passed: 142/142.
- Hidden/control Unicode scan passed for 13 changed text files.

## Visual smoke screenshot folder/files
Folder: `C:\CODEX\Temp\S2-66_DESKTOP_UPLOAD_RECEIPT_VISUAL_SMOKE_20260501_121133\`
- `01_baseline_signin.png`
- `02_signed_in_shell.png`
- `03_upload_section_after_fake_site_upload_success.png`
- `04_upload_receipt_request_preview.png`
- `05_after_fake_upload_receipt_accepted.png`
- `06_after_sign_out.png`

## Handoff docs/task card
- `docs/task-cards/S2-66_desktop-upload-receipt-boundary-task-card.txt`

## Next step
Approved later slice: real control-plane App.Api UploadReceipt client after request/DTO reuse and backend binding are agreed.

## NO-GO / Deferred
- No real App.Api UploadReceipt call.
- No server receipt creation.
- No backend DTO/contracts/migrations/deploy.
- No real site upload, no video byte send, no App.Api upload.
- No offline queue, GroupTree runtime, or report draft runtime.
- No App.Web/App.Mobile.Android changes.
- Screenshots/runtime artifacts are not committed.
- No real credentials, secrets, tokens, passwords, Authorization headers, raw session ids, raw response bodies, or full local paths are logged or shown.