### PR TITLE
S2-67 desktop group tree selection placeholder

### DIFF
--- a/docs/task-cards/S2-67_desktop-group-tree-selection-placeholder-task-card.txt
+++ b/docs/task-cards/S2-67_desktop-group-tree-selection-placeholder-task-card.txt
@@ -1,0 +1,147 @@
+Title:
+S2-67 Desktop Group Tree Selection Placeholder / Fake Group Context Boundary
+
+Module:
+App.Desktop / GroupTree selection placeholder
+
+Owner:
+Coder 1 acting as Coder 2 / Desktop Client
+
+Client form:
+desktop standalone
+
+Type:
+narrow runtime desktop UI slice after S2-66 upload receipt fake/dev chain
+
+Status:
+Runtime task card created with implementation.
+
+Goal:
+Activate the signed-in "Группы" desktop section, add an App.Desktop-local fake/dev GroupTree boundary for visual smoke, allow selecting a safe fake group node, and show that selected group context in the upload section as preview-only upload context.
+
+Context:
+S2-58 added the debug-only fake-auth visual-smoke harness.
+S2-59 added the Russian signed-in shell and navigation placeholders.
+S2-60 through S2-66 built the desktop upload dev-smoke chain for file selection, SHA-256, temporary businessObjectKey, fake PreUploadCheck, fake direct site upload, and fake UploadReceipt.
+The architectural upload flow still includes GroupTree before upload context:
+SignIn -> GroupTree -> file select -> SHA-256 -> businessObjectKey -> PreUploadCheck -> direct site upload -> UploadReceipt.
+
+Scope:
+- Keep the current Russian SignIn UI before authentication.
+- After fake-auth SignIn, show the signed-in shell.
+- Make the "Группы" card an active navigation entry.
+- Show the "Группы" section title and deferred App.Api integration note.
+- Add an App.Desktop-local IDesktopGroupTreeClient boundary.
+- Keep the fake/dev GroupTree disabled by default.
+- Enable fake/dev GroupTree only with AA_DESKTOP_DEV_FAKE_GROUP_TREE_ENABLED=true.
+- Show fake nodes only when the env guard is enabled:
+  - root / Вся организация
+  - branch-001 / Тестовая ветка
+  - site-001 / Тестовый объект
+- Allow selecting site-001 and show:
+  - "Выбрана группа: Тестовый объект"
+  - safe key/id preview site-001
+- Provide a safe continue action from the selected fake group preview to the upload section without treating the fake group as production truth.
+- Show selected group context in the upload section as preview-only:
+  - "Контекст группы"
+  - "Тестовый объект"
+  - site-001
+- If no group is selected, show:
+  - "Группа не выбрана. Для production-flow выбор группы будет обязательным в отдельном slice."
+- Back/sign-out clear selected group state.
+
+Allowed changed areas:
+- docs/task-cards/S2-67_desktop-group-tree-selection-placeholder-task-card.txt
+- src/App.Desktop/**
+- tests/Unit/App.Desktop.Tests/**
+
+Forbidden changed areas:
+- src/App.Api/**
+- src/App.Worker/**
+- src/App.Web/**
+- src/App.Mobile.Android/**
+- src/App.UI.Shared/**
+- src/BuildingBlocks.Contracts/**
+- src/Modules/**
+- DB migrations
+- .github/workflows/**
+- deploy scripts
+- docs/ops/**
+- committed screenshots or runtime artifacts
+
+Contracts:
+none
+
+Migrations:
+none
+
+Feature flags/env guard:
+AA_DESKTOP_DEV_FAKE_GROUP_TREE_ENABLED=true for visual smoke only.
+
+Events:
+none
+
+Offline behavior:
+none
+
+Security guardrails:
+- Do not call App.Api for GroupTree in S2-67.
+- Do not add backend DTOs, shared contracts, API routes, migrations, deploy changes, App.Web changes, or App.Mobile.Android changes.
+- Do not claim fake group node ids are a production source of truth.
+- Do not display or log password, accessToken, refreshToken, Authorization, raw session id, raw response body, token-like values, or full local paths.
+- Screenshots and runtime artifacts stay under C:\CODEX\Temp and are not committed.
+
+Deferred:
+Real App.Api GroupTree integration is not implemented in S2-67. The real control-plane GroupTree client remains a separate approved slice.
+
+Rollback:
+revert S2-67 PR
+
+Validation:
+- git diff --check
+- dotnet restore AnalyticsAutomation-Core.sln -nologo
+- dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore
+- dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal
+- dotnet build AnalyticsAutomation-Core.sln -nologo -v minimal
+- dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal
+- hidden/control Unicode scan over changed text files
+- App.Desktop fake-auth/fake-group-tree/fake-upload-chain visual smoke with screenshots
+
+Definition of done:
+- The "Группы" card is active after successful SignIn.
+- Fake GroupTree is disabled by default.
+- Fake GroupTree is enabled only by AA_DESKTOP_DEV_FAKE_GROUP_TREE_ENABLED=true in debug/dev-test visual smoke.
+- Disabled GroupTree shows the safe deferred message and makes no App.Api call.
+- Enabled fake GroupTree shows root, branch-001, and site-001 with safe Russian labels.
+- Selecting site-001 shows the safe selected group preview.
+- Upload section shows the selected group context as preview-only.
+- Upload section shows the safe missing-group message when no group is selected.
+- Back/sign-out clear selected group state.
+- No PreUploadCheck, site upload, or UploadReceipt behavior changes beyond the existing fake/dev chain.
+- Automated App.Desktop tests cover env guard behavior, fake nodes, selection preview, upload group context, reset behavior, forbidden call patterns, and visible-string safety.
+- Required visual-smoke screenshots are saved under C:\CODEX\Temp and kept out of git.
+
+Visual-smoke definition of done:
+- Run App.Desktop with:
+  AA_DESKTOP_DEV_FAKE_AUTH_ENABLED=true
+  AA_DESKTOP_DEV_FAKE_GROUP_TREE_ENABLED=true
+  AA_DESKTOP_DEV_FAKE_UPLOAD_FILE_ENABLED=true
+  AA_DESKTOP_DEV_FAKE_UPLOAD_HASH_ENABLED=true
+  AA_DESKTOP_DEV_FAKE_BUSINESS_OBJECT_KEY_ENABLED=true
+  AA_DESKTOP_DEV_FAKE_PREUPLOAD_CHECK_ENABLED=true
+  AA_DESKTOP_DEV_FAKE_SITE_UPLOAD_ENABLED=true
+  AA_DESKTOP_DEV_FAKE_UPLOAD_RECEIPT_ENABLED=true
+- Do not set AA_DESKTOP_CONTROL_PLANE_BASE_ADDRESS.
+- Use non-secret fake-auth visual-smoke data:
+  - login: visual-smoke-user
+  - password: visual-smoke-password
+- Capture screenshots under C:\CODEX\Temp\S2-67_DESKTOP_GROUP_TREE_SELECTION_VISUAL_SMOKE_<timestamp>\.
+- Required screenshots:
+  - 01_baseline_signin.png
+  - 02_signed_in_shell.png
+  - 03_group_tree_fake_nodes.png
+  - 04_after_fake_group_selected.png
+  - 05_upload_section_with_group_context.png
+  - 06_after_sign_out.png
+- Confirm no password, accessToken, refreshToken, Authorization, raw session id, raw response body, raw path, or real secret is visible.
+- Confirm screenshots and runtime artifacts are not committed.

--- a/src/App.Desktop/Boundaries/DesktopGroupTreeBoundary.cs
+++ b/src/App.Desktop/Boundaries/DesktopGroupTreeBoundary.cs
@@ -1,0 +1,115 @@
+namespace App.Desktop.Boundaries;
+
+public interface IDesktopGroupTreeClient
+{
+    ValueTask<DesktopGroupTreeLoadResult> GetGroupTreeAsync(CancellationToken cancellationToken);
+}
+
+public static class DesktopGroupTreeText
+{
+    public const string Title = "Группы";
+    public const string Description =
+        "Раздел подготовлен. Реальная загрузка дерева групп из App.Api будет добавлена отдельным approved slice.";
+    public const string NavigationCardMessage = "Открыть безопасный preview выбора группы.";
+    public const string DisabledMessage =
+        "Дерево групп пока доступно только в dev-smoke режиме. Реальный вызов App.Api будет добавлен отдельным approved slice.";
+    public const string LoadingMessage = "Загружается desktop-local dev-smoke дерево групп.";
+    public const string LoadedMessage = "Dev-smoke дерево групп загружено из desktop-local fake boundary.";
+    public const string SelectionUnavailableMessage = "Выберите доступный dev-smoke узел группы.";
+    public const string BackToWorkspaceButton = "Назад к рабочей области";
+    public const string SelectGroupButton = "Выбрать";
+    public const string ContinueToUploadButton = "Перейти к загрузке видео";
+    public const string GroupIdLabel = "safe key/id preview";
+
+    public static string CreateSelectedGroupMessage(string displayName)
+    {
+        return $"Выбрана группа: {displayName}";
+    }
+}
+
+public sealed record DesktopGroupTreeNode(
+    string Id,
+    string DisplayName,
+    int Depth,
+    bool CanSelect)
+{
+    public const string RootId = "root";
+    public const string RootDisplayName = "Вся организация";
+    public const string BranchId = "branch-001";
+    public const string BranchDisplayName = "Тестовая ветка";
+    public const string SiteId = "site-001";
+    public const string SiteDisplayName = "Тестовый объект";
+
+    public static IReadOnlyList<DesktopGroupTreeNode> VisualSmokeNodes { get; } =
+    [
+        new(RootId, RootDisplayName, Depth: 0, CanSelect: false),
+        new(BranchId, BranchDisplayName, Depth: 1, CanSelect: false),
+        new(SiteId, SiteDisplayName, Depth: 2, CanSelect: true)
+    ];
+
+    public string Preview => $"{Id} / {DisplayName}";
+}
+
+public sealed record DesktopSelectedGroupContext(
+    string Id,
+    string DisplayName)
+{
+    public string SelectedGroupMessage => DesktopGroupTreeText.CreateSelectedGroupMessage(DisplayName);
+
+    public override string ToString()
+    {
+        return $"{nameof(DesktopSelectedGroupContext)} {{ Id = {Id}, DisplayName = {DisplayName} }}";
+    }
+}
+
+public sealed class DesktopGroupTreeLoadResult
+{
+    private DesktopGroupTreeLoadResult(
+        DesktopGroupTreeLoadStatus status,
+        IReadOnlyList<DesktopGroupTreeNode> nodes,
+        string message)
+    {
+        Status = status;
+        Nodes = nodes;
+        Message = message;
+    }
+
+    public DesktopGroupTreeLoadStatus Status { get; }
+
+    public IReadOnlyList<DesktopGroupTreeNode> Nodes { get; }
+
+    public string Message { get; }
+
+    public static DesktopGroupTreeLoadResult Disabled { get; } = new(
+        DesktopGroupTreeLoadStatus.Disabled,
+        [],
+        DesktopGroupTreeText.DisabledMessage);
+
+    public static DesktopGroupTreeLoadResult Loaded(IReadOnlyList<DesktopGroupTreeNode> nodes)
+    {
+        ArgumentNullException.ThrowIfNull(nodes);
+
+        return new DesktopGroupTreeLoadResult(
+            DesktopGroupTreeLoadStatus.Loaded,
+            nodes,
+            DesktopGroupTreeText.LoadedMessage);
+    }
+
+    public static DesktopGroupTreeLoadResult Canceled { get; } = new(
+        DesktopGroupTreeLoadStatus.Canceled,
+        [],
+        DesktopGroupTreeText.SelectionUnavailableMessage);
+
+    public override string ToString()
+    {
+        return $"{nameof(DesktopGroupTreeLoadResult)} {{ Status = {Status}, NodeCount = {Nodes.Count}, "
+            + $"Message = {Message} }}";
+    }
+}
+
+public enum DesktopGroupTreeLoadStatus
+{
+    Disabled,
+    Loaded,
+    Canceled
+}

--- a/src/App.Desktop/Boundaries/DesktopSignInBoundary.cs
+++ b/src/App.Desktop/Boundaries/DesktopSignInBoundary.cs
@@ -100,7 +100,7 @@ public static class DesktopSignedInShellText
 
     public static IReadOnlyList<DesktopNavigationPlaceholderCard> NavigationCards { get; } =
     [
-        new("Группы", DeferredPlaceholderMessage),
+        new(DesktopGroupTreeText.Title, DesktopGroupTreeText.NavigationCardMessage, DesktopNavigationCardTarget.GroupTreeSection),
         new("Загрузка видео", DesktopUploadSectionText.NavigationCardMessage, DesktopNavigationCardTarget.UploadSection),
         new("Проверка перед загрузкой", DeferredPlaceholderMessage),
         new("Квитанции загрузки", DeferredPlaceholderMessage)
@@ -122,12 +122,14 @@ public sealed record DesktopNavigationPlaceholderCard(
 public enum DesktopNavigationCardTarget
 {
     Deferred,
+    GroupTreeSection,
     UploadSection
 }
 
 public enum DesktopWorkspaceSection
 {
     Workspace,
+    GroupTree,
     Upload
 }
 
@@ -137,6 +139,11 @@ public static class DesktopUploadSectionText
     public const string Description =
         "Этот раздел показывает безопасные сведения о выбранном видеофайле. Реальная загрузка будет включена в следующем approved desktop slice.";
     public const string NavigationCardMessage = "Открыть заготовку выбора видеофайла.";
+    public const string GroupContextTitle = "Контекст группы";
+    public const string GroupContextMissingMessage =
+        "Группа не выбрана. Для production-flow выбор группы будет обязательным в отдельном slice.";
+    public const string GroupContextNameLabel = "Группа";
+    public const string GroupContextIdLabel = "safe key/id preview";
     public const string StepOneTitle = "Шаг 1. Метаданные файла";
     public const string SelectVideoFileButton = "Выбрать видеофайл";
     public const string PlaceholderResult = "Выберите видеофайл для безопасного предпросмотра.";

--- a/src/App.Desktop/Components/DesktopShell.razor
+++ b/src/App.Desktop/Components/DesktopShell.razor
@@ -1,5 +1,6 @@
 @inject IBlazorWebViewHostBoundary BlazorHostBoundary
 @inject DesktopSignInViewModel SignInViewModel
+@inject DesktopGroupTreeViewModel GroupTreeViewModel
 @inject DesktopUploadSectionViewModel UploadSectionViewModel
 @using App.Desktop.Services.Upload
 @using Microsoft.AspNetCore.Components.Web
@@ -34,7 +35,71 @@
                     </button>
                 </div>
 
-                @if (UploadSectionViewModel.IsUploadSectionOpen)
+                @if (UploadSectionViewModel.IsGroupTreeSectionOpen)
+                {
+                    <section class="desktop-group-tree" aria-labelledby="desktop-group-tree-title">
+                        <div class="desktop-group-tree__heading">
+                            <div>
+                                <h2 id="desktop-group-tree-title">@DesktopGroupTreeText.Title</h2>
+                                <p>@DesktopGroupTreeText.Description</p>
+                            </div>
+
+                            <button
+                                class="desktop-group-tree__back"
+                                type="button"
+                                disabled="@SignInViewModel.IsBusy"
+                                @onclick="BackToWorkspace">
+                                @DesktopGroupTreeText.BackToWorkspaceButton
+                            </button>
+                        </div>
+
+                        <p class="desktop-group-tree__message" role="status" aria-live="polite">
+                            @GroupTreeViewModel.StatusMessage
+                        </p>
+
+                        @if (GroupTreeViewModel.HasSelectedGroup)
+                        {
+                            <p class="desktop-group-tree__selected-message">
+                                @GroupTreeViewModel.SelectedGroupMessage
+                            </p>
+
+                            <dl class="desktop-group-tree__selection">
+                                <div>
+                                    <dt>@DesktopGroupTreeText.GroupIdLabel</dt>
+                                    <dd>@GroupTreeViewModel.SelectedGroup?.Id</dd>
+                                </div>
+                            </dl>
+
+                            <button
+                                class="desktop-group-tree__continue"
+                                type="button"
+                                disabled="@SignInViewModel.IsBusy"
+                                @onclick="ContinueToUploadWithGroupContext">
+                                @DesktopGroupTreeText.ContinueToUploadButton
+                            </button>
+                        }
+
+                        @if (GroupTreeViewModel.HasNodes)
+                        {
+                            <ul class="desktop-group-tree__nodes" aria-label="@DesktopGroupTreeText.Title">
+                                @foreach (DesktopGroupTreeNode node in GroupTreeViewModel.Nodes)
+                                {
+                                    <li class="@GetGroupTreeNodeClass(node)">
+                                        <span class="desktop-group-tree__node-name">@node.Preview</span>
+                                        <button
+                                            class="desktop-group-tree__select"
+                                            type="button"
+                                            disabled="@(SignInViewModel.IsBusy || !node.CanSelect)"
+                                            @onclick="() => SelectGroup(node.Id)">
+                                            @DesktopGroupTreeText.SelectGroupButton
+                                        </button>
+                                    </li>
+                                }
+                            </ul>
+                        }
+                    </section>
+                }
+                else if (UploadSectionViewModel.IsUploadSectionOpen)
                 {
                     <section class="desktop-upload" aria-labelledby="desktop-upload-title">
                         <div class="desktop-upload__heading">
@@ -50,6 +115,30 @@
                                 @onclick="BackToWorkspace">
                                 @DesktopUploadSectionText.BackToWorkspaceButton
                             </button>
+                        </div>
+
+                        <div class="desktop-upload__group-context">
+                            <h3>@DesktopUploadSectionText.GroupContextTitle</h3>
+
+                            @if (UploadSectionViewModel.HasSelectedGroupContext)
+                            {
+                                <dl class="desktop-upload__group-context-preview">
+                                    <div>
+                                        <dt>@DesktopUploadSectionText.GroupContextNameLabel</dt>
+                                        <dd>@UploadSectionViewModel.SelectedGroupDisplayName</dd>
+                                    </div>
+                                    <div>
+                                        <dt>@DesktopUploadSectionText.GroupContextIdLabel</dt>
+                                        <dd>@UploadSectionViewModel.SelectedGroupId</dd>
+                                    </div>
+                                </dl>
+                            }
+                            else
+                            {
+                                <p class="desktop-upload__message" role="status" aria-live="polite">
+                                    @UploadSectionViewModel.GroupContextStatusMessage
+                                </p>
+                            }
                         </div>
 
                         <div class="desktop-upload__step">
@@ -406,7 +495,7 @@
                                 type="button"
                                 disabled="@IsNavigationCardDisabled(card)"
                                 aria-disabled="@IsNavigationCardDisabled(card)"
-                                @onclick="() => OpenNavigationCard(card)">
+                                @onclick="() => OpenNavigationCardAsync(card)">
                                 <span class="desktop-navigation-card__title">@card.Title</span>
                                 <span class="desktop-navigation-card__message">@card.Message</span>
                             </button>
@@ -506,15 +595,29 @@
         }
 
         await SignInViewModel.SignOutAsync(CancellationToken.None);
+        GroupTreeViewModel.ResetForBackOrSignOut();
         UploadSectionViewModel.ResetForSignedOutState();
 
         StateHasChanged();
     }
 
-    private void OpenNavigationCard(DesktopNavigationPlaceholderCard card)
+    private async Task OpenNavigationCardAsync(DesktopNavigationPlaceholderCard card)
     {
         if (IsNavigationCardDisabled(card))
         {
+            return;
+        }
+
+        if (card.Target == DesktopNavigationCardTarget.GroupTreeSection)
+        {
+            UploadSectionViewModel.OpenGroupTreeSection();
+            ValueTask<DesktopGroupTreeLoadResult> loadAttempt =
+                GroupTreeViewModel.LoadAsync(CancellationToken.None);
+            StateHasChanged();
+
+            await loadAttempt;
+
+            StateHasChanged();
             return;
         }
 
@@ -523,7 +626,21 @@
 
     private void BackToWorkspace()
     {
+        GroupTreeViewModel.ResetForBackOrSignOut();
         UploadSectionViewModel.BackToWorkspace();
+    }
+
+    private void SelectGroup(string groupId)
+    {
+        GroupTreeViewModel.SelectGroup(groupId);
+    }
+
+    private void ContinueToUploadWithGroupContext()
+    {
+        if (GroupTreeViewModel.HasSelectedGroup)
+        {
+            UploadSectionViewModel.OpenUploadSection();
+        }
     }
 
     private async Task SelectVideoFileAsync()
@@ -613,7 +730,7 @@
 
     private static bool IsNavigationCardDisabled(DesktopNavigationPlaceholderCard card)
     {
-        return card.Target != DesktopNavigationCardTarget.UploadSection;
+        return card.Target == DesktopNavigationCardTarget.Deferred;
     }
 
     private static string GetNavigationCardClass(DesktopNavigationPlaceholderCard card)
@@ -621,5 +738,12 @@
         return IsNavigationCardDisabled(card)
             ? "desktop-navigation-card"
             : "desktop-navigation-card desktop-navigation-card--active";
+    }
+
+    private static string GetGroupTreeNodeClass(DesktopGroupTreeNode node)
+    {
+        return node.CanSelect
+            ? "desktop-group-tree__node desktop-group-tree__node--selectable"
+            : "desktop-group-tree__node";
     }
 }

--- a/src/App.Desktop/Components/_Imports.razor
+++ b/src/App.Desktop/Components/_Imports.razor
@@ -1,4 +1,5 @@
 @using global::App.Desktop.Boundaries
 @using global::App.Desktop.Services.Auth
+@using global::App.Desktop.Services.GroupTree
 @using global::App.UI.Shared.Pages
 @using Microsoft.AspNetCore.Components

--- a/src/App.Desktop/Composition/DesktopCompositionRoot.cs
+++ b/src/App.Desktop/Composition/DesktopCompositionRoot.cs
@@ -2,6 +2,7 @@ using System.Net.Http;
 
 using App.Desktop.Boundaries;
 using App.Desktop.Services.Auth;
+using App.Desktop.Services.GroupTree;
 using App.Desktop.Services.Placeholders;
 using App.Desktop.Services.Upload;
 
@@ -20,7 +21,8 @@ public static class DesktopCompositionRoot
     {
         return BuildServices(
             DesktopAuthOptions.FromEnvironment(),
-            DesktopUploadSectionOptions.FromEnvironment());
+            DesktopUploadSectionOptions.FromEnvironment(),
+            DesktopGroupTreeOptions.FromEnvironment());
     }
 
     public static ServiceProvider BuildServices(DesktopAuthOptions authOptions)
@@ -32,8 +34,17 @@ public static class DesktopCompositionRoot
         DesktopAuthOptions authOptions,
         DesktopUploadSectionOptions uploadSectionOptions)
     {
+        return BuildServices(authOptions, uploadSectionOptions, DesktopGroupTreeOptions.Disabled);
+    }
+
+    public static ServiceProvider BuildServices(
+        DesktopAuthOptions authOptions,
+        DesktopUploadSectionOptions uploadSectionOptions,
+        DesktopGroupTreeOptions groupTreeOptions)
+    {
         ArgumentNullException.ThrowIfNull(authOptions);
         ArgumentNullException.ThrowIfNull(uploadSectionOptions);
+        ArgumentNullException.ThrowIfNull(groupTreeOptions);
 
         var services = new ServiceCollection();
 
@@ -44,9 +55,11 @@ public static class DesktopCompositionRoot
 
         services.AddSingleton(authOptions);
         services.AddSingleton(uploadSectionOptions);
+        services.AddSingleton(groupTreeOptions);
         services.AddSingleton<IDesktopShellLifecycle, PlaceholderDesktopShellLifecycle>();
         services.AddSingleton<IDesktopSessionStore, DisabledDesktopSessionStore>();
         services.AddSingleton<DesktopSessionState>();
+        services.AddSingleton<DesktopGroupSelectionState>();
         services.AddSingleton<IDesktopSessionState>(
             serviceProvider => serviceProvider.GetRequiredService<DesktopSessionState>());
         services.AddSingleton<IDesktopAuthSessionBoundary>(
@@ -70,8 +83,18 @@ public static class DesktopCompositionRoot
 
         services.AddSingleton<IDesktopSignInService, DesktopSignInService>();
         services.AddTransient<DesktopSignInViewModel>();
+        services.AddTransient<DesktopGroupTreeViewModel>();
         services.AddTransient<DesktopUploadSectionViewModel>();
         services.AddSingleton<ISecureSessionStorage, PlaceholderSecureSessionStorage>();
+        if (groupTreeOptions.IsDevFakeGroupTreeEnabled)
+        {
+            services.AddSingleton<IDesktopGroupTreeClient, FakeDesktopGroupTreeClient>();
+        }
+        else
+        {
+            services.AddSingleton<IDesktopGroupTreeClient, DisabledDesktopGroupTreeClient>();
+        }
+
         if (uploadSectionOptions.IsDevFakeUploadFileEnabled)
         {
             services.AddSingleton<IDesktopVideoFilePicker, FakeDesktopVideoFilePicker>();

--- a/src/App.Desktop/Services/GroupTree/DesktopGroupSelectionState.cs
+++ b/src/App.Desktop/Services/GroupTree/DesktopGroupSelectionState.cs
@@ -1,0 +1,103 @@
+using App.Desktop.Boundaries;
+
+namespace App.Desktop.Services.GroupTree;
+
+public sealed class DesktopGroupSelectionState
+{
+    public DesktopSelectedGroupContext? SelectedGroup { get; private set; }
+
+    public bool TrySelect(DesktopGroupTreeNode? node)
+    {
+        if (node?.CanSelect != true
+            || !TryCreateSafeId(node.Id, out string safeId)
+            || !TryCreateSafeDisplayName(node.DisplayName, out string safeDisplayName))
+        {
+            return false;
+        }
+
+        SelectedGroup = new DesktopSelectedGroupContext(safeId, safeDisplayName);
+        return true;
+    }
+
+    public void Clear()
+    {
+        SelectedGroup = null;
+    }
+
+    private static bool TryCreateSafeId(string? value, out string safeValue)
+    {
+        safeValue = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        string trimmed = value.Trim();
+        if (trimmed.Length > 80)
+        {
+            return false;
+        }
+
+        foreach (char character in trimmed)
+        {
+            if (!char.IsAsciiLetterOrDigit(character) && character is not '-' and not '_')
+            {
+                return false;
+            }
+        }
+
+        safeValue = trimmed;
+        return true;
+    }
+
+    private static bool TryCreateSafeDisplayName(string? value, out string safeValue)
+    {
+        safeValue = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        string trimmed = value.Trim();
+        if (trimmed.Length > 80)
+        {
+            return false;
+        }
+
+        foreach (char character in trimmed)
+        {
+            if (char.IsControl(character))
+            {
+                return false;
+            }
+        }
+
+        string lower = trimmed.ToLowerInvariant();
+        string[] blockedFragments =
+        [
+            "authorization",
+            "bearer",
+            "password",
+            "token",
+            "sessionid",
+            "session_id",
+            "access_token",
+            "refresh_token",
+            "accesstoken",
+            "refreshtoken"
+        ];
+
+        foreach (string blockedFragment in blockedFragments)
+        {
+            if (lower.Contains(blockedFragment, StringComparison.Ordinal))
+            {
+                return false;
+            }
+        }
+
+        safeValue = trimmed;
+        return true;
+    }
+}

--- a/src/App.Desktop/Services/GroupTree/DesktopGroupTreeOptions.cs
+++ b/src/App.Desktop/Services/GroupTree/DesktopGroupTreeOptions.cs
@@ -1,0 +1,48 @@
+namespace App.Desktop.Services.GroupTree;
+
+public sealed class DesktopGroupTreeOptions
+{
+    public const string DevFakeGroupTreeEnabledEnvironmentVariable =
+        "AA_DESKTOP_DEV_FAKE_GROUP_TREE_ENABLED";
+
+    private DesktopGroupTreeOptions(bool isDevFakeGroupTreeEnabled)
+    {
+        IsDevFakeGroupTreeEnabled = isDevFakeGroupTreeEnabled;
+    }
+
+    public static DesktopGroupTreeOptions Disabled { get; } = new(isDevFakeGroupTreeEnabled: false);
+
+#if DEBUG
+    public static DesktopGroupTreeOptions EnabledForDevFakeGroupTree { get; } = new(
+        isDevFakeGroupTreeEnabled: true);
+#else
+    public static DesktopGroupTreeOptions EnabledForDevFakeGroupTree => Disabled;
+#endif
+
+    public bool IsDevFakeGroupTreeEnabled { get; }
+
+    public static DesktopGroupTreeOptions FromEnvironment()
+    {
+        return FromEnvironmentValue(
+            Environment.GetEnvironmentVariable(DevFakeGroupTreeEnabledEnvironmentVariable));
+    }
+
+    public static DesktopGroupTreeOptions FromEnvironmentValue(string? devFakeGroupTreeEnabled)
+    {
+#if DEBUG
+        return new DesktopGroupTreeOptions(IsDevFakeGroupTreeEnabledValue(devFakeGroupTreeEnabled));
+#else
+        return Disabled;
+#endif
+    }
+
+    public override string ToString()
+    {
+        return $"{nameof(DesktopGroupTreeOptions)} {{ IsDevFakeGroupTreeEnabled = {IsDevFakeGroupTreeEnabled} }}";
+    }
+
+    private static bool IsDevFakeGroupTreeEnabledValue(string? value)
+    {
+        return string.Equals(value?.Trim(), "true", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/App.Desktop/Services/GroupTree/DesktopGroupTreeViewModel.cs
+++ b/src/App.Desktop/Services/GroupTree/DesktopGroupTreeViewModel.cs
@@ -1,0 +1,97 @@
+using App.Desktop.Boundaries;
+
+namespace App.Desktop.Services.GroupTree;
+
+public sealed class DesktopGroupTreeViewModel(
+    IDesktopGroupTreeClient groupTreeClient,
+    DesktopGroupTreeOptions groupTreeOptions,
+    DesktopGroupSelectionState groupSelectionState)
+{
+    private readonly IDesktopGroupTreeClient _groupTreeClient =
+        groupTreeClient ?? throw new ArgumentNullException(nameof(groupTreeClient));
+    private readonly DesktopGroupTreeOptions _groupTreeOptions =
+        groupTreeOptions ?? throw new ArgumentNullException(nameof(groupTreeOptions));
+    private readonly DesktopGroupSelectionState _groupSelectionState =
+        groupSelectionState ?? throw new ArgumentNullException(nameof(groupSelectionState));
+
+    public bool IsLoading { get; private set; }
+
+    public bool IsDevFakeGroupTreeEnabled => _groupTreeOptions.IsDevFakeGroupTreeEnabled;
+
+    public IReadOnlyList<DesktopGroupTreeNode> Nodes { get; private set; } = [];
+
+    public bool HasNodes => Nodes.Count > 0;
+
+    public DesktopSelectedGroupContext? SelectedGroup => _groupSelectionState.SelectedGroup;
+
+    public bool HasSelectedGroup => SelectedGroup is not null;
+
+    public string? SelectedGroupMessage => SelectedGroup?.SelectedGroupMessage;
+
+    public string StatusMessage { get; private set; } = DesktopGroupTreeText.Description;
+
+    public async ValueTask<DesktopGroupTreeLoadResult> LoadAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!IsDevFakeGroupTreeEnabled)
+        {
+            Nodes = [];
+            StatusMessage = DesktopGroupTreeText.DisabledMessage;
+            return DesktopGroupTreeLoadResult.Disabled;
+        }
+
+        IsLoading = true;
+        StatusMessage = DesktopGroupTreeText.LoadingMessage;
+
+        try
+        {
+            DesktopGroupTreeLoadResult result = await _groupTreeClient.GetGroupTreeAsync(cancellationToken);
+
+            Nodes = result.Status == DesktopGroupTreeLoadStatus.Loaded
+                ? result.Nodes
+                : [];
+            StatusMessage = result.Message;
+            return result;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            Nodes = [];
+            StatusMessage = DesktopGroupTreeText.SelectionUnavailableMessage;
+            return DesktopGroupTreeLoadResult.Canceled;
+        }
+        finally
+        {
+            IsLoading = false;
+        }
+    }
+
+    public DesktopSelectedGroupContext? SelectGroup(string groupId)
+    {
+        if (!IsDevFakeGroupTreeEnabled)
+        {
+            StatusMessage = DesktopGroupTreeText.DisabledMessage;
+            return null;
+        }
+
+        DesktopGroupTreeNode? node = Nodes.FirstOrDefault(
+            candidate => string.Equals(candidate.Id, groupId, StringComparison.Ordinal));
+
+        if (!_groupSelectionState.TrySelect(node))
+        {
+            StatusMessage = DesktopGroupTreeText.SelectionUnavailableMessage;
+            return null;
+        }
+
+        StatusMessage = DesktopGroupTreeText.LoadedMessage;
+        return _groupSelectionState.SelectedGroup;
+    }
+
+    public void ResetForBackOrSignOut()
+    {
+        IsLoading = false;
+        Nodes = [];
+        StatusMessage = DesktopGroupTreeText.Description;
+        _groupSelectionState.Clear();
+    }
+}

--- a/src/App.Desktop/Services/GroupTree/DisabledDesktopGroupTreeClient.cs
+++ b/src/App.Desktop/Services/GroupTree/DisabledDesktopGroupTreeClient.cs
@@ -1,0 +1,12 @@
+using App.Desktop.Boundaries;
+
+namespace App.Desktop.Services.GroupTree;
+
+public sealed class DisabledDesktopGroupTreeClient : IDesktopGroupTreeClient
+{
+    public ValueTask<DesktopGroupTreeLoadResult> GetGroupTreeAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return ValueTask.FromResult(DesktopGroupTreeLoadResult.Disabled);
+    }
+}

--- a/src/App.Desktop/Services/GroupTree/FakeDesktopGroupTreeClient.cs
+++ b/src/App.Desktop/Services/GroupTree/FakeDesktopGroupTreeClient.cs
@@ -1,0 +1,12 @@
+using App.Desktop.Boundaries;
+
+namespace App.Desktop.Services.GroupTree;
+
+public sealed class FakeDesktopGroupTreeClient : IDesktopGroupTreeClient
+{
+    public ValueTask<DesktopGroupTreeLoadResult> GetGroupTreeAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return ValueTask.FromResult(DesktopGroupTreeLoadResult.Loaded(DesktopGroupTreeNode.VisualSmokeNodes));
+    }
+}

--- a/src/App.Desktop/Services/Upload/DesktopUploadSectionViewModel.cs
+++ b/src/App.Desktop/Services/Upload/DesktopUploadSectionViewModel.cs
@@ -1,4 +1,5 @@
 using App.Desktop.Boundaries;
+using App.Desktop.Services.GroupTree;
 
 namespace App.Desktop.Services.Upload;
 
@@ -8,6 +9,7 @@ public sealed class DesktopUploadSectionViewModel(
     IDesktopPreUploadCheckClient preUploadCheckClient,
     IDesktopDirectSiteUploadClient directSiteUploadClient,
     IDesktopUploadReceiptClient uploadReceiptClient,
+    DesktopGroupSelectionState groupSelectionState,
     DesktopUploadSectionOptions uploadSectionOptions)
 {
     public DesktopUploadSectionViewModel(
@@ -19,6 +21,7 @@ public sealed class DesktopUploadSectionViewModel(
             new DisabledDesktopPreUploadCheckClient(),
             new DisabledDesktopDirectSiteUploadClient(),
             new DisabledDesktopUploadReceiptClient(),
+            new DesktopGroupSelectionState(),
             DesktopUploadSectionOptions.Disabled)
     {
     }
@@ -33,6 +36,7 @@ public sealed class DesktopUploadSectionViewModel(
             new DisabledDesktopPreUploadCheckClient(),
             new DisabledDesktopDirectSiteUploadClient(),
             new DisabledDesktopUploadReceiptClient(),
+            new DesktopGroupSelectionState(),
             uploadSectionOptions)
     {
     }
@@ -49,6 +53,25 @@ public sealed class DesktopUploadSectionViewModel(
             preUploadCheckClient,
             directSiteUploadClient,
             new DisabledDesktopUploadReceiptClient(),
+            new DesktopGroupSelectionState(),
+            uploadSectionOptions)
+    {
+    }
+
+    public DesktopUploadSectionViewModel(
+        IDesktopVideoFilePicker videoFilePicker,
+        IDesktopVideoHashService videoHashService,
+        IDesktopPreUploadCheckClient preUploadCheckClient,
+        IDesktopDirectSiteUploadClient directSiteUploadClient,
+        IDesktopUploadReceiptClient uploadReceiptClient,
+        DesktopUploadSectionOptions uploadSectionOptions)
+        : this(
+            videoFilePicker,
+            videoHashService,
+            preUploadCheckClient,
+            directSiteUploadClient,
+            uploadReceiptClient,
+            new DesktopGroupSelectionState(),
             uploadSectionOptions)
     {
     }
@@ -63,6 +86,8 @@ public sealed class DesktopUploadSectionViewModel(
         directSiteUploadClient ?? throw new ArgumentNullException(nameof(directSiteUploadClient));
     private readonly IDesktopUploadReceiptClient _uploadReceiptClient =
         uploadReceiptClient ?? throw new ArgumentNullException(nameof(uploadReceiptClient));
+    private readonly DesktopGroupSelectionState _groupSelectionState =
+        groupSelectionState ?? throw new ArgumentNullException(nameof(groupSelectionState));
     private readonly DesktopUploadSectionOptions _uploadSectionOptions =
         uploadSectionOptions ?? throw new ArgumentNullException(nameof(uploadSectionOptions));
 
@@ -71,6 +96,8 @@ public sealed class DesktopUploadSectionViewModel(
     public DesktopWorkspaceSection CurrentSection { get; private set; } = DesktopWorkspaceSection.Workspace;
 
     public bool IsUploadSectionOpen => CurrentSection == DesktopWorkspaceSection.Upload;
+
+    public bool IsGroupTreeSectionOpen => CurrentSection == DesktopWorkspaceSection.GroupTree;
 
     public bool IsSelectingFile { get; private set; }
 
@@ -83,6 +110,18 @@ public sealed class DesktopUploadSectionViewModel(
     public bool IsCreatingUploadReceipt { get; private set; }
 
     public bool CanCalculateHash => SelectedFile is not null && !IsSelectingFile && !IsHashing;
+
+    public DesktopSelectedGroupContext? SelectedGroupContext => _groupSelectionState.SelectedGroup;
+
+    public bool HasSelectedGroupContext => SelectedGroupContext is not null;
+
+    public string GroupContextStatusMessage => HasSelectedGroupContext
+        ? string.Empty
+        : DesktopUploadSectionText.GroupContextMissingMessage;
+
+    public string? SelectedGroupDisplayName => SelectedGroupContext?.DisplayName;
+
+    public string? SelectedGroupId => SelectedGroupContext?.Id;
 
     public DesktopUploadSelectedFile? SelectedFile { get; private set; }
 
@@ -192,16 +231,23 @@ public sealed class DesktopUploadSectionViewModel(
         CurrentSection = DesktopWorkspaceSection.Upload;
     }
 
+    public void OpenGroupTreeSection()
+    {
+        CurrentSection = DesktopWorkspaceSection.GroupTree;
+    }
+
     public void BackToWorkspace()
     {
         CurrentSection = DesktopWorkspaceSection.Workspace;
         ResetSelection();
+        _groupSelectionState.Clear();
     }
 
     public void ResetForSignedOutState()
     {
         CurrentSection = DesktopWorkspaceSection.Workspace;
         ResetSelection();
+        _groupSelectionState.Clear();
     }
 
     public async ValueTask<DesktopUploadSelectedFile?> SelectVideoFileAsync(CancellationToken cancellationToken)

--- a/src/App.Desktop/wwwroot/app.css
+++ b/src/App.Desktop/wwwroot/app.css
@@ -257,6 +257,16 @@ body {
     background: #ffffff;
 }
 
+.desktop-group-tree {
+    display: grid;
+    gap: 18px;
+    box-sizing: border-box;
+    padding: 22px;
+    border: 1px solid #d7dde5;
+    border-radius: 8px;
+    background: #ffffff;
+}
+
 .desktop-upload__heading {
     display: flex;
     align-items: start;
@@ -264,7 +274,20 @@ body {
     gap: 18px;
 }
 
+.desktop-group-tree__heading {
+    display: flex;
+    align-items: start;
+    justify-content: space-between;
+    gap: 18px;
+}
+
 .desktop-upload__heading h2 {
+    margin: 0;
+    font-size: 1.15rem;
+    font-weight: 650;
+}
+
+.desktop-group-tree__heading h2 {
     margin: 0;
     font-size: 1.15rem;
     font-weight: 650;
@@ -278,13 +301,37 @@ body {
     line-height: 1.45;
 }
 
+.desktop-group-tree__heading p {
+    max-width: 680px;
+    margin: 10px 0 0;
+    color: #52616f;
+    font-size: 0.94rem;
+    line-height: 1.45;
+}
+
+.desktop-group-tree__message,
+.desktop-group-tree__selected-message {
+    margin: 0;
+    color: #52616f;
+    font-size: 0.9rem;
+    font-weight: 600;
+    line-height: 1.4;
+}
+
+.desktop-group-tree__selected-message {
+    color: #17643c;
+}
+
 .desktop-upload__back,
+.desktop-group-tree__back,
 .desktop-upload__select,
 .desktop-upload__hash,
 .desktop-upload__key,
 .desktop-upload__preupload,
 .desktop-upload__site-upload,
-.desktop-upload__receipt {
+.desktop-upload__receipt,
+.desktop-group-tree__select,
+.desktop-group-tree__continue {
     min-height: 38px;
     padding: 0 16px;
     border-radius: 6px;
@@ -294,7 +341,8 @@ body {
     white-space: nowrap;
 }
 
-.desktop-upload__back {
+.desktop-upload__back,
+.desktop-group-tree__back {
     border: 1px solid #394756;
     background: #ffffff;
     color: #253241;
@@ -305,7 +353,9 @@ body {
 .desktop-upload__key,
 .desktop-upload__preupload,
 .desktop-upload__site-upload,
-.desktop-upload__receipt {
+.desktop-upload__receipt,
+.desktop-group-tree__select,
+.desktop-group-tree__continue {
     width: fit-content;
     border: 1px solid #18406b;
     background: #18406b;
@@ -313,12 +363,15 @@ body {
 }
 
 .desktop-upload__back:disabled,
+.desktop-group-tree__back:disabled,
 .desktop-upload__select:disabled,
 .desktop-upload__hash:disabled,
 .desktop-upload__key:disabled,
 .desktop-upload__preupload:disabled,
 .desktop-upload__site-upload:disabled,
-.desktop-upload__receipt:disabled {
+.desktop-upload__receipt:disabled,
+.desktop-group-tree__select:disabled,
+.desktop-group-tree__continue:disabled {
     color: #687789;
     border-color: #b9c3cf;
     background: #eef1f5;
@@ -328,6 +381,54 @@ body {
     border-color: #54708b;
     background: #ffffff;
     color: #253241;
+}
+
+.desktop-group-tree__nodes {
+    display: grid;
+    gap: 10px;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.desktop-group-tree__node {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 14px;
+    min-height: 54px;
+    padding: 12px;
+    border: 1px solid #d1d8e1;
+    border-radius: 8px;
+    background: #fbfcfe;
+}
+
+.desktop-group-tree__node--selectable {
+    border-color: #2f6f9f;
+    background: #f8fbff;
+}
+
+.desktop-group-tree__node-name {
+    color: #18212f;
+    font-size: 0.92rem;
+    font-weight: 650;
+    overflow-wrap: anywhere;
+}
+
+.desktop-upload__group-context {
+    display: grid;
+    gap: 12px;
+    padding: 18px;
+    border: 1px solid #d1d8e1;
+    border-radius: 8px;
+    background: #fbfcfe;
+}
+
+.desktop-upload__group-context h3 {
+    margin: 0;
+    color: #18212f;
+    font-size: 1rem;
+    font-weight: 700;
 }
 
 .desktop-upload__step {
@@ -390,6 +491,7 @@ body {
 
 .desktop-upload__selection,
 .desktop-upload__hash-result,
+.desktop-upload__group-context-preview,
 .desktop-upload__business-object-key,
 .desktop-upload__preupload-preview,
 .desktop-upload__preupload-decision,
@@ -401,6 +503,10 @@ body {
     grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 12px;
     margin: 4px 0 0;
+}
+
+.desktop-upload__group-context-preview {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 .desktop-upload__hash-result {
@@ -435,15 +541,24 @@ body {
     grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
+.desktop-group-tree__selection {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 12px;
+    margin: 0;
+}
+
 .desktop-upload__selection div,
 .desktop-upload__hash-result div,
+.desktop-upload__group-context-preview div,
 .desktop-upload__business-object-key div,
 .desktop-upload__preupload-preview div,
 .desktop-upload__preupload-decision div,
 .desktop-upload__site-upload-preview div,
 .desktop-upload__site-upload-result div,
 .desktop-upload__receipt-preview div,
-.desktop-upload__receipt-result div {
+.desktop-upload__receipt-result div,
+.desktop-group-tree__selection div {
     min-width: 0;
     padding: 12px;
     border: 1px solid #d7dde5;
@@ -453,13 +568,15 @@ body {
 
 .desktop-upload__selection dt,
 .desktop-upload__hash-result dt,
+.desktop-upload__group-context-preview dt,
 .desktop-upload__business-object-key dt,
 .desktop-upload__preupload-preview dt,
 .desktop-upload__preupload-decision dt,
 .desktop-upload__site-upload-preview dt,
 .desktop-upload__site-upload-result dt,
 .desktop-upload__receipt-preview dt,
-.desktop-upload__receipt-result dt {
+.desktop-upload__receipt-result dt,
+.desktop-group-tree__selection dt {
     margin: 0 0 4px;
     color: #52616f;
     font-size: 0.78rem;
@@ -468,13 +585,15 @@ body {
 
 .desktop-upload__selection dd,
 .desktop-upload__hash-result dd,
+.desktop-upload__group-context-preview dd,
 .desktop-upload__business-object-key dd,
 .desktop-upload__preupload-preview dd,
 .desktop-upload__preupload-decision dd,
 .desktop-upload__site-upload-preview dd,
 .desktop-upload__site-upload-result dd,
 .desktop-upload__receipt-preview dd,
-.desktop-upload__receipt-result dd {
+.desktop-upload__receipt-result dd,
+.desktop-group-tree__selection dd {
     margin: 0;
     color: #18212f;
     font-size: 0.9rem;
@@ -497,23 +616,28 @@ body {
         width: 100%;
     }
 
-    .desktop-upload__heading {
+    .desktop-upload__heading,
+    .desktop-group-tree__heading {
         align-items: stretch;
         flex-direction: column;
     }
 
     .desktop-upload__back,
+    .desktop-group-tree__back,
     .desktop-upload__select,
     .desktop-upload__hash,
     .desktop-upload__key,
     .desktop-upload__preupload,
     .desktop-upload__site-upload,
-    .desktop-upload__receipt {
+    .desktop-upload__receipt,
+    .desktop-group-tree__select,
+    .desktop-group-tree__continue {
         width: 100%;
     }
 
     .desktop-upload__selection,
     .desktop-upload__hash-result,
+    .desktop-upload__group-context-preview,
     .desktop-upload__business-object-key,
     .desktop-upload__preupload-preview,
     .desktop-upload__preupload-decision,
@@ -522,6 +646,11 @@ body {
     .desktop-upload__receipt-preview,
     .desktop-upload__receipt-result {
         grid-template-columns: 1fr;
+    }
+
+    .desktop-group-tree__node {
+        align-items: stretch;
+        flex-direction: column;
     }
 
     .desktop-upload__actions {

--- a/tests/Unit/App.Desktop.Tests/DesktopCompositionRootTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopCompositionRootTests.cs
@@ -1,6 +1,7 @@
 using App.Desktop.Boundaries;
 using App.Desktop.Composition;
 using App.Desktop.Services.Auth;
+using App.Desktop.Services.GroupTree;
 using App.Desktop.Services.Upload;
 
 using Microsoft.Extensions.DependencyInjection;
@@ -26,6 +27,9 @@ public sealed class DesktopCompositionRootTests
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeSiteUploadEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadReceiptEnabled);
+        Assert.False(services.GetRequiredService<DesktopGroupTreeOptions>().IsDevFakeGroupTreeEnabled);
+        Assert.IsType<DisabledDesktopGroupTreeClient>(services.GetRequiredService<IDesktopGroupTreeClient>());
+        Assert.IsType<DesktopGroupTreeViewModel>(services.GetRequiredService<DesktopGroupTreeViewModel>());
         Assert.IsType<WpfDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
         Assert.IsType<DesktopVideoHashService>(services.GetRequiredService<IDesktopVideoHashService>());
         Assert.IsType<DisabledDesktopPreUploadCheckClient>(
@@ -47,7 +51,8 @@ public sealed class DesktopCompositionRootTests
             .Set(DesktopUploadSectionOptions.DevFakeBusinessObjectKeyEnabledEnvironmentVariable, null)
             .Set(DesktopUploadSectionOptions.DevFakePreUploadCheckEnabledEnvironmentVariable, null)
             .Set(DesktopUploadSectionOptions.DevFakeSiteUploadEnabledEnvironmentVariable, null)
-            .Set(DesktopUploadSectionOptions.DevFakeUploadReceiptEnabledEnvironmentVariable, null);
+            .Set(DesktopUploadSectionOptions.DevFakeUploadReceiptEnabledEnvironmentVariable, null)
+            .Set(DesktopGroupTreeOptions.DevFakeGroupTreeEnabledEnvironmentVariable, null);
 
         using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
 
@@ -58,7 +63,9 @@ public sealed class DesktopCompositionRootTests
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeSiteUploadEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadReceiptEnabled);
+        Assert.False(services.GetRequiredService<DesktopGroupTreeOptions>().IsDevFakeGroupTreeEnabled);
         Assert.IsType<UnavailableDesktopAuthClient>(services.GetRequiredService<IDesktopAuthClient>());
+        Assert.IsType<DisabledDesktopGroupTreeClient>(services.GetRequiredService<IDesktopGroupTreeClient>());
         Assert.IsType<WpfDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
         Assert.IsType<DesktopVideoHashService>(services.GetRequiredService<IDesktopVideoHashService>());
         Assert.IsType<DisabledDesktopPreUploadCheckClient>(
@@ -370,11 +377,33 @@ public sealed class DesktopCompositionRootTests
     }
 
     [Fact]
-    public void EnvironmentOptionsEnableFakeUploadFileHashBusinessObjectKeyPreUploadCheckSiteUploadAndUploadReceiptTogetherForVisualSmoke()
+    public void EnvironmentOptionsEnableFakeGroupTreeOnlyWhenExplicitlyRequested()
+    {
+        using var environment = new EnvironmentVariableScope()
+            .Set(DesktopAuthOptions.ControlPlaneBaseAddressEnvironmentVariable, null)
+            .Set(DesktopAuthOptions.DevFakeAuthEnabledEnvironmentVariable, null)
+            .Set(DesktopGroupTreeOptions.DevFakeGroupTreeEnabledEnvironmentVariable, "true");
+
+        using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
+
+#if DEBUG
+        Assert.True(services.GetRequiredService<DesktopGroupTreeOptions>().IsDevFakeGroupTreeEnabled);
+        Assert.True(services.GetRequiredService<DesktopGroupTreeViewModel>().IsDevFakeGroupTreeEnabled);
+        Assert.IsType<FakeDesktopGroupTreeClient>(services.GetRequiredService<IDesktopGroupTreeClient>());
+#else
+        Assert.False(services.GetRequiredService<DesktopGroupTreeOptions>().IsDevFakeGroupTreeEnabled);
+        Assert.False(services.GetRequiredService<DesktopGroupTreeViewModel>().IsDevFakeGroupTreeEnabled);
+        Assert.IsType<DisabledDesktopGroupTreeClient>(services.GetRequiredService<IDesktopGroupTreeClient>());
+#endif
+    }
+
+    [Fact]
+    public void EnvironmentOptionsEnableFakeGroupTreeUploadFileHashBusinessObjectKeyPreUploadCheckSiteUploadAndUploadReceiptTogetherForVisualSmoke()
     {
         using var environment = new EnvironmentVariableScope()
             .Set(DesktopAuthOptions.ControlPlaneBaseAddressEnvironmentVariable, null)
             .Set(DesktopAuthOptions.DevFakeAuthEnabledEnvironmentVariable, "true")
+            .Set(DesktopGroupTreeOptions.DevFakeGroupTreeEnabledEnvironmentVariable, "true")
             .Set(DesktopUploadSectionOptions.DevFakeUploadFileEnabledEnvironmentVariable, "true")
             .Set(DesktopUploadSectionOptions.DevFakeUploadHashEnabledEnvironmentVariable, "true")
             .Set(DesktopUploadSectionOptions.DevFakeBusinessObjectKeyEnabledEnvironmentVariable, "true")
@@ -392,7 +421,9 @@ public sealed class DesktopCompositionRootTests
         Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
         Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeSiteUploadEnabled);
         Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadReceiptEnabled);
+        Assert.True(services.GetRequiredService<DesktopGroupTreeOptions>().IsDevFakeGroupTreeEnabled);
         Assert.IsType<FakeDesktopAuthClient>(services.GetRequiredService<IDesktopAuthClient>());
+        Assert.IsType<FakeDesktopGroupTreeClient>(services.GetRequiredService<IDesktopGroupTreeClient>());
         Assert.IsType<FakeDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
         Assert.IsType<FakeDesktopVideoHashService>(services.GetRequiredService<IDesktopVideoHashService>());
         Assert.True(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakeBusinessObjectKeyEnabled);
@@ -413,7 +444,9 @@ public sealed class DesktopCompositionRootTests
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeSiteUploadEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadReceiptEnabled);
+        Assert.False(services.GetRequiredService<DesktopGroupTreeOptions>().IsDevFakeGroupTreeEnabled);
         Assert.IsType<UnavailableDesktopAuthClient>(services.GetRequiredService<IDesktopAuthClient>());
+        Assert.IsType<DisabledDesktopGroupTreeClient>(services.GetRequiredService<IDesktopGroupTreeClient>());
         Assert.IsType<WpfDesktopVideoFilePicker>(services.GetRequiredService<IDesktopVideoFilePicker>());
         Assert.IsType<DesktopVideoHashService>(services.GetRequiredService<IDesktopVideoHashService>());
         Assert.IsType<DisabledDesktopPreUploadCheckClient>(

--- a/tests/Unit/App.Desktop.Tests/DesktopGroupTreeTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopGroupTreeTests.cs
@@ -1,0 +1,300 @@
+using App.Desktop.Boundaries;
+using App.Desktop.Services.GroupTree;
+using App.Desktop.Services.Upload;
+
+namespace App.Desktop.Tests;
+
+public sealed class DesktopGroupTreeTests
+{
+    [Fact]
+    public void FakeGroupTreeIsDisabledByDefault()
+    {
+        Assert.False(DesktopGroupTreeOptions.Disabled.IsDevFakeGroupTreeEnabled);
+        Assert.False(DesktopGroupTreeOptions.FromEnvironmentValue(null).IsDevFakeGroupTreeEnabled);
+        Assert.False(DesktopGroupTreeOptions.FromEnvironmentValue("false").IsDevFakeGroupTreeEnabled);
+        Assert.False(DesktopGroupTreeOptions.FromEnvironmentValue("1").IsDevFakeGroupTreeEnabled);
+    }
+
+    [Theory]
+    [InlineData("true")]
+    [InlineData(" TRUE ")]
+    public void FakeGroupTreeIsEnabledOnlyByExplicitTrueValue(string value)
+    {
+        DesktopGroupTreeOptions options = DesktopGroupTreeOptions.FromEnvironmentValue(value);
+
+#if DEBUG
+        Assert.True(options.IsDevFakeGroupTreeEnabled);
+#else
+        Assert.False(options.IsDevFakeGroupTreeEnabled);
+#endif
+    }
+
+    [Fact]
+    public async Task DisabledGroupTreeShowsSafeMessageAndDoesNotCallBoundary()
+    {
+        var client = new ThrowingDesktopGroupTreeClient();
+        var viewModel = new DesktopGroupTreeViewModel(
+            client,
+            DesktopGroupTreeOptions.Disabled,
+            new DesktopGroupSelectionState());
+
+        DesktopGroupTreeLoadResult result = await viewModel.LoadAsync(CancellationToken.None);
+
+        Assert.Equal(DesktopGroupTreeLoadStatus.Disabled, result.Status);
+        Assert.Empty(viewModel.Nodes);
+        Assert.Equal(DesktopGroupTreeText.DisabledMessage, viewModel.StatusMessage);
+        Assert.Equal(0, client.CallCount);
+    }
+
+    [Fact]
+    public async Task FakeGroupTreeNodesUseSafeRussianLabels()
+    {
+        DesktopGroupTreeLoadResult result =
+            await new FakeDesktopGroupTreeClient().GetGroupTreeAsync(CancellationToken.None);
+
+        Assert.Equal(DesktopGroupTreeLoadStatus.Loaded, result.Status);
+        Assert.Collection(
+            result.Nodes,
+            node => AssertNode(node, "root", "Вся организация", canSelect: false),
+            node => AssertNode(node, "branch-001", "Тестовая ветка", canSelect: false),
+            node => AssertNode(node, "site-001", "Тестовый объект", canSelect: true));
+    }
+
+    [Fact]
+    public async Task SelectingFakeSiteGroupShowsSafeSelectedPreview()
+    {
+        var viewModel = CreateEnabledViewModel();
+        _ = await viewModel.LoadAsync(CancellationToken.None);
+
+        DesktopSelectedGroupContext? selected = viewModel.SelectGroup("site-001");
+
+#if DEBUG
+        Assert.NotNull(selected);
+        Assert.Equal("site-001", selected.Id);
+        Assert.Equal("Тестовый объект", selected.DisplayName);
+        Assert.Equal("Выбрана группа: Тестовый объект", viewModel.SelectedGroupMessage);
+        Assert.Equal(DesktopGroupTreeText.LoadedMessage, viewModel.StatusMessage);
+#else
+        Assert.Null(selected);
+        Assert.False(viewModel.HasSelectedGroup);
+#endif
+    }
+
+    [Fact]
+    public void UploadSectionShowsSafeMissingGroupContextMessageWhenNotSelected()
+    {
+        var viewModel = CreateUploadViewModel(new DesktopGroupSelectionState());
+
+        Assert.False(viewModel.HasSelectedGroupContext);
+        Assert.Equal(DesktopUploadSectionText.GroupContextTitle, "Контекст группы");
+        Assert.Equal(
+            "Группа не выбрана. Для production-flow выбор группы будет обязательным в отдельном slice.",
+            viewModel.GroupContextStatusMessage);
+    }
+
+    [Fact]
+    public void UploadSectionShowsSelectedGroupContextWhenSelected()
+    {
+        var groupSelectionState = new DesktopGroupSelectionState();
+        Assert.True(groupSelectionState.TrySelect(DesktopGroupTreeNode.VisualSmokeNodes[2]));
+        var viewModel = CreateUploadViewModel(groupSelectionState);
+
+        Assert.True(viewModel.HasSelectedGroupContext);
+        Assert.Equal("Тестовый объект", viewModel.SelectedGroupDisplayName);
+        Assert.Equal("site-001", viewModel.SelectedGroupId);
+        Assert.Equal(string.Empty, viewModel.GroupContextStatusMessage);
+    }
+
+    [Fact]
+    public async Task SelectedGroupContextDoesNotChangeExistingFakeUploadChainPreviews()
+    {
+        var groupSelectionState = new DesktopGroupSelectionState();
+        Assert.True(groupSelectionState.TrySelect(DesktopGroupTreeNode.VisualSmokeNodes[2]));
+        var viewModel = new DesktopUploadSectionViewModel(
+            new FakeDesktopVideoFilePicker(),
+            new FakeDesktopVideoHashService(),
+            new FakeDesktopPreUploadCheckClient(),
+            new FakeDesktopDirectSiteUploadClient(),
+            new FakeDesktopUploadReceiptClient(),
+            groupSelectionState,
+            DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "false", "true", "true", "true"));
+
+        _ = await viewModel.SelectVideoFileAsync(CancellationToken.None);
+        _ = await viewModel.CalculateSha256Async(CancellationToken.None);
+        viewModel.BusinessObjectKeyInput = "report-draft-001";
+        _ = viewModel.ApplyBusinessObjectKey();
+
+        DesktopPreUploadCheckRequestPreview? preview = viewModel.PreUploadCheckRequestPreview;
+
+        Assert.NotNull(preview);
+        Assert.Equal("report-draft-001", preview.BusinessObjectKeyPreview);
+        Assert.DoesNotContain("site-001", preview.ToString(), StringComparison.Ordinal);
+
+        _ = await viewModel.CheckPreUploadAsync(CancellationToken.None);
+        _ = await viewModel.UploadToSiteAsync(CancellationToken.None);
+        _ = await viewModel.CreateUploadReceiptAsync(CancellationToken.None);
+
+#if DEBUG
+        Assert.Equal("ALLOW", viewModel.PreUploadCheckDecisionPreview);
+        Assert.Equal("SUCCESS", viewModel.SiteUploadStatusPreview);
+        Assert.Equal("ACCEPTED", viewModel.UploadReceiptStatusPreview);
+#else
+        Assert.Null(viewModel.PreUploadCheckDecisionPreview);
+        Assert.Null(viewModel.SiteUploadStatusPreview);
+        Assert.Null(viewModel.UploadReceiptStatusPreview);
+#endif
+    }
+
+    [Fact]
+    public void BackAndSignOutClearSelectedGroupState()
+    {
+        var groupSelectionState = new DesktopGroupSelectionState();
+        Assert.True(groupSelectionState.TrySelect(DesktopGroupTreeNode.VisualSmokeNodes[2]));
+        var viewModel = CreateUploadViewModel(groupSelectionState);
+
+        viewModel.BackToWorkspace();
+
+        Assert.Null(groupSelectionState.SelectedGroup);
+        Assert.False(viewModel.HasSelectedGroupContext);
+
+        Assert.True(groupSelectionState.TrySelect(DesktopGroupTreeNode.VisualSmokeNodes[2]));
+
+        viewModel.ResetForSignedOutState();
+
+        Assert.Null(groupSelectionState.SelectedGroup);
+        Assert.False(viewModel.HasSelectedGroupContext);
+    }
+
+    [Fact]
+    public void GroupTreeFilesDoNotIntroduceRealAppApiCalls()
+    {
+        string[] sourceFiles =
+        [
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Boundaries", "DesktopGroupTreeBoundary.cs"),
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "GroupTree", "DesktopGroupTreeOptions.cs"),
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "GroupTree", "DesktopGroupSelectionState.cs"),
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "GroupTree", "DesktopGroupTreeViewModel.cs"),
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "GroupTree", "DisabledDesktopGroupTreeClient.cs"),
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "GroupTree", "FakeDesktopGroupTreeClient.cs")
+        ];
+
+        foreach (string sourceFile in sourceFiles)
+        {
+            string source = File.ReadAllText(sourceFile);
+
+            Assert.DoesNotContain("HttpClient", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("IControlPlaneApiClient", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("RequestPreUploadCheckAsync", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("RecordUploadReceiptAsync", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("GetAsync", source, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("PostAsync", source, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("SendAsync", source, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    [Fact]
+    public void GroupTreeAndGroupContextVisualStringsDoNotExposeSecretsOrFullLocalPath()
+    {
+        var groupSelectionState = new DesktopGroupSelectionState();
+        Assert.True(groupSelectionState.TrySelect(DesktopGroupTreeNode.VisualSmokeNodes[2]));
+        string[] visibleStrings =
+        [
+            DesktopGroupTreeText.Title,
+            DesktopGroupTreeText.Description,
+            DesktopGroupTreeText.NavigationCardMessage,
+            DesktopGroupTreeText.DisabledMessage,
+            DesktopGroupTreeText.LoadingMessage,
+            DesktopGroupTreeText.LoadedMessage,
+            DesktopGroupTreeText.SelectionUnavailableMessage,
+            DesktopGroupTreeText.BackToWorkspaceButton,
+            DesktopGroupTreeText.SelectGroupButton,
+            DesktopGroupTreeText.ContinueToUploadButton,
+            DesktopGroupTreeText.GroupIdLabel,
+            DesktopGroupTreeText.CreateSelectedGroupMessage("Тестовый объект"),
+            DesktopGroupTreeNode.RootId,
+            DesktopGroupTreeNode.RootDisplayName,
+            DesktopGroupTreeNode.BranchId,
+            DesktopGroupTreeNode.BranchDisplayName,
+            DesktopGroupTreeNode.SiteId,
+            DesktopGroupTreeNode.SiteDisplayName,
+            groupSelectionState.SelectedGroup?.ToString() ?? string.Empty,
+            DesktopUploadSectionText.GroupContextTitle,
+            DesktopUploadSectionText.GroupContextMissingMessage,
+            DesktopUploadSectionText.GroupContextNameLabel,
+            DesktopUploadSectionText.GroupContextIdLabel
+        ];
+
+        foreach (string visibleString in visibleStrings)
+        {
+            Assert.DoesNotContain("password", visibleString, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("Authorization", visibleString, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("accessToken", visibleString, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("refreshToken", visibleString, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("session_id", visibleString, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("raw response", visibleString, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain(Path.GetTempPath(), visibleString, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain(@"\", visibleString, StringComparison.Ordinal);
+        }
+    }
+
+    private static DesktopGroupTreeViewModel CreateEnabledViewModel()
+    {
+        return new DesktopGroupTreeViewModel(
+            new FakeDesktopGroupTreeClient(),
+            DesktopGroupTreeOptions.EnabledForDevFakeGroupTree,
+            new DesktopGroupSelectionState());
+    }
+
+    private static DesktopUploadSectionViewModel CreateUploadViewModel(
+        DesktopGroupSelectionState groupSelectionState)
+    {
+        return new DesktopUploadSectionViewModel(
+            new FakeDesktopVideoFilePicker(),
+            new FakeDesktopVideoHashService(),
+            new DisabledDesktopPreUploadCheckClient(),
+            new DisabledDesktopDirectSiteUploadClient(),
+            new DisabledDesktopUploadReceiptClient(),
+            groupSelectionState,
+            DesktopUploadSectionOptions.Disabled);
+    }
+
+    private static void AssertNode(
+        DesktopGroupTreeNode node,
+        string expectedId,
+        string expectedDisplayName,
+        bool canSelect)
+    {
+        Assert.Equal(expectedId, node.Id);
+        Assert.Equal(expectedDisplayName, node.DisplayName);
+        Assert.Equal(canSelect, node.CanSelect);
+        Assert.DoesNotContain("password", node.Preview, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Authorization", node.Preview, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private sealed class ThrowingDesktopGroupTreeClient : IDesktopGroupTreeClient
+    {
+        public int CallCount { get; private set; }
+
+        public ValueTask<DesktopGroupTreeLoadResult> GetGroupTreeAsync(CancellationToken cancellationToken)
+        {
+            CallCount++;
+            throw new InvalidOperationException("Disabled fake GroupTree boundary should not be called.");
+        }
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "AnalyticsAutomation-Core.sln")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException("Repository root was not found.");
+    }
+}

--- a/tests/Unit/App.Desktop.Tests/DesktopSignInServiceTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopSignInServiceTests.cs
@@ -253,10 +253,17 @@ public sealed class DesktopSignInServiceTests
         Assert.Contains("@DesktopSignedInShellText.SignOutButton", markup, StringComparison.Ordinal);
         Assert.Contains("@onclick=\"SignOutAsync\"", markup, StringComparison.Ordinal);
         Assert.Contains("DesktopSignedInShellText.NavigationCards", markup, StringComparison.Ordinal);
-        Assert.Contains("@onclick=\"() => OpenNavigationCard(card)\"", markup, StringComparison.Ordinal);
+        Assert.Contains("@onclick=\"() => OpenNavigationCardAsync(card)\"", markup, StringComparison.Ordinal);
+        Assert.Contains("GroupTreeViewModel.LoadAsync(CancellationToken.None)", markup, StringComparison.Ordinal);
+        Assert.Contains("GroupTreeViewModel.SelectGroup(groupId)", markup, StringComparison.Ordinal);
+        Assert.Contains("ContinueToUploadWithGroupContext", markup, StringComparison.Ordinal);
         Assert.Contains("UploadSectionViewModel.OpenUploadSection()", markup, StringComparison.Ordinal);
+        Assert.Contains("UploadSectionViewModel.OpenGroupTreeSection()", markup, StringComparison.Ordinal);
+        Assert.Contains("GroupTreeViewModel.ResetForBackOrSignOut()", markup, StringComparison.Ordinal);
         Assert.Contains("UploadSectionViewModel.ResetForSignedOutState()", markup, StringComparison.Ordinal);
+        Assert.Contains("DesktopGroupTreeText.Title", markup, StringComparison.Ordinal);
         Assert.Contains("DesktopUploadSectionText.Title", markup, StringComparison.Ordinal);
+        Assert.Contains("DesktopUploadSectionText.GroupContextTitle", markup, StringComparison.Ordinal);
         Assert.Contains("DesktopUploadSectionText.SelectVideoFileButton", markup, StringComparison.Ordinal);
         Assert.Contains("DesktopUploadSectionText.BackToWorkspaceButton", markup, StringComparison.Ordinal);
         Assert.Contains("UploadSectionViewModel.SelectVideoFileAsync(CancellationToken.None)", markup, StringComparison.Ordinal);
@@ -292,7 +299,7 @@ public sealed class DesktopSignInServiceTests
 
         Assert.Collection(
             DesktopSignedInShellText.NavigationCards,
-            card => AssertPlaceholderCard(card, "Группы"),
+            card => AssertGroupTreeNavigationCard(card),
             card => AssertUploadNavigationCard(card),
             card => AssertPlaceholderCard(card, "Проверка перед загрузкой"),
             card => AssertPlaceholderCard(card, "Квитанции загрузки"));
@@ -704,6 +711,13 @@ public sealed class DesktopSignInServiceTests
         Assert.Equal(expectedTitle, card.Title);
         Assert.Equal(DesktopSignedInShellText.DeferredPlaceholderMessage, card.Message);
         Assert.Equal(DesktopNavigationCardTarget.Deferred, card.Target);
+    }
+
+    private static void AssertGroupTreeNavigationCard(DesktopNavigationPlaceholderCard card)
+    {
+        Assert.Equal(DesktopGroupTreeText.Title, card.Title);
+        Assert.Equal(DesktopGroupTreeText.NavigationCardMessage, card.Message);
+        Assert.Equal(DesktopNavigationCardTarget.GroupTreeSection, card.Target);
     }
 
     private static void AssertUploadNavigationCard(DesktopNavigationPlaceholderCard card)

--- a/tests/Unit/App.Desktop.Tests/DesktopUploadSectionTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopUploadSectionTests.cs
@@ -37,6 +37,12 @@ public sealed class DesktopUploadSectionTests
         Assert.Equal(
             "Этот раздел показывает безопасные сведения о выбранном видеофайле. Реальная загрузка будет включена в следующем approved desktop slice.",
             DesktopUploadSectionText.Description);
+        Assert.Equal("Контекст группы", DesktopUploadSectionText.GroupContextTitle);
+        Assert.Equal(
+            "Группа не выбрана. Для production-flow выбор группы будет обязательным в отдельном slice.",
+            DesktopUploadSectionText.GroupContextMissingMessage);
+        Assert.Equal("Группа", DesktopUploadSectionText.GroupContextNameLabel);
+        Assert.Equal("safe key/id preview", DesktopUploadSectionText.GroupContextIdLabel);
         Assert.Equal("Шаг 1. Метаданные файла", DesktopUploadSectionText.StepOneTitle);
         Assert.Equal("Выбрать видеофайл", DesktopUploadSectionText.SelectVideoFileButton);
         Assert.Equal(
@@ -1378,6 +1384,10 @@ public sealed class DesktopUploadSectionTests
             DesktopUploadSectionText.Title,
             DesktopUploadSectionText.Description,
             DesktopUploadSectionText.NavigationCardMessage,
+            DesktopUploadSectionText.GroupContextTitle,
+            DesktopUploadSectionText.GroupContextMissingMessage,
+            DesktopUploadSectionText.GroupContextNameLabel,
+            DesktopUploadSectionText.GroupContextIdLabel,
             DesktopUploadSectionText.StepOneTitle,
             DesktopUploadSectionText.SelectVideoFileButton,
             DesktopUploadSectionText.PlaceholderResult,


### PR DESCRIPTION
## Coder
Coder 1 acting as Coder 2 / Desktop Client

## Task ID S2-67
Desktop Group Tree Selection Placeholder / Fake Group Context Boundary

## PR head SHA
15a4fe5b14cdb381d9eae9450ca3e161edc78b59

## Module
App.Desktop / GroupTree selection placeholder

## Scope
Adds an App.Desktop-local dev-smoke GroupTree boundary and selected group context preview for the existing desktop signed-in shell and fake upload chain. This slice does not implement production GroupTree integration.

## Exact files changed
- docs/task-cards/S2-67_desktop-group-tree-selection-placeholder-task-card.txt
- src/App.Desktop/Boundaries/DesktopGroupTreeBoundary.cs
- src/App.Desktop/Boundaries/DesktopSignInBoundary.cs
- src/App.Desktop/Components/DesktopShell.razor
- src/App.Desktop/Components/_Imports.razor
- src/App.Desktop/Composition/DesktopCompositionRoot.cs
- src/App.Desktop/Services/GroupTree/DesktopGroupSelectionState.cs
- src/App.Desktop/Services/GroupTree/DesktopGroupTreeOptions.cs
- src/App.Desktop/Services/GroupTree/DesktopGroupTreeViewModel.cs
- src/App.Desktop/Services/GroupTree/DisabledDesktopGroupTreeClient.cs
- src/App.Desktop/Services/GroupTree/FakeDesktopGroupTreeClient.cs
- src/App.Desktop/Services/Upload/DesktopUploadSectionViewModel.cs
- src/App.Desktop/wwwroot/app.css
- tests/Unit/App.Desktop.Tests/DesktopCompositionRootTests.cs
- tests/Unit/App.Desktop.Tests/DesktopGroupTreeTests.cs
- tests/Unit/App.Desktop.Tests/DesktopSignInServiceTests.cs
- tests/Unit/App.Desktop.Tests/DesktopUploadSectionTests.cs

## Changed areas
- Desktop signed-in shell: the "Группы" card opens an active GroupTree section.
- App.Desktop-local GroupTree model, selection state, fake/dev boundary, and disabled-by-default options.
- Upload section: preview-only selected group context display.
- App.Desktop unit tests for guard behavior, fake nodes, safe selection preview, upload context preview, reset behavior, and no App.Api call introduction.
- Task card: docs/task-cards/S2-67_desktop-group-tree-selection-placeholder-task-card.txt

## Base main SHA
7e59b6c02b5dacef8b49b94f5ceeb676ac89bf7a

## Coordination log entries reviewed
Reviewed TEAM COORDINATION LOG issue #89 entries/comments for S2-58 through S2-66:
- #127 S2-58 fake auth visual smoke harness
- #128 S2-59 signed-in shell navigation placeholders
- #129 S2-60 upload file selection placeholder
- #130 S2-61 file picker boundary
- #131 S2-62 SHA-256 boundary
- #132 S2-63 businessObjectKey placeholder
- #133 S2-64 fake PreUploadCheck request preview
- #134 S2-65 fake direct site upload boundary
- #135 S2-66 fake UploadReceipt boundary

## Handoff/task cards reviewed
Reviewed desktop task cards S2-58, S2-59, S2-60, S2-61, S2-62, S2-63, S2-64, S2-65, and S2-66.

## Fake group nodes
- root / Вся организация
- branch-001 / Тестовая ветка
- site-001 / Тестовый объект

## Contracts
None. No backend DTO or BuildingBlocks contract changes.

## Migrations
None.

## Feature flags/env guard
AA_DESKTOP_DEV_FAKE_GROUP_TREE_ENABLED=true enables fake GroupTree nodes for visual smoke only. The fake boundary is disabled by default.

## API impact
No real App.Api GroupTree call is implemented or introduced. No App.Api files changed.

## Web impact
None. App.Web was not changed.

## Android impact
None. App.Mobile.Android was not changed.

## Offline behavior
None.

## Rollback
Revert the S2-67 PR.

## Validation
- git diff --check passed.
- dotnet restore AnalyticsAutomation-Core.sln -nologo passed.
- dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore passed.
- dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal passed with 0 warnings/errors.
- dotnet build AnalyticsAutomation-Core.sln -nologo -v minimal passed; existing analyzer warnings remain in untouched modules.
- dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal passed: 155/155.
- Local hidden/control Unicode scan over changed text files passed.
- Remote hidden/control Unicode scan over PR files through GitHub Git Blob API passed.
- Allowed-scope check passed.
- App.Desktop fake-auth/fake-group-tree/fake-upload-chain visual smoke completed.

## Visual smoke screenshot folder/files
Folder: C:\CODEX\Temp\S2-67_DESKTOP_GROUP_TREE_SELECTION_VISUAL_SMOKE_20260501_142145

Files:
- 01_baseline_signin.png
- 02_signed_in_shell.png
- 03_group_tree_fake_nodes.png
- 04_after_fake_group_selected.png
- 05_upload_section_with_group_context.png
- 06_after_sign_out.png

Screenshots and runtime artifacts are not committed.

## Secret hygiene
No real credentials, secrets, tokens, Authorization values, passwords, raw session ids, raw response bodies, or full local paths were logged or added to visible UI output.

## Handoff docs/task card
- docs/task-cards/S2-67_desktop-group-tree-selection-placeholder-task-card.txt

## Next step
Implement the real approved control-plane GroupTree client integration in a separate slice.

## NO-GO / Deferred
- No production GroupTree integration.
- No real App.Api GroupTree call.
- No backend contracts, migrations, deploy changes, App.Web changes, or App.Mobile.Android changes.
- No real PreUploadCheck, direct site upload, or UploadReceipt behavior changes beyond the existing fake/dev upload chain.
- No video bytes are read or sent.