### PR TITLE
[codex] S2-68 Desktop GroupTree Control-Plane Client Probe

### DIFF
--- a/docs/task-cards/S2-68_desktop-group-tree-control-plane-client-probe-task-card.txt
+++ b/docs/task-cards/S2-68_desktop-group-tree-control-plane-client-probe-task-card.txt
@@ -1,0 +1,164 @@
+Title:
+S2-68 Desktop GroupTree Control-Plane Client Probe / Existing API Boundary
+
+Module:
+App.Desktop / GroupTree control-plane client probe
+
+Owner:
+Coder 1 acting as Coder 2 / Desktop Client
+
+Client form:
+desktop standalone
+
+Type:
+narrow runtime desktop-only client boundary slice after S2-67 fake GroupTree placeholder
+
+Status:
+Runtime task card created with implementation.
+
+Goal:
+Probe the existing App.Api / Modules.GroupTree / contracts surface read-only and, only because an existing approved endpoint was found, add an App.Desktop-local live GroupTree client boundary without backend, contract, migration, deploy, Web, or Android changes.
+
+Existing GroupTree API endpoint/contract found:
+Yes.
+
+Read-only sources inspected:
+- src/App.Api/Program.cs
+- src/Modules/GroupTree/GroupTreeModule.cs
+- src/BuildingBlocks/Contracts/Groups/GroupTreeFoundationDtos.cs
+- src/BuildingBlocks/Contracts/Groups/GroupTreeDtos.cs
+- tests/Integration/App.Api/AnonymousEndpointTests.cs
+- tests/Integration/App.Api/AuthenticatedEndpointTests.cs
+- tests/Integration/** references found by repository search
+
+Existing approved surface used:
+- GET /api/group-tree/nodes
+- Authorization: bearer session access token from existing desktop sign-in session
+- Response shape derived from existing code only:
+  GroupNodeFlatDto[] with groupNodeId, parentGroupNodeId, code, name, depth, isActive
+
+Scope:
+- Keep the current Russian SignIn UI before authentication.
+- After SignIn, keep the signed-in shell.
+- Preserve the S2-67 fake/dev GroupTree visual-smoke behavior.
+- Add HttpDesktopGroupTreeClient as an App.Desktop-local IDesktopGroupTreeClient implementation.
+- Select the live client only when AA_DESKTOP_CONTROL_PLANE_BASE_ADDRESS is configured.
+- Do not select fake GroupTree when a live base address is configured.
+- Keep selected group context preview-only for the upload section.
+- Clear selected group context on back/sign-out.
+
+Allowed changed areas:
+- docs/task-cards/S2-68_desktop-group-tree-control-plane-client-probe-task-card.txt
+- src/App.Desktop/**
+- tests/Unit/App.Desktop.Tests/**
+
+Forbidden changed areas:
+- src/App.Api/**
+- src/App.Worker/**
+- src/App.Web/**
+- src/App.Mobile.Android/**
+- src/App.UI.Shared/**
+- src/BuildingBlocks.Contracts/**
+- src/Modules/**
+- DB migrations
+- .github/workflows/**
+- deploy scripts
+- docs/ops/**
+- committed screenshots or runtime artifacts
+
+Contracts:
+none
+
+Migrations:
+none
+
+Feature flags/env guard:
+- Existing AA_DESKTOP_DEV_FAKE_GROUP_TREE_ENABLED=true keeps the fake/dev GroupTree visual-smoke path when no live control-plane base address is configured.
+- Existing AA_DESKTOP_CONTROL_PLANE_BASE_ADDRESS enables the live App.Api GroupTree client.
+- If AA_DESKTOP_CONTROL_PLANE_BASE_ADDRESS is configured, fake GroupTree is not selected even when AA_DESKTOP_DEV_FAKE_GROUP_TREE_ENABLED=true.
+- If AA_DESKTOP_CONTROL_PLANE_BASE_ADDRESS is absent and fake guard is off, GroupTree remains disabled/unavailable with a safe Russian message.
+
+Events:
+none
+
+Offline behavior:
+none
+
+Security guardrails:
+- Do not log or display accessToken, refreshToken, Authorization, password, raw session id, raw response body, token-like values, or full local paths.
+- The live client sends only the bearer access token in the request header and never includes it in result diagnostics.
+- The live client does not read or expose raw response bodies.
+- Unavailable, unauthorized, failed, or malformed responses produce safe Russian status messages.
+- Screenshots and runtime artifacts stay under C:\CODEX\Temp and are not committed.
+
+Explicitly out of scope:
+- App.Api changes.
+- Modules changes.
+- BuildingBlocks.Contracts changes.
+- Backend endpoint/DTO/contract additions.
+- DB migrations.
+- Deploy/workflow changes.
+- App.Web changes.
+- App.Mobile.Android changes.
+- Real PreUploadCheck changes.
+- Real direct site upload changes.
+- Real UploadReceipt changes.
+- Video bytes through App.Api.
+- Offline queue.
+- Report draft runtime.
+
+Deferred:
+No backend/API contract work is performed in S2-68. Further GroupTree production behavior beyond loading and preview-only desktop selection remains a later approved slice. Business object/report-draft binding and upload chain integration remain deferred.
+
+Rollback:
+revert S2-68 PR
+
+Validation:
+- git diff --check
+- dotnet restore AnalyticsAutomation-Core.sln -nologo
+- dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore
+- dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal
+- dotnet build AnalyticsAutomation-Core.sln -nologo -v minimal
+- dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal
+- hidden/control Unicode scan over changed text files
+- App.Desktop fake-auth/fake-group-tree/fake-upload-chain visual smoke with screenshots
+
+Definition of done:
+- Existing GroupTree API/contract is documented as found.
+- HttpDesktopGroupTreeClient uses only GET /api/group-tree/nodes and the existing GroupNodeFlatDto response shape.
+- Live GroupTree client requires AA_DESKTOP_CONTROL_PLANE_BASE_ADDRESS.
+- Fake GroupTree remains disabled by default and enabled only by AA_DESKTOP_DEV_FAKE_GROUP_TREE_ENABLED=true when live base address is absent.
+- Fake GroupTree is not selected when live base address is configured.
+- Disabled/no-base/no-fake state shows a safe Russian disabled message.
+- Live unavailable, failed, unauthorized, and malformed responses show safe Russian messages.
+- Tokens/passwords/Authorization/raw bodies/full local paths are not visible in UI/result diagnostics.
+- Selected group context remains preview-only in the upload section.
+- Back/sign-out clear selected group state.
+- No App.Api, contracts, migrations, deploy, App.Web, or App.Mobile.Android files are changed.
+- No real PreUploadCheck/site upload/UploadReceipt behavior changes are introduced beyond the existing fake/dev chain.
+- Automated App.Desktop unit tests cover guards, live endpoint request construction, safe failures, fake preservation, preview-only group context, reset behavior, forbidden upload-chain calls, and visible-string safety.
+
+Visual-smoke definition of done:
+- Run App.Desktop with:
+  AA_DESKTOP_DEV_FAKE_AUTH_ENABLED=true
+  AA_DESKTOP_DEV_FAKE_GROUP_TREE_ENABLED=true
+  AA_DESKTOP_DEV_FAKE_UPLOAD_FILE_ENABLED=true
+  AA_DESKTOP_DEV_FAKE_UPLOAD_HASH_ENABLED=true
+  AA_DESKTOP_DEV_FAKE_BUSINESS_OBJECT_KEY_ENABLED=true
+  AA_DESKTOP_DEV_FAKE_PREUPLOAD_CHECK_ENABLED=true
+  AA_DESKTOP_DEV_FAKE_SITE_UPLOAD_ENABLED=true
+  AA_DESKTOP_DEV_FAKE_UPLOAD_RECEIPT_ENABLED=true
+- Do not set AA_DESKTOP_CONTROL_PLANE_BASE_ADDRESS for fake-auth visual smoke.
+- Use non-secret fake-auth visual-smoke data:
+  login: visual-smoke-user
+  password: visual-smoke-password
+- Capture screenshots under C:\CODEX\Temp\S2-68_DESKTOP_GROUP_TREE_CLIENT_PROBE_VISUAL_SMOKE_<timestamp>\.
+- Required screenshots:
+  01_baseline_signin.png
+  02_signed_in_shell.png
+  03_group_tree_fake_nodes.png
+  04_after_fake_group_selected.png
+  05_upload_section_with_group_context.png
+  06_after_sign_out.png
+- Confirm no password, accessToken, refreshToken, Authorization, raw session id, raw response body, raw path, or real secret is visible.
+- Confirm screenshots and runtime artifacts are not committed.

--- a/src/App.Desktop/Boundaries/DesktopGroupTreeBoundary.cs
+++ b/src/App.Desktop/Boundaries/DesktopGroupTreeBoundary.cs
@@ -9,13 +9,23 @@ public static class DesktopGroupTreeText
 {
     public const string Title = "Группы";
     public const string Description =
-        "Раздел подготовлен. Реальная загрузка дерева групп из App.Api будет добавлена отдельным approved slice.";
+        "Раздел подготовлен. Dev-smoke дерево доступно локально, а live-режим использует существующий App.Api endpoint /api/group-tree/nodes.";
     public const string NavigationCardMessage = "Открыть безопасный preview выбора группы.";
     public const string DisabledMessage =
-        "Дерево групп пока доступно только в dev-smoke режиме. Реальный вызов App.Api будет добавлен отдельным approved slice.";
+        "Дерево групп недоступно: не задан live control-plane base address и dev-smoke guard выключен.";
     public const string LoadingMessage = "Загружается desktop-local dev-smoke дерево групп.";
+    public const string LiveLoadingMessage = "Загружается дерево групп из App.Api control plane.";
     public const string LoadedMessage = "Dev-smoke дерево групп загружено из desktop-local fake boundary.";
-    public const string SelectionUnavailableMessage = "Выберите доступный dev-smoke узел группы.";
+    public const string LiveLoadedMessage = "Дерево групп загружено из App.Api control plane.";
+    public const string LiveUnauthorizedMessage =
+        "Сессия не подтверждена для загрузки дерева групп. Выполните вход снова.";
+    public const string LiveUnavailableMessage =
+        "Дерево групп сейчас недоступно. Проверьте подключение и повторите попытку позже.";
+    public const string LiveFailedMessage =
+        "Не удалось загрузить дерево групп из App.Api. Подробности скрыты безопасно.";
+    public const string LiveMalformedMessage =
+        "App.Api вернул неподдерживаемый ответ дерева групп. Интеграция остановлена безопасно.";
+    public const string SelectionUnavailableMessage = "Выберите доступный узел группы.";
     public const string BackToWorkspaceButton = "Назад к рабочей области";
     public const string SelectGroupButton = "Выбрать";
     public const string ContinueToUploadButton = "Перейти к загрузке видео";
@@ -87,18 +97,46 @@ public sealed class DesktopGroupTreeLoadResult
 
     public static DesktopGroupTreeLoadResult Loaded(IReadOnlyList<DesktopGroupTreeNode> nodes)
     {
+        return Loaded(nodes, DesktopGroupTreeText.LoadedMessage);
+    }
+
+    public static DesktopGroupTreeLoadResult Loaded(
+        IReadOnlyList<DesktopGroupTreeNode> nodes,
+        string message)
+    {
         ArgumentNullException.ThrowIfNull(nodes);
+        ArgumentException.ThrowIfNullOrWhiteSpace(message);
 
         return new DesktopGroupTreeLoadResult(
             DesktopGroupTreeLoadStatus.Loaded,
             nodes,
-            DesktopGroupTreeText.LoadedMessage);
+            message);
     }
 
     public static DesktopGroupTreeLoadResult Canceled { get; } = new(
         DesktopGroupTreeLoadStatus.Canceled,
         [],
         DesktopGroupTreeText.SelectionUnavailableMessage);
+
+    public static DesktopGroupTreeLoadResult Unavailable(string message)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(message);
+
+        return new DesktopGroupTreeLoadResult(
+            DesktopGroupTreeLoadStatus.Unavailable,
+            [],
+            message);
+    }
+
+    public static DesktopGroupTreeLoadResult Failed(string message)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(message);
+
+        return new DesktopGroupTreeLoadResult(
+            DesktopGroupTreeLoadStatus.Failed,
+            [],
+            message);
+    }
 
     public override string ToString()
     {
@@ -111,5 +149,7 @@ public enum DesktopGroupTreeLoadStatus
 {
     Disabled,
     Loaded,
-    Canceled
+    Canceled,
+    Unavailable,
+    Failed
 }

--- a/src/App.Desktop/Boundaries/DesktopSessionBoundary.cs
+++ b/src/App.Desktop/Boundaries/DesktopSessionBoundary.cs
@@ -13,6 +13,12 @@ public interface IDesktopSessionState
     ValueTask<DesktopSessionSnapshot> SignOutAsync(CancellationToken cancellationToken);
 }
 
+public interface IDesktopControlPlaneAccessTokenProvider
+{
+    ValueTask<DesktopControlPlaneAccessTokenSnapshot> GetCurrentAccessTokenAsync(
+        CancellationToken cancellationToken);
+}
+
 public interface IDesktopSessionStore
 {
     ValueTask<DesktopStoredSession?> LoadAsync(CancellationToken cancellationToken);
@@ -67,6 +73,19 @@ public enum DesktopSessionStatus
 {
     SignedOut,
     SignedIn
+}
+
+public sealed record DesktopControlPlaneAccessTokenSnapshot(
+    bool IsAuthenticated,
+    string? AccessToken)
+{
+    public bool HasAccessToken => IsAuthenticated && !string.IsNullOrWhiteSpace(AccessToken);
+
+    public override string ToString()
+    {
+        return $"{nameof(DesktopControlPlaneAccessTokenSnapshot)} {{ IsAuthenticated = {IsAuthenticated}, "
+            + $"HasAccessToken = {HasAccessToken} }}";
+    }
 }
 
 public sealed class DesktopAuthenticatedSession

--- a/src/App.Desktop/Composition/DesktopCompositionRoot.cs
+++ b/src/App.Desktop/Composition/DesktopCompositionRoot.cs
@@ -19,22 +19,30 @@ public static class DesktopCompositionRoot
 
     public static ServiceProvider BuildServicesFromEnvironment()
     {
+        DesktopAuthOptions authOptions = DesktopAuthOptions.FromEnvironment();
+
         return BuildServices(
-            DesktopAuthOptions.FromEnvironment(),
+            authOptions,
             DesktopUploadSectionOptions.FromEnvironment(),
-            DesktopGroupTreeOptions.FromEnvironment());
+            DesktopGroupTreeOptions.FromAuthOptions(authOptions));
     }
 
     public static ServiceProvider BuildServices(DesktopAuthOptions authOptions)
     {
-        return BuildServices(authOptions, DesktopUploadSectionOptions.Disabled);
+        return BuildServices(
+            authOptions,
+            DesktopUploadSectionOptions.Disabled,
+            DesktopGroupTreeOptions.FromAuthOptions(authOptions, devFakeGroupTreeEnabled: null));
     }
 
     public static ServiceProvider BuildServices(
         DesktopAuthOptions authOptions,
         DesktopUploadSectionOptions uploadSectionOptions)
     {
-        return BuildServices(authOptions, uploadSectionOptions, DesktopGroupTreeOptions.Disabled);
+        return BuildServices(
+            authOptions,
+            uploadSectionOptions,
+            DesktopGroupTreeOptions.FromAuthOptions(authOptions, devFakeGroupTreeEnabled: null));
     }
 
     public static ServiceProvider BuildServices(
@@ -46,6 +54,10 @@ public static class DesktopCompositionRoot
         ArgumentNullException.ThrowIfNull(uploadSectionOptions);
         ArgumentNullException.ThrowIfNull(groupTreeOptions);
 
+        DesktopGroupTreeOptions effectiveGroupTreeOptions = authOptions.IsControlPlaneSignInConfigured
+            ? DesktopGroupTreeOptions.EnabledForLiveControlPlane
+            : groupTreeOptions;
+
         var services = new ServiceCollection();
 
         services.AddWpfBlazorWebView();
@@ -55,7 +67,7 @@ public static class DesktopCompositionRoot
 
         services.AddSingleton(authOptions);
         services.AddSingleton(uploadSectionOptions);
-        services.AddSingleton(groupTreeOptions);
+        services.AddSingleton(effectiveGroupTreeOptions);
         services.AddSingleton<IDesktopShellLifecycle, PlaceholderDesktopShellLifecycle>();
         services.AddSingleton<IDesktopSessionStore, DisabledDesktopSessionStore>();
         services.AddSingleton<DesktopSessionState>();
@@ -63,6 +75,8 @@ public static class DesktopCompositionRoot
         services.AddSingleton<IDesktopSessionState>(
             serviceProvider => serviceProvider.GetRequiredService<DesktopSessionState>());
         services.AddSingleton<IDesktopAuthSessionBoundary>(
+            serviceProvider => serviceProvider.GetRequiredService<DesktopSessionState>());
+        services.AddSingleton<IDesktopControlPlaneAccessTokenProvider>(
             serviceProvider => serviceProvider.GetRequiredService<DesktopSessionState>());
         if (authOptions.IsDevFakeAuthEnabled)
         {
@@ -86,7 +100,12 @@ public static class DesktopCompositionRoot
         services.AddTransient<DesktopGroupTreeViewModel>();
         services.AddTransient<DesktopUploadSectionViewModel>();
         services.AddSingleton<ISecureSessionStorage, PlaceholderSecureSessionStorage>();
-        if (groupTreeOptions.IsDevFakeGroupTreeEnabled)
+        if (effectiveGroupTreeOptions.IsLiveControlPlaneGroupTreeEnabled
+            && authOptions.IsControlPlaneSignInConfigured)
+        {
+            services.AddSingleton<IDesktopGroupTreeClient, HttpDesktopGroupTreeClient>();
+        }
+        else if (effectiveGroupTreeOptions.IsDevFakeGroupTreeEnabled)
         {
             services.AddSingleton<IDesktopGroupTreeClient, FakeDesktopGroupTreeClient>();
         }

--- a/src/App.Desktop/Services/Auth/DesktopSessionState.cs
+++ b/src/App.Desktop/Services/Auth/DesktopSessionState.cs
@@ -4,7 +4,8 @@ namespace App.Desktop.Services.Auth;
 
 public sealed class DesktopSessionState(IDesktopSessionStore sessionStore) :
     IDesktopSessionState,
-    IDesktopAuthSessionBoundary
+    IDesktopAuthSessionBoundary,
+    IDesktopControlPlaneAccessTokenProvider
 {
     private DesktopSessionSnapshot _current = DesktopSessionSnapshot.SignedOut;
     private DesktopAuthenticatedSession? _session;
@@ -69,6 +70,16 @@ public sealed class DesktopSessionState(IDesktopSessionStore sessionStore) :
         return ValueTask.FromResult(new DesktopAuthSessionSnapshot(
             _current.IsSignedIn,
             _current.DisplayName));
+    }
+
+    ValueTask<DesktopControlPlaneAccessTokenSnapshot> IDesktopControlPlaneAccessTokenProvider.GetCurrentAccessTokenAsync(
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return ValueTask.FromResult(new DesktopControlPlaneAccessTokenSnapshot(
+            _current.IsSignedIn,
+            _session?.AccessToken));
     }
 
     async ValueTask IDesktopAuthSessionBoundary.SignOutAsync(CancellationToken cancellationToken)

--- a/src/App.Desktop/Services/GroupTree/DesktopGroupTreeOptions.cs
+++ b/src/App.Desktop/Services/GroupTree/DesktopGroupTreeOptions.cs
@@ -1,44 +1,107 @@
+using App.Desktop.Services.Auth;
+
 namespace App.Desktop.Services.GroupTree;
 
 public sealed class DesktopGroupTreeOptions
 {
+    public const string ControlPlaneBaseAddressEnvironmentVariable =
+        DesktopAuthOptions.ControlPlaneBaseAddressEnvironmentVariable;
+
     public const string DevFakeGroupTreeEnabledEnvironmentVariable =
         "AA_DESKTOP_DEV_FAKE_GROUP_TREE_ENABLED";
 
-    private DesktopGroupTreeOptions(bool isDevFakeGroupTreeEnabled)
+    private DesktopGroupTreeOptions(
+        bool isLiveControlPlaneGroupTreeEnabled,
+        bool isDevFakeGroupTreeEnabled)
     {
+        IsLiveControlPlaneGroupTreeEnabled = isLiveControlPlaneGroupTreeEnabled;
         IsDevFakeGroupTreeEnabled = isDevFakeGroupTreeEnabled;
     }
 
-    public static DesktopGroupTreeOptions Disabled { get; } = new(isDevFakeGroupTreeEnabled: false);
+    public static DesktopGroupTreeOptions Disabled { get; } = new(
+        isLiveControlPlaneGroupTreeEnabled: false,
+        isDevFakeGroupTreeEnabled: false);
+
+    public static DesktopGroupTreeOptions EnabledForLiveControlPlane { get; } = new(
+        isLiveControlPlaneGroupTreeEnabled: true,
+        isDevFakeGroupTreeEnabled: false);
 
 #if DEBUG
     public static DesktopGroupTreeOptions EnabledForDevFakeGroupTree { get; } = new(
+        isLiveControlPlaneGroupTreeEnabled: false,
         isDevFakeGroupTreeEnabled: true);
 #else
     public static DesktopGroupTreeOptions EnabledForDevFakeGroupTree => Disabled;
 #endif
 
+    public bool IsLiveControlPlaneGroupTreeEnabled { get; }
+
     public bool IsDevFakeGroupTreeEnabled { get; }
+
+    public bool IsGroupTreeClientConfigured =>
+        IsLiveControlPlaneGroupTreeEnabled || IsDevFakeGroupTreeEnabled;
 
     public static DesktopGroupTreeOptions FromEnvironment()
     {
-        return FromEnvironmentValue(
+        return FromEnvironmentValues(
+            Environment.GetEnvironmentVariable(ControlPlaneBaseAddressEnvironmentVariable),
             Environment.GetEnvironmentVariable(DevFakeGroupTreeEnabledEnvironmentVariable));
     }
 
     public static DesktopGroupTreeOptions FromEnvironmentValue(string? devFakeGroupTreeEnabled)
     {
+        return FromEnvironmentValues(
+            controlPlaneBaseAddress: null,
+            devFakeGroupTreeEnabled);
+    }
+
+    public static DesktopGroupTreeOptions FromEnvironmentValues(
+        string? controlPlaneBaseAddress,
+        string? devFakeGroupTreeEnabled)
+    {
+        DesktopAuthOptions authOptions =
+            DesktopAuthOptions.FromControlPlaneBaseAddress(controlPlaneBaseAddress);
+
+        return FromAuthOptions(authOptions, devFakeGroupTreeEnabled);
+    }
+
+    public static DesktopGroupTreeOptions FromAuthOptions(DesktopAuthOptions authOptions)
+    {
+        ArgumentNullException.ThrowIfNull(authOptions);
+
+        return FromAuthOptions(
+            authOptions,
+            Environment.GetEnvironmentVariable(DevFakeGroupTreeEnabledEnvironmentVariable));
+    }
+
+    public static DesktopGroupTreeOptions FromAuthOptions(
+        DesktopAuthOptions authOptions,
+        string? devFakeGroupTreeEnabled)
+    {
+        ArgumentNullException.ThrowIfNull(authOptions);
+
+        if (authOptions.IsControlPlaneSignInConfigured)
+        {
+            return EnabledForLiveControlPlane;
+        }
+
 #if DEBUG
-        return new DesktopGroupTreeOptions(IsDevFakeGroupTreeEnabledValue(devFakeGroupTreeEnabled));
+        if (IsDevFakeGroupTreeEnabledValue(devFakeGroupTreeEnabled))
+        {
+            return EnabledForDevFakeGroupTree;
+        }
 #else
-        return Disabled;
+        _ = devFakeGroupTreeEnabled;
 #endif
+
+        return Disabled;
     }
 
     public override string ToString()
     {
-        return $"{nameof(DesktopGroupTreeOptions)} {{ IsDevFakeGroupTreeEnabled = {IsDevFakeGroupTreeEnabled} }}";
+        return $"{nameof(DesktopGroupTreeOptions)} {{ "
+            + $"IsLiveControlPlaneGroupTreeEnabled = {IsLiveControlPlaneGroupTreeEnabled}, "
+            + $"IsDevFakeGroupTreeEnabled = {IsDevFakeGroupTreeEnabled} }}";
     }
 
     private static bool IsDevFakeGroupTreeEnabledValue(string? value)

--- a/src/App.Desktop/Services/GroupTree/DesktopGroupTreeViewModel.cs
+++ b/src/App.Desktop/Services/GroupTree/DesktopGroupTreeViewModel.cs
@@ -18,6 +18,8 @@ public sealed class DesktopGroupTreeViewModel(
 
     public bool IsDevFakeGroupTreeEnabled => _groupTreeOptions.IsDevFakeGroupTreeEnabled;
 
+    public bool IsLiveControlPlaneGroupTreeEnabled => _groupTreeOptions.IsLiveControlPlaneGroupTreeEnabled;
+
     public IReadOnlyList<DesktopGroupTreeNode> Nodes { get; private set; } = [];
 
     public bool HasNodes => Nodes.Count > 0;
@@ -34,7 +36,7 @@ public sealed class DesktopGroupTreeViewModel(
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        if (!IsDevFakeGroupTreeEnabled)
+        if (!_groupTreeOptions.IsGroupTreeClientConfigured)
         {
             Nodes = [];
             StatusMessage = DesktopGroupTreeText.DisabledMessage;
@@ -42,7 +44,9 @@ public sealed class DesktopGroupTreeViewModel(
         }
 
         IsLoading = true;
-        StatusMessage = DesktopGroupTreeText.LoadingMessage;
+        StatusMessage = IsLiveControlPlaneGroupTreeEnabled
+            ? DesktopGroupTreeText.LiveLoadingMessage
+            : DesktopGroupTreeText.LoadingMessage;
 
         try
         {
@@ -68,7 +72,7 @@ public sealed class DesktopGroupTreeViewModel(
 
     public DesktopSelectedGroupContext? SelectGroup(string groupId)
     {
-        if (!IsDevFakeGroupTreeEnabled)
+        if (!_groupTreeOptions.IsGroupTreeClientConfigured)
         {
             StatusMessage = DesktopGroupTreeText.DisabledMessage;
             return null;

--- a/src/App.Desktop/Services/GroupTree/HttpDesktopGroupTreeClient.cs
+++ b/src/App.Desktop/Services/GroupTree/HttpDesktopGroupTreeClient.cs
@@ -1,0 +1,212 @@
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+using App.Desktop.Boundaries;
+
+namespace App.Desktop.Services.GroupTree;
+
+public sealed class HttpDesktopGroupTreeClient : IDesktopGroupTreeClient
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+    private const string SafeFallbackDisplayName = "Группа без безопасного имени";
+
+    private readonly HttpClient _httpClient;
+    private readonly IDesktopControlPlaneAccessTokenProvider _accessTokenProvider;
+    private readonly Uri _nodesEndpoint;
+
+    public HttpDesktopGroupTreeClient(
+        HttpClient httpClient,
+        IDesktopControlPlaneAccessTokenProvider accessTokenProvider)
+        : this(httpClient, accessTokenProvider, new Uri("/api/group-tree/nodes", UriKind.Relative))
+    {
+    }
+
+    public HttpDesktopGroupTreeClient(
+        HttpClient httpClient,
+        IDesktopControlPlaneAccessTokenProvider accessTokenProvider,
+        Uri nodesEndpoint)
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
+        ArgumentNullException.ThrowIfNull(accessTokenProvider);
+        ArgumentNullException.ThrowIfNull(nodesEndpoint);
+
+        _httpClient = httpClient;
+        _accessTokenProvider = accessTokenProvider;
+        _nodesEndpoint = nodesEndpoint;
+    }
+
+    public async ValueTask<DesktopGroupTreeLoadResult> GetGroupTreeAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        try
+        {
+            DesktopControlPlaneAccessTokenSnapshot accessToken =
+                await _accessTokenProvider.GetCurrentAccessTokenAsync(cancellationToken);
+
+            if (!accessToken.HasAccessToken)
+            {
+                return DesktopGroupTreeLoadResult.Unavailable(DesktopGroupTreeText.LiveUnauthorizedMessage);
+            }
+
+            using var request = new HttpRequestMessage(HttpMethod.Get, _nodesEndpoint);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken.AccessToken);
+
+            using HttpResponseMessage response = await _httpClient.SendAsync(
+                request,
+                HttpCompletionOption.ResponseHeadersRead,
+                cancellationToken);
+
+            if (response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
+            {
+                return DesktopGroupTreeLoadResult.Unavailable(DesktopGroupTreeText.LiveUnauthorizedMessage);
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                return DesktopGroupTreeLoadResult.Failed(DesktopGroupTreeText.LiveFailedMessage);
+            }
+
+            List<GroupNodeFlatPayload>? payload =
+                await response.Content.ReadFromJsonAsync<List<GroupNodeFlatPayload>>(JsonOptions, cancellationToken);
+
+            IReadOnlyList<DesktopGroupTreeNode>? nodes = TryMapNodes(payload);
+            if (nodes is null)
+            {
+                return DesktopGroupTreeLoadResult.Failed(DesktopGroupTreeText.LiveMalformedMessage);
+            }
+
+            return DesktopGroupTreeLoadResult.Loaded(nodes, DesktopGroupTreeText.LiveLoadedMessage);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            return DesktopGroupTreeLoadResult.Unavailable(DesktopGroupTreeText.LiveUnavailableMessage);
+        }
+        catch (HttpRequestException)
+        {
+            return DesktopGroupTreeLoadResult.Unavailable(DesktopGroupTreeText.LiveUnavailableMessage);
+        }
+        catch (InvalidOperationException)
+        {
+            return DesktopGroupTreeLoadResult.Unavailable(DesktopGroupTreeText.LiveUnavailableMessage);
+        }
+        catch (JsonException)
+        {
+            return DesktopGroupTreeLoadResult.Failed(DesktopGroupTreeText.LiveMalformedMessage);
+        }
+        catch (NotSupportedException)
+        {
+            return DesktopGroupTreeLoadResult.Failed(DesktopGroupTreeText.LiveMalformedMessage);
+        }
+    }
+
+    private static List<DesktopGroupTreeNode>? TryMapNodes(
+        IReadOnlyCollection<GroupNodeFlatPayload>? payload)
+    {
+        if (payload is null)
+        {
+            return null;
+        }
+
+        var parentNodeIds = payload
+            .Where(item => item.ParentGroupNodeId.HasValue)
+            .Select(item => item.ParentGroupNodeId!.Value)
+            .ToHashSet();
+
+        var nodes = new List<DesktopGroupTreeNode>(payload.Count);
+
+        foreach (GroupNodeFlatPayload item in payload
+            .OrderBy(item => item.Depth ?? int.MaxValue)
+            .ThenBy(item => item.Name, StringComparer.Ordinal))
+        {
+            if (item.GroupNodeId == Guid.Empty
+                || item.Depth is null or < 0 or > 64
+                || item.IsActive is null)
+            {
+                return null;
+            }
+
+            string displayName = TryCreateSafeDisplayName(item.Name, out string safeDisplayName)
+                ? safeDisplayName
+                : SafeFallbackDisplayName;
+
+            bool canSelect = item.IsActive.Value && !parentNodeIds.Contains(item.GroupNodeId);
+
+            nodes.Add(new DesktopGroupTreeNode(
+                item.GroupNodeId.ToString("D"),
+                displayName,
+                item.Depth.Value,
+                canSelect));
+        }
+
+        return nodes;
+    }
+
+    private static bool TryCreateSafeDisplayName(string? value, out string safeValue)
+    {
+        safeValue = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        string trimmed = value.Trim();
+        if (trimmed.Length > 80)
+        {
+            return false;
+        }
+
+        foreach (char character in trimmed)
+        {
+            if (char.IsControl(character))
+            {
+                return false;
+            }
+        }
+
+        string lower = trimmed.ToLowerInvariant();
+        string[] blockedFragments =
+        [
+            "authorization",
+            "bearer",
+            "password",
+            "token",
+            "sessionid",
+            "session_id",
+            "access_token",
+            "refresh_token",
+            "accesstoken",
+            "refreshtoken"
+        ];
+
+        foreach (string blockedFragment in blockedFragments)
+        {
+            if (lower.Contains(blockedFragment, StringComparison.Ordinal))
+            {
+                return false;
+            }
+        }
+
+        safeValue = trimmed;
+        return true;
+    }
+
+    private sealed class GroupNodeFlatPayload
+    {
+        public Guid GroupNodeId { get; init; }
+
+        public Guid? ParentGroupNodeId { get; init; }
+
+        public string? Code { get; init; }
+
+        public string? Name { get; init; }
+
+        public int? Depth { get; init; }
+
+        public bool? IsActive { get; init; }
+    }
+}

--- a/tests/Unit/App.Desktop.Tests/DesktopCompositionRootTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopCompositionRootTests.cs
@@ -27,6 +27,7 @@ public sealed class DesktopCompositionRootTests
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeSiteUploadEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadReceiptEnabled);
+        Assert.False(services.GetRequiredService<DesktopGroupTreeOptions>().IsLiveControlPlaneGroupTreeEnabled);
         Assert.False(services.GetRequiredService<DesktopGroupTreeOptions>().IsDevFakeGroupTreeEnabled);
         Assert.IsType<DisabledDesktopGroupTreeClient>(services.GetRequiredService<IDesktopGroupTreeClient>());
         Assert.IsType<DesktopGroupTreeViewModel>(services.GetRequiredService<DesktopGroupTreeViewModel>());
@@ -63,6 +64,7 @@ public sealed class DesktopCompositionRootTests
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeSiteUploadEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadReceiptEnabled);
+        Assert.False(services.GetRequiredService<DesktopGroupTreeOptions>().IsLiveControlPlaneGroupTreeEnabled);
         Assert.False(services.GetRequiredService<DesktopGroupTreeOptions>().IsDevFakeGroupTreeEnabled);
         Assert.IsType<UnavailableDesktopAuthClient>(services.GetRequiredService<IDesktopAuthClient>());
         Assert.IsType<DisabledDesktopGroupTreeClient>(services.GetRequiredService<IDesktopGroupTreeClient>());
@@ -387,10 +389,12 @@ public sealed class DesktopCompositionRootTests
         using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
 
 #if DEBUG
+        Assert.False(services.GetRequiredService<DesktopGroupTreeOptions>().IsLiveControlPlaneGroupTreeEnabled);
         Assert.True(services.GetRequiredService<DesktopGroupTreeOptions>().IsDevFakeGroupTreeEnabled);
         Assert.True(services.GetRequiredService<DesktopGroupTreeViewModel>().IsDevFakeGroupTreeEnabled);
         Assert.IsType<FakeDesktopGroupTreeClient>(services.GetRequiredService<IDesktopGroupTreeClient>());
 #else
+        Assert.False(services.GetRequiredService<DesktopGroupTreeOptions>().IsLiveControlPlaneGroupTreeEnabled);
         Assert.False(services.GetRequiredService<DesktopGroupTreeOptions>().IsDevFakeGroupTreeEnabled);
         Assert.False(services.GetRequiredService<DesktopGroupTreeViewModel>().IsDevFakeGroupTreeEnabled);
         Assert.IsType<DisabledDesktopGroupTreeClient>(services.GetRequiredService<IDesktopGroupTreeClient>());
@@ -421,6 +425,7 @@ public sealed class DesktopCompositionRootTests
         Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
         Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeSiteUploadEnabled);
         Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadReceiptEnabled);
+        Assert.False(services.GetRequiredService<DesktopGroupTreeOptions>().IsLiveControlPlaneGroupTreeEnabled);
         Assert.True(services.GetRequiredService<DesktopGroupTreeOptions>().IsDevFakeGroupTreeEnabled);
         Assert.IsType<FakeDesktopAuthClient>(services.GetRequiredService<IDesktopAuthClient>());
         Assert.IsType<FakeDesktopGroupTreeClient>(services.GetRequiredService<IDesktopGroupTreeClient>());
@@ -444,6 +449,7 @@ public sealed class DesktopCompositionRootTests
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeSiteUploadEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadReceiptEnabled);
+        Assert.False(services.GetRequiredService<DesktopGroupTreeOptions>().IsLiveControlPlaneGroupTreeEnabled);
         Assert.False(services.GetRequiredService<DesktopGroupTreeOptions>().IsDevFakeGroupTreeEnabled);
         Assert.IsType<UnavailableDesktopAuthClient>(services.GetRequiredService<IDesktopAuthClient>());
         Assert.IsType<DisabledDesktopGroupTreeClient>(services.GetRequiredService<IDesktopGroupTreeClient>());
@@ -465,8 +471,11 @@ public sealed class DesktopCompositionRootTests
             DesktopAuthOptions.FromControlPlaneBaseAddress("https://control-plane.local"));
 
         Assert.IsType<HttpDesktopAuthClient>(services.GetRequiredService<IDesktopAuthClient>());
+        Assert.IsType<HttpDesktopGroupTreeClient>(services.GetRequiredService<IDesktopGroupTreeClient>());
         Assert.IsType<DisabledDesktopSessionStore>(services.GetRequiredService<IDesktopSessionStore>());
         Assert.True(services.GetRequiredService<DesktopAuthOptions>().IsControlPlaneSignInConfigured);
+        Assert.True(services.GetRequiredService<DesktopGroupTreeOptions>().IsLiveControlPlaneGroupTreeEnabled);
+        Assert.False(services.GetRequiredService<DesktopGroupTreeOptions>().IsDevFakeGroupTreeEnabled);
         Assert.Equal(
             new Uri("https://control-plane.local"),
             services.GetRequiredService<HttpClient>().BaseAddress);
@@ -503,6 +512,39 @@ public sealed class DesktopCompositionRootTests
         Assert.Equal(
             new Uri("https://control-plane.local"),
             services.GetRequiredService<HttpClient>().BaseAddress);
+    }
+
+    [Fact]
+    public void ExplicitFakeGroupTreeFlagDoesNotReplaceConfiguredLiveGroupTreeClient()
+    {
+        using var environment = new EnvironmentVariableScope()
+            .Set(DesktopAuthOptions.ControlPlaneBaseAddressEnvironmentVariable, "https://control-plane.local")
+            .Set(DesktopAuthOptions.DevFakeAuthEnabledEnvironmentVariable, "true")
+            .Set(DesktopGroupTreeOptions.DevFakeGroupTreeEnabledEnvironmentVariable, "true");
+
+        using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
+
+        Assert.False(services.GetRequiredService<DesktopAuthOptions>().IsDevFakeAuthEnabled);
+        Assert.True(services.GetRequiredService<DesktopAuthOptions>().IsControlPlaneSignInConfigured);
+        Assert.True(services.GetRequiredService<DesktopGroupTreeOptions>().IsLiveControlPlaneGroupTreeEnabled);
+        Assert.False(services.GetRequiredService<DesktopGroupTreeOptions>().IsDevFakeGroupTreeEnabled);
+        Assert.True(services.GetRequiredService<DesktopGroupTreeViewModel>().IsLiveControlPlaneGroupTreeEnabled);
+        Assert.False(services.GetRequiredService<DesktopGroupTreeViewModel>().IsDevFakeGroupTreeEnabled);
+        Assert.IsType<HttpDesktopAuthClient>(services.GetRequiredService<IDesktopAuthClient>());
+        Assert.IsType<HttpDesktopGroupTreeClient>(services.GetRequiredService<IDesktopGroupTreeClient>());
+    }
+
+    [Fact]
+    public void ExplicitGroupTreeOptionsCannotOverrideConfiguredLiveBaseAddress()
+    {
+        using var services = DesktopCompositionRoot.BuildServices(
+            DesktopAuthOptions.FromControlPlaneBaseAddress("https://control-plane.local"),
+            DesktopUploadSectionOptions.Disabled,
+            DesktopGroupTreeOptions.EnabledForDevFakeGroupTree);
+
+        Assert.True(services.GetRequiredService<DesktopGroupTreeOptions>().IsLiveControlPlaneGroupTreeEnabled);
+        Assert.False(services.GetRequiredService<DesktopGroupTreeOptions>().IsDevFakeGroupTreeEnabled);
+        Assert.IsType<HttpDesktopGroupTreeClient>(services.GetRequiredService<IDesktopGroupTreeClient>());
     }
 
     [Fact]

--- a/tests/Unit/App.Desktop.Tests/DesktopGroupTreeTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopGroupTreeTests.cs
@@ -1,3 +1,7 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+
 using App.Desktop.Boundaries;
 using App.Desktop.Services.GroupTree;
 using App.Desktop.Services.Upload;
@@ -30,6 +34,34 @@ public sealed class DesktopGroupTreeTests
     }
 
     [Fact]
+    public void LiveGroupTreeRequiresConfiguredControlPlaneBaseAddress()
+    {
+        DesktopGroupTreeOptions disabled = DesktopGroupTreeOptions.FromEnvironmentValues(
+            controlPlaneBaseAddress: null,
+            devFakeGroupTreeEnabled: null);
+        DesktopGroupTreeOptions live = DesktopGroupTreeOptions.FromEnvironmentValues(
+            "https://control-plane.local",
+            devFakeGroupTreeEnabled: null);
+
+        Assert.False(disabled.IsLiveControlPlaneGroupTreeEnabled);
+        Assert.False(disabled.IsGroupTreeClientConfigured);
+        Assert.True(live.IsLiveControlPlaneGroupTreeEnabled);
+        Assert.False(live.IsDevFakeGroupTreeEnabled);
+        Assert.True(live.IsGroupTreeClientConfigured);
+    }
+
+    [Fact]
+    public void LiveBaseAddressDisablesFakeGroupTreeSelection()
+    {
+        DesktopGroupTreeOptions options = DesktopGroupTreeOptions.FromEnvironmentValues(
+            "https://control-plane.local",
+            devFakeGroupTreeEnabled: "true");
+
+        Assert.True(options.IsLiveControlPlaneGroupTreeEnabled);
+        Assert.False(options.IsDevFakeGroupTreeEnabled);
+    }
+
+    [Fact]
     public async Task DisabledGroupTreeShowsSafeMessageAndDoesNotCallBoundary()
     {
         var client = new ThrowingDesktopGroupTreeClient();
@@ -44,6 +76,160 @@ public sealed class DesktopGroupTreeTests
         Assert.Empty(viewModel.Nodes);
         Assert.Equal(DesktopGroupTreeText.DisabledMessage, viewModel.StatusMessage);
         Assert.Equal(0, client.CallCount);
+    }
+
+    [Fact]
+    public async Task HttpGroupTreeClientUsesExistingNodesEndpointAndReturnsSafeNodes()
+    {
+        string accessToken = CreateSensitiveValue("access");
+        Guid rootId = Guid.NewGuid();
+        Guid branchId = Guid.NewGuid();
+        Guid siteId = Guid.NewGuid();
+        var handler = new StubHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = JsonContent<object[]>(
+            [
+                new
+                {
+                    groupNodeId = rootId,
+                    parentGroupNodeId = (Guid?)null,
+                    code = "root",
+                    name = "Вся организация",
+                    depth = 0,
+                    isActive = true
+                },
+                new
+                {
+                    groupNodeId = branchId,
+                    parentGroupNodeId = (Guid?)rootId,
+                    code = "branch-001",
+                    name = "Тестовая ветка",
+                    depth = 1,
+                    isActive = true
+                },
+                new
+                {
+                    groupNodeId = siteId,
+                    parentGroupNodeId = (Guid?)branchId,
+                    code = "site-001",
+                    name = "Тестовый объект",
+                    depth = 2,
+                    isActive = true
+                }
+            ])
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://control-plane.local")
+        };
+        var client = new HttpDesktopGroupTreeClient(
+            httpClient,
+            new StaticDesktopControlPlaneAccessTokenProvider(accessToken));
+
+        DesktopGroupTreeLoadResult result = await client.GetGroupTreeAsync(CancellationToken.None);
+
+        Assert.Equal(DesktopGroupTreeLoadStatus.Loaded, result.Status);
+        Assert.Equal(DesktopGroupTreeText.LiveLoadedMessage, result.Message);
+        Assert.NotNull(handler.LastRequest);
+        Assert.Equal(HttpMethod.Get, handler.LastRequest.Method);
+        Assert.Equal("/api/group-tree/nodes", handler.LastRequest.RequestUri?.AbsolutePath);
+        Assert.Equal("Bearer", handler.LastRequest.Headers.Authorization?.Scheme);
+        Assert.Equal(accessToken, handler.LastRequest.Headers.Authorization?.Parameter);
+        Assert.Collection(
+            result.Nodes,
+            node => AssertNode(node, rootId.ToString("D"), "Вся организация", canSelect: false),
+            node => AssertNode(node, branchId.ToString("D"), "Тестовая ветка", canSelect: false),
+            node => AssertNode(node, siteId.ToString("D"), "Тестовый объект", canSelect: true));
+        Assert.DoesNotContain(accessToken, result.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task HttpGroupTreeClientDoesNotExposeTokenValuesOrRawFailureBody()
+    {
+        string accessToken = CreateSensitiveValue("access");
+        string responseToken = CreateSensitiveValue("refresh");
+        string rawBody = $"{{\"accessToken\":\"{responseToken}\",\"detail\":\"unsafe\"}}";
+        var handler = new StubHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.InternalServerError)
+        {
+            Content = new StringContent(rawBody, Encoding.UTF8, "application/json")
+        });
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://control-plane.local")
+        };
+        var client = new HttpDesktopGroupTreeClient(
+            httpClient,
+            new StaticDesktopControlPlaneAccessTokenProvider(accessToken));
+
+        DesktopGroupTreeLoadResult result = await client.GetGroupTreeAsync(CancellationToken.None);
+
+        Assert.Equal(DesktopGroupTreeLoadStatus.Failed, result.Status);
+        Assert.Equal(DesktopGroupTreeText.LiveFailedMessage, result.Message);
+        Assert.DoesNotContain(accessToken, result.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(responseToken, result.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(rawBody, result.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task HttpGroupTreeClientHandlesUnavailableAndMalformedResponsesSafely()
+    {
+        string accessToken = CreateSensitiveValue("access");
+        var unavailableHandler = new StubHttpMessageHandler(_ => throw new HttpRequestException(
+            $"Transport failed with {accessToken}"));
+        var unavailableClient = new HttpDesktopGroupTreeClient(
+            new HttpClient(unavailableHandler)
+            {
+                BaseAddress = new Uri("https://control-plane.local")
+            },
+            new StaticDesktopControlPlaneAccessTokenProvider(accessToken));
+
+        DesktopGroupTreeLoadResult unavailable =
+            await unavailableClient.GetGroupTreeAsync(CancellationToken.None);
+
+        Assert.Equal(DesktopGroupTreeLoadStatus.Unavailable, unavailable.Status);
+        Assert.Equal(DesktopGroupTreeText.LiveUnavailableMessage, unavailable.Message);
+        Assert.DoesNotContain(accessToken, unavailable.ToString(), StringComparison.Ordinal);
+
+        string malformedBody = $"{{\"refreshToken\":\"{CreateSensitiveValue("refresh")}\",";
+        var malformedHandler = new StubHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(malformedBody, Encoding.UTF8, "application/json")
+        });
+        var malformedClient = new HttpDesktopGroupTreeClient(
+            new HttpClient(malformedHandler)
+            {
+                BaseAddress = new Uri("https://control-plane.local")
+            },
+            new StaticDesktopControlPlaneAccessTokenProvider(accessToken));
+
+        DesktopGroupTreeLoadResult malformed =
+            await malformedClient.GetGroupTreeAsync(CancellationToken.None);
+
+        Assert.Equal(DesktopGroupTreeLoadStatus.Failed, malformed.Status);
+        Assert.Equal(DesktopGroupTreeText.LiveMalformedMessage, malformed.Message);
+        Assert.DoesNotContain(accessToken, malformed.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain(malformedBody, malformed.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task HttpGroupTreeClientWithoutSessionShowsSafeUnavailableMessage()
+    {
+        var handler = new StubHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = JsonContent(Array.Empty<object>())
+        });
+        var client = new HttpDesktopGroupTreeClient(
+            new HttpClient(handler)
+            {
+                BaseAddress = new Uri("https://control-plane.local")
+            },
+            new StaticDesktopControlPlaneAccessTokenProvider(accessToken: null));
+
+        DesktopGroupTreeLoadResult result = await client.GetGroupTreeAsync(CancellationToken.None);
+
+        Assert.Equal(DesktopGroupTreeLoadStatus.Unavailable, result.Status);
+        Assert.Equal(DesktopGroupTreeText.LiveUnauthorizedMessage, result.Message);
+        Assert.Null(handler.LastRequest);
     }
 
     [Fact]
@@ -166,7 +352,7 @@ public sealed class DesktopGroupTreeTests
     }
 
     [Fact]
-    public void GroupTreeFilesDoNotIntroduceRealAppApiCalls()
+    public void GroupTreeFilesOnlyUseApprovedGroupTreeEndpointAndNoUploadChainCalls()
     {
         string[] sourceFiles =
         [
@@ -175,20 +361,55 @@ public sealed class DesktopGroupTreeTests
             Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "GroupTree", "DesktopGroupSelectionState.cs"),
             Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "GroupTree", "DesktopGroupTreeViewModel.cs"),
             Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "GroupTree", "DisabledDesktopGroupTreeClient.cs"),
-            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "GroupTree", "FakeDesktopGroupTreeClient.cs")
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "GroupTree", "FakeDesktopGroupTreeClient.cs"),
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "GroupTree", "HttpDesktopGroupTreeClient.cs")
         ];
 
         foreach (string sourceFile in sourceFiles)
         {
             string source = File.ReadAllText(sourceFile);
 
-            Assert.DoesNotContain("HttpClient", source, StringComparison.Ordinal);
             Assert.DoesNotContain("IControlPlaneApiClient", source, StringComparison.Ordinal);
             Assert.DoesNotContain("RequestPreUploadCheckAsync", source, StringComparison.Ordinal);
             Assert.DoesNotContain("RecordUploadReceiptAsync", source, StringComparison.Ordinal);
-            Assert.DoesNotContain("GetAsync", source, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("PostAsync", source, StringComparison.OrdinalIgnoreCase);
-            Assert.DoesNotContain("SendAsync", source, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("/api/group-tree/routing-preview", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("/api/auth", source, StringComparison.Ordinal);
+        }
+
+        string liveClientSource = File.ReadAllText(
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "GroupTree", "HttpDesktopGroupTreeClient.cs"));
+
+        Assert.Contains("/api/group-tree/nodes", liveClientSource, StringComparison.Ordinal);
+        Assert.DoesNotContain("/api/group-tree/nodes/", liveClientSource, StringComparison.Ordinal);
+        Assert.DoesNotContain("ReadAsStringAsync", liveClientSource, StringComparison.Ordinal);
+        Assert.DoesNotContain("WriteLine", liveClientSource, StringComparison.Ordinal);
+        Assert.DoesNotContain("Log", liveClientSource, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void LiveGroupTreeVisualStringsDoNotExposeTokenLabels()
+    {
+        string[] visibleStrings =
+        [
+            DesktopGroupTreeText.LiveLoadingMessage,
+            DesktopGroupTreeText.LiveLoadedMessage,
+            DesktopGroupTreeText.LiveUnauthorizedMessage,
+            DesktopGroupTreeText.LiveUnavailableMessage,
+            DesktopGroupTreeText.LiveFailedMessage,
+            DesktopGroupTreeText.LiveMalformedMessage,
+            DesktopGroupTreeLoadResult.Unavailable(DesktopGroupTreeText.LiveUnauthorizedMessage).ToString(),
+            DesktopGroupTreeLoadResult.Failed(DesktopGroupTreeText.LiveMalformedMessage).ToString()
+        ];
+
+        foreach (string visibleString in visibleStrings)
+        {
+            Assert.DoesNotContain("password", visibleString, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("Authorization", visibleString, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("accessToken", visibleString, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("refreshToken", visibleString, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("session_id", visibleString, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("raw response", visibleString, StringComparison.OrdinalIgnoreCase);
         }
     }
 
@@ -280,6 +501,49 @@ public sealed class DesktopGroupTreeTests
             CallCount++;
             throw new InvalidOperationException("Disabled fake GroupTree boundary should not be called.");
         }
+    }
+
+    private sealed class StaticDesktopControlPlaneAccessTokenProvider(string? accessToken) :
+        IDesktopControlPlaneAccessTokenProvider
+    {
+        public ValueTask<DesktopControlPlaneAccessTokenSnapshot> GetCurrentAccessTokenAsync(
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            return ValueTask.FromResult(new DesktopControlPlaneAccessTokenSnapshot(
+                IsAuthenticated: !string.IsNullOrWhiteSpace(accessToken),
+                accessToken));
+        }
+    }
+
+    private sealed class StubHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> responseFactory) :
+        HttpMessageHandler
+    {
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            LastRequest = request;
+            return Task.FromResult(responseFactory(request));
+        }
+    }
+
+    private static StringContent JsonContent<T>(T value)
+    {
+        return new StringContent(
+            JsonSerializer.Serialize(value),
+            Encoding.UTF8,
+            "application/json");
+    }
+
+    private static string CreateSensitiveValue(string prefix)
+    {
+        return $"{prefix}-{Guid.NewGuid():N}";
     }
 
     private static string FindRepositoryRoot()

--- a/tests/Unit/App.Desktop.Tests/DesktopSessionStateTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopSessionStateTests.cs
@@ -98,6 +98,25 @@ public sealed class DesktopSessionStateTests
     }
 
     [Fact]
+    public async Task ControlPlaneAccessTokenBoundaryReturnsTokenWithoutDiagnosticLeak()
+    {
+        var state = new DesktopSessionState(new RecordingDesktopSessionStore());
+        var boundary = (IDesktopControlPlaneAccessTokenProvider)state;
+        var session = CreateAuthenticatedSession();
+
+        await state.SetSignedInAsync(session, CancellationToken.None);
+
+        DesktopControlPlaneAccessTokenSnapshot snapshot =
+            await boundary.GetCurrentAccessTokenAsync(CancellationToken.None);
+
+        Assert.True(snapshot.IsAuthenticated);
+        Assert.True(snapshot.HasAccessToken);
+        Assert.Equal(session.AccessToken, snapshot.AccessToken);
+        Assert.DoesNotContain(session.AccessToken, snapshot.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("Authorization", snapshot.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task SessionDiagnosticsDoNotIncludeTokenValues()
     {
         var store = new RecordingDesktopSessionStore();


### PR DESCRIPTION
Coder: Codex / Coder 1 acting as Coder 2 / Desktop Client

Task ID: S2-68

Module: App.Desktop / GroupTree control-plane client probe

Scope:
- Read-only probe of existing App.Api / Modules.GroupTree / contracts GroupTree surface.
- App.Desktop-only live GroupTree client boundary using the existing approved endpoint.
- S2-67 fake/dev GroupTree visual smoke preserved.

Changed areas:
- docs/task-cards/S2-68_desktop-group-tree-control-plane-client-probe-task-card.txt
- src/App.Desktop/Boundaries/DesktopGroupTreeBoundary.cs
- src/App.Desktop/Boundaries/DesktopSessionBoundary.cs
- src/App.Desktop/Composition/DesktopCompositionRoot.cs
- src/App.Desktop/Services/Auth/DesktopSessionState.cs
- src/App.Desktop/Services/GroupTree/DesktopGroupTreeOptions.cs
- src/App.Desktop/Services/GroupTree/DesktopGroupTreeViewModel.cs
- src/App.Desktop/Services/GroupTree/HttpDesktopGroupTreeClient.cs
- tests/Unit/App.Desktop.Tests/DesktopCompositionRootTests.cs
- tests/Unit/App.Desktop.Tests/DesktopGroupTreeTests.cs
- tests/Unit/App.Desktop.Tests/DesktopSessionStateTests.cs

Base main SHA: 9947757cb9bbb364c721793ab52e951c6ec1e228

Coordination log entries reviewed:
- TEAM COORDINATION LOG issue #89 metadata/comments.
- Desktop chain entries PR #127 S2-58 through PR #136 S2-67.

Handoff/task cards reviewed:
- docs/task-cards/S2-58_desktop-visual-smoke-fake-auth-task-card.txt
- docs/task-cards/S2-59_desktop-signed-in-shell-navigation-task-card.txt
- docs/task-cards/S2-60_desktop-upload-section-file-selection-placeholder-task-card.txt
- docs/task-cards/S2-61_desktop-upload-file-picker-boundary-task-card.txt
- docs/task-cards/S2-62_desktop-upload-sha256-boundary-task-card.txt
- docs/task-cards/S2-63_desktop-upload-business-object-key-placeholder-task-card.txt
- docs/task-cards/S2-64_desktop-preuploadcheck-request-preview-task-card.txt
- docs/task-cards/S2-65_desktop-direct-site-upload-boundary-task-card.txt
- docs/task-cards/S2-66_desktop-upload-receipt-boundary-task-card.txt
- docs/task-cards/S2-67_desktop-group-tree-selection-placeholder-task-card.txt

Existing GroupTree API/contract found: yes
- Existing endpoint: GET /api/group-tree/nodes
- Existing response shape: GroupNodeFlatDto[] from BuildingBlocks.Contracts.Groups
- Existing auth behavior: endpoint requires authenticated bearer session

Contracts: none

Migrations: none

Feature flags/env guard:
- AA_DESKTOP_CONTROL_PLANE_BASE_ADDRESS enables live GroupTree client.
- AA_DESKTOP_DEV_FAKE_GROUP_TREE_ENABLED=true keeps fake/dev GroupTree only when no live base address is configured.
- Fake GroupTree is not selected when a live base address is configured.

API impact:
- No App.Api changes.
- No new endpoint, DTO, contract, or server behavior.
- Existing GET /api/group-tree/nodes is consumed by App.Desktop only.

Web impact: none

Android impact: none

Offline behavior: none

Rollback: revert S2-68 PR

Validation:
- git diff --check: pass
- dotnet restore AnalyticsAutomation-Core.sln -nologo: pass
- dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore: pass after running whitespace formatter for repo style final-newline normalization
- dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal: pass, 0 warnings
- dotnet build AnalyticsAutomation-Core.sln -nologo -v minimal: pass, existing out-of-scope warnings
- dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal: pass, 165 tests
- hidden/control Unicode scan over changed text files: pass
- App.Desktop fake-auth/fake-group-tree/fake-upload-chain visual smoke: pass

Visual smoke screenshot folder/files:
C:\CODEX\Temp\S2-68_DESKTOP_GROUP_TREE_CLIENT_PROBE_VISUAL_SMOKE_20260501_164834\
- 01_baseline_signin.png
- 02_signed_in_shell.png
- 03_group_tree_fake_nodes.png
- 04_after_fake_group_selected.png
- 05_upload_section_with_group_context.png
- 06_after_sign_out.png

Handoff docs/task card:
- docs/task-cards/S2-68_desktop-group-tree-control-plane-client-probe-task-card.txt

Next step:
- Review the desktop-only client boundary and visual smoke evidence.
- Later approved slice can decide broader production GroupTree selection semantics and downstream upload binding.

NO-GO / Deferred:
- No App.Api/contracts/migrations/deploy/Web/Android changes in this PR.
- Real production upload binding, business object/report-draft binding, PreUploadCheck/site upload/UploadReceipt integration remain deferred.