### PR TITLE
[codex] S2-69 desktop PreUploadCheck control-plane client probe

### DIFF
--- a/docs/task-cards/S2-69_desktop-preuploadcheck-control-plane-client-probe-task-card.txt
+++ b/docs/task-cards/S2-69_desktop-preuploadcheck-control-plane-client-probe-task-card.txt
@@ -1,0 +1,168 @@
+Title:
+S2-69 Desktop PreUploadCheck Control-Plane Client Probe / Existing API Boundary
+
+Module:
+App.Desktop / PreUploadCheck control-plane client probe
+
+Owner:
+Coder 1 acting as Coder 2 / Desktop Client
+
+Client form:
+desktop standalone
+
+Type:
+narrow runtime desktop-only client boundary slice after S2-68 GroupTree control-plane probe
+
+Status:
+Runtime task card created with implementation.
+
+Goal:
+Probe the existing App.Api / Modules.VideoUpload / contracts PreUploadCheck surface read-only and, only because an existing approved endpoint was found, add an App.Desktop-local live PreUploadCheck client boundary without backend, contract, migration, deploy, Web, or Android changes.
+
+Existing PreUploadCheck API endpoint/contract found:
+Yes.
+
+Read-only sources inspected:
+- src/App.Api/Program.cs
+- src/Modules/VideoUpload/VideoUploadModule.cs
+- src/BuildingBlocks/Contracts/VideoUpload/PreUploadCheckDtos.cs
+- tests/Integration/App.Api/UploadControlPlaneAuthorizationTests.cs
+- tests/Integration/VideoUpload/PreUploadCheckServiceTests.cs
+- tests/Integration/** references found by repository search
+
+Existing approved surface used:
+- POST /api/video/pre-upload-check
+- Authorization: bearer session access token from existing desktop sign-in session
+- Request shape derived from existing code only:
+  VideoPreUploadCheckRequestDto with userId, deviceId, groupNodeId, businessObjectKey, fileName, sizeBytes, byteSha256, contentType, capturedAtUtc
+- Response shape derived from existing code only:
+  VideoPreUploadCheckResponseDto with preUploadCheckId, decision, canUploadToSite, reasonCode, message, existingPreUploadCheckId, requiredNextSteps, sitePlan, checkedAtUtc
+
+Scope:
+- Keep the current Russian SignIn UI before authentication.
+- After SignIn, keep the signed-in shell.
+- Preserve S2-68 GroupTree live/fake behavior.
+- Preserve S2-64 fake/dev PreUploadCheck visual smoke behavior when no live base address is configured.
+- Add HttpDesktopPreUploadCheckClient as an App.Desktop-local IDesktopPreUploadCheckClient implementation.
+- Select the live client only when AA_DESKTOP_CONTROL_PLANE_BASE_ADDRESS is configured.
+- Do not select fake PreUploadCheck when a live base address is configured.
+- Keep selected group context preview-only in the upload section.
+- Keep PreUploadCheck decision as the input for the downstream existing fake/dev site upload chain.
+- Clear PreUploadCheck preview/decision state on back and sign-out.
+
+Allowed changed areas:
+- docs/task-cards/S2-69_desktop-preuploadcheck-control-plane-client-probe-task-card.txt
+- src/App.Desktop/**
+- tests/Unit/App.Desktop.Tests/**
+
+Forbidden changed areas:
+- src/App.Api/**
+- src/App.Worker/**
+- src/App.Web/**
+- src/App.Mobile.Android/**
+- src/App.UI.Shared/**
+- src/BuildingBlocks.Contracts/**
+- src/Modules/**
+- DB migrations
+- .github/workflows/**
+- deploy scripts
+- docs/ops/**
+- committed screenshots or runtime artifacts
+
+Contracts:
+none
+
+Migrations:
+none
+
+Feature flags/env guard:
+- Existing AA_DESKTOP_DEV_FAKE_PREUPLOAD_CHECK_ENABLED=true keeps the fake/dev PreUploadCheck visual-smoke path when no live control-plane base address is configured.
+- Existing AA_DESKTOP_CONTROL_PLANE_BASE_ADDRESS enables the live App.Api PreUploadCheck client.
+- If AA_DESKTOP_CONTROL_PLANE_BASE_ADDRESS is configured, fake PreUploadCheck is not selected even when AA_DESKTOP_DEV_FAKE_PREUPLOAD_CHECK_ENABLED=true.
+- If AA_DESKTOP_CONTROL_PLANE_BASE_ADDRESS is absent and fake guard is off, PreUploadCheck remains disabled/unavailable with a safe Russian message.
+
+Events:
+none
+
+Offline behavior:
+none
+
+Security guardrails:
+- The live client sends the bearer access token only in the request header.
+- Do not log or display accessToken, refreshToken, Authorization, password, raw session id, raw response body, token-like values, or full local file paths.
+- The live client sends only safe fields from the existing request contract.
+- The live client does not read, log, or surface raw response bodies.
+- Unavailable, failed, unauthorized, and malformed responses produce safe Russian status messages.
+- Video bytes do not go through App.Api.
+- Screenshots and runtime artifacts stay under C:\CODEX\Temp and are not committed.
+
+Explicitly out of scope:
+- App.Api changes.
+- Modules changes.
+- BuildingBlocks.Contracts changes.
+- Backend endpoint/DTO/contract additions.
+- DB migrations.
+- Deploy/workflow changes.
+- App.Web changes.
+- App.Mobile.Android changes.
+- Real site upload changes.
+- Real UploadReceipt changes.
+- Video bytes through App.Api.
+- Offline queue.
+- Report draft runtime.
+
+Deferred:
+Real PreUploadCheck endpoint/contract was found, so the desktop HTTP client boundary is implemented in S2-69. Production source of truth for businessObjectKey and report-draft/business-object binding remains deferred to a separate approved slice. Real site upload and real UploadReceipt behavior remain deferred beyond the existing fake/dev chain.
+
+Rollback:
+revert S2-69 PR
+
+Validation:
+- git diff --check
+- dotnet restore AnalyticsAutomation-Core.sln -nologo
+- dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore
+- dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal
+- dotnet build AnalyticsAutomation-Core.sln -nologo -v minimal
+- dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal
+- hidden/control Unicode scan over changed text files
+- App.Desktop fake-auth/fake-group-tree/fake-upload-chain visual smoke with screenshots
+
+Definition of done:
+- Existing PreUploadCheck API/contract is documented as found.
+- HttpDesktopPreUploadCheckClient uses only POST /api/video/pre-upload-check and the existing VideoPreUploadCheck request/response shape.
+- Live PreUploadCheck client requires AA_DESKTOP_CONTROL_PLANE_BASE_ADDRESS.
+- Fake PreUploadCheck remains disabled by default and enabled only by AA_DESKTOP_DEV_FAKE_PREUPLOAD_CHECK_ENABLED=true when live base address is absent.
+- Fake PreUploadCheck is not selected when live base address is configured.
+- Disabled/no-base/no-fake state shows a safe Russian disabled/deferred message.
+- Live unavailable, failed, unauthorized, and malformed responses show safe Russian messages.
+- Tokens/passwords/Authorization/raw bodies/full local paths are not visible in UI/result diagnostics.
+- Request preview remains safe and does not show raw request/response body.
+- Back/sign-out clear PreUploadCheck preview and decision state.
+- No App.Api, contracts, migrations, deploy, App.Web, or App.Mobile.Android files are changed.
+- No real site upload or real UploadReceipt behavior changes are introduced beyond the existing fake/dev chain.
+- Automated App.Desktop unit tests cover guards, live endpoint request construction, safe decision mapping, safe failures, fake preservation, reset behavior, downstream fake/dev gating, and visible-string safety.
+
+Visual-smoke definition of done:
+- Run App.Desktop with:
+  AA_DESKTOP_DEV_FAKE_AUTH_ENABLED=true
+  AA_DESKTOP_DEV_FAKE_GROUP_TREE_ENABLED=true
+  AA_DESKTOP_DEV_FAKE_UPLOAD_FILE_ENABLED=true
+  AA_DESKTOP_DEV_FAKE_UPLOAD_HASH_ENABLED=true
+  AA_DESKTOP_DEV_FAKE_BUSINESS_OBJECT_KEY_ENABLED=true
+  AA_DESKTOP_DEV_FAKE_PREUPLOAD_CHECK_ENABLED=true
+  AA_DESKTOP_DEV_FAKE_SITE_UPLOAD_ENABLED=true
+  AA_DESKTOP_DEV_FAKE_UPLOAD_RECEIPT_ENABLED=true
+- Do not set AA_DESKTOP_CONTROL_PLANE_BASE_ADDRESS for fake-auth visual smoke.
+- Use non-secret fake-auth visual-smoke data:
+  login: visual-smoke-user
+  password: visual-smoke-password
+- Capture screenshots under C:\CODEX\Temp\S2-69_DESKTOP_PREUPLOADCHECK_CLIENT_PROBE_VISUAL_SMOKE_<timestamp>\.
+- Required screenshots:
+  01_baseline_signin.png
+  02_signed_in_shell.png
+  03_upload_section_before_preuploadcheck.png
+  04_preuploadcheck_request_preview.png
+  05_after_fake_preuploadcheck_allow.png
+  06_after_sign_out.png
+- Confirm no password, accessToken, refreshToken, Authorization, raw session id, raw response body, raw path, or real secret is visible.
+- Confirm screenshots and runtime artifacts are not committed.

--- a/src/App.Desktop/Boundaries/DesktopSessionBoundary.cs
+++ b/src/App.Desktop/Boundaries/DesktopSessionBoundary.cs
@@ -33,6 +33,7 @@ public interface IDesktopSessionStore
 public sealed record DesktopSessionSnapshot(
     DesktopSessionStatus Status,
     Guid? UserId,
+    Guid? DeviceId,
     string? DisplayName,
     bool HasAccessToken,
     bool HasRefreshToken,
@@ -41,6 +42,7 @@ public sealed record DesktopSessionSnapshot(
     public static DesktopSessionSnapshot SignedOut { get; } = new(
         DesktopSessionStatus.SignedOut,
         UserId: null,
+        DeviceId: null,
         DisplayName: null,
         HasAccessToken: false,
         HasRefreshToken: false,
@@ -55,6 +57,7 @@ public sealed record DesktopSessionSnapshot(
         return new DesktopSessionSnapshot(
             DesktopSessionStatus.SignedIn,
             session.UserId,
+            session.DeviceId,
             session.DisplayName,
             HasAccessToken: true,
             HasRefreshToken: !string.IsNullOrWhiteSpace(session.RefreshToken),
@@ -63,7 +66,7 @@ public sealed record DesktopSessionSnapshot(
 
     public override string ToString()
     {
-        return $"{nameof(DesktopSessionSnapshot)} {{ Status = {Status}, UserId = {UserId}, "
+        return $"{nameof(DesktopSessionSnapshot)} {{ Status = {Status}, UserId = {UserId}, DeviceId = {DeviceId}, "
             + $"DisplayName = {DisplayName}, HasAccessToken = {HasAccessToken}, "
             + $"HasRefreshToken = {HasRefreshToken}, ExpiresAtUtc = {ExpiresAtUtc:O} }}";
     }

--- a/src/App.Desktop/Boundaries/DesktopSignInBoundary.cs
+++ b/src/App.Desktop/Boundaries/DesktopSignInBoundary.cs
@@ -186,10 +186,14 @@ public static class DesktopUploadSectionText
         "Выберите файл, рассчитайте SHA-256 и укажите ключ бизнес-объекта для preview запроса.";
     public const string PreUploadCheckReadyMessage =
         "Preview запроса готов. Реальный вызов App.Api в этом slice не выполняется.";
+    public const string PreUploadCheckLiveReadyMessage =
+        "Preview запроса готов. Будет использован существующий control-plane endpoint PreUploadCheck.";
     public const string PreUploadCheckInProgressMessage =
         "Выполняется предварительная проверка в desktop-local dev boundary.";
+    public const string PreUploadCheckLiveInProgressMessage =
+        "Выполняется предварительная проверка через control-plane boundary.";
     public const string PreUploadCheckDeferredMessage =
-        "Предварительная проверка пока доступна только в dev-smoke режиме. Реальный вызов App.Api будет добавлен отдельным approved slice.";
+        "Предварительная проверка недоступна: задайте live control-plane base address или включите dev-smoke guard.";
     public const string PreUploadCheckAllowedDevMessage =
         "Предварительная проверка: загрузка разрешена в dev-smoke режиме.";
     public const string PreUploadCheckAllowWithReviewDevMessage =
@@ -198,6 +202,22 @@ public static class DesktopUploadSectionText
         "Предварительная проверка: загрузка заблокирована как hard duplicate в dev-smoke режиме.";
     public const string PreUploadCheckBlockPossibleFalsificationDevMessage =
         "Предварительная проверка: загрузка заблокирована как possible falsification в dev-smoke режиме.";
+    public const string PreUploadCheckAllowedLiveMessage =
+        "Предварительная проверка выполнена: загрузка разрешена.";
+    public const string PreUploadCheckAllowWithReviewLiveMessage =
+        "Предварительная проверка выполнена: загрузка разрешена с последующей проверкой.";
+    public const string PreUploadCheckBlockHardDuplicateLiveMessage =
+        "Предварительная проверка выполнена: загрузка заблокирована как hard duplicate.";
+    public const string PreUploadCheckBlockPossibleFalsificationLiveMessage =
+        "Предварительная проверка выполнена: загрузка заблокирована как possible falsification.";
+    public const string PreUploadCheckLiveUnauthorizedMessage =
+        "Предварительная проверка недоступна: требуется повторный вход.";
+    public const string PreUploadCheckLiveUnavailableMessage =
+        "Предварительная проверка временно недоступна. Проверьте подключение или настройку.";
+    public const string PreUploadCheckLiveFailedMessage =
+        "Предварительная проверка не выполнена. Попробуйте ещё раз.";
+    public const string PreUploadCheckLiveMalformedMessage =
+        "Предварительная проверка вернула неподдерживаемый ответ.";
     public const string PreUploadCheckCanceledMessage = "Предварительная проверка отменена.";
     public const string PreUploadCheckButton = "Проверить перед загрузкой";
     public const string PreUploadCheckBusyButton = "Проверяется...";

--- a/src/App.Desktop/Composition/DesktopCompositionRoot.cs
+++ b/src/App.Desktop/Composition/DesktopCompositionRoot.cs
@@ -57,6 +57,9 @@ public static class DesktopCompositionRoot
         DesktopGroupTreeOptions effectiveGroupTreeOptions = authOptions.IsControlPlaneSignInConfigured
             ? DesktopGroupTreeOptions.EnabledForLiveControlPlane
             : groupTreeOptions;
+        DesktopUploadSectionOptions effectiveUploadSectionOptions = authOptions.IsControlPlaneSignInConfigured
+            ? uploadSectionOptions.WithLiveControlPlanePreUploadCheck()
+            : uploadSectionOptions;
 
         var services = new ServiceCollection();
 
@@ -66,7 +69,7 @@ public static class DesktopCompositionRoot
 #endif
 
         services.AddSingleton(authOptions);
-        services.AddSingleton(uploadSectionOptions);
+        services.AddSingleton(effectiveUploadSectionOptions);
         services.AddSingleton(effectiveGroupTreeOptions);
         services.AddSingleton<IDesktopShellLifecycle, PlaceholderDesktopShellLifecycle>();
         services.AddSingleton<IDesktopSessionStore, DisabledDesktopSessionStore>();
@@ -114,7 +117,7 @@ public static class DesktopCompositionRoot
             services.AddSingleton<IDesktopGroupTreeClient, DisabledDesktopGroupTreeClient>();
         }
 
-        if (uploadSectionOptions.IsDevFakeUploadFileEnabled)
+        if (effectiveUploadSectionOptions.IsDevFakeUploadFileEnabled)
         {
             services.AddSingleton<IDesktopVideoFilePicker, FakeDesktopVideoFilePicker>();
         }
@@ -123,7 +126,7 @@ public static class DesktopCompositionRoot
             services.AddSingleton<IDesktopVideoFilePicker, WpfDesktopVideoFilePicker>();
         }
 
-        if (uploadSectionOptions.IsDevFakeUploadHashEnabled)
+        if (effectiveUploadSectionOptions.IsDevFakeUploadHashEnabled)
         {
             services.AddSingleton<IDesktopVideoHashService, FakeDesktopVideoHashService>();
         }
@@ -132,7 +135,12 @@ public static class DesktopCompositionRoot
             services.AddSingleton<IDesktopVideoHashService, DesktopVideoHashService>();
         }
 
-        if (uploadSectionOptions.IsDevFakePreUploadCheckEnabled)
+        if (effectiveUploadSectionOptions.IsLiveControlPlanePreUploadCheckEnabled
+            && authOptions.IsControlPlaneSignInConfigured)
+        {
+            services.AddSingleton<IDesktopPreUploadCheckClient, HttpDesktopPreUploadCheckClient>();
+        }
+        else if (effectiveUploadSectionOptions.IsDevFakePreUploadCheckEnabled)
         {
             services.AddSingleton<IDesktopPreUploadCheckClient, FakeDesktopPreUploadCheckClient>();
         }
@@ -141,7 +149,7 @@ public static class DesktopCompositionRoot
             services.AddSingleton<IDesktopPreUploadCheckClient, DisabledDesktopPreUploadCheckClient>();
         }
 
-        if (uploadSectionOptions.IsDevFakeSiteUploadEnabled)
+        if (effectiveUploadSectionOptions.IsDevFakeSiteUploadEnabled)
         {
             services.AddSingleton<IDesktopDirectSiteUploadClient, FakeDesktopDirectSiteUploadClient>();
         }
@@ -150,7 +158,7 @@ public static class DesktopCompositionRoot
             services.AddSingleton<IDesktopDirectSiteUploadClient, DisabledDesktopDirectSiteUploadClient>();
         }
 
-        if (uploadSectionOptions.IsDevFakeUploadReceiptEnabled)
+        if (effectiveUploadSectionOptions.IsDevFakeUploadReceiptEnabled)
         {
             services.AddSingleton<IDesktopUploadReceiptClient, FakeDesktopUploadReceiptClient>();
         }

--- a/src/App.Desktop/Services/Upload/DesktopPreUploadCheck.cs
+++ b/src/App.Desktop/Services/Upload/DesktopPreUploadCheck.cs
@@ -1,4 +1,5 @@
 using App.Desktop.Boundaries;
+using App.Desktop.Services.GroupTree;
 
 namespace App.Desktop.Services.Upload;
 
@@ -12,7 +13,8 @@ public sealed class DesktopPreUploadCheckRequestPreview
         string contentType,
         string sha256Hex,
         string businessObjectKeyPreview,
-        string capturedAtUtc)
+        string capturedAtUtc,
+        Guid? groupNodeId)
     {
         FileName = fileName;
         SizeBytes = sizeBytes;
@@ -20,6 +22,7 @@ public sealed class DesktopPreUploadCheckRequestPreview
         Sha256Hex = sha256Hex;
         BusinessObjectKeyPreview = businessObjectKeyPreview;
         CapturedAtUtc = capturedAtUtc;
+        GroupNodeId = groupNodeId;
     }
 
     public string FileName { get; }
@@ -34,10 +37,13 @@ public sealed class DesktopPreUploadCheckRequestPreview
 
     public string CapturedAtUtc { get; }
 
+    public Guid? GroupNodeId { get; }
+
     public static DesktopPreUploadCheckRequestPreview? TryCreate(
         DesktopUploadSelectedFile? selectedFile,
         string? sha256Hex,
-        DesktopUploadBusinessObjectKey? businessObjectKey)
+        DesktopUploadBusinessObjectKey? businessObjectKey,
+        DesktopSelectedGroupContext? selectedGroupContext = null)
     {
         string safeSha256Hex = sha256Hex ?? string.Empty;
 
@@ -55,14 +61,16 @@ public sealed class DesktopPreUploadCheckRequestPreview
             selectedFile.ContentType,
             safeSha256Hex,
             businessObjectKey.Value,
-            CapturedAtUtcPlaceholder);
+            CapturedAtUtcPlaceholder,
+            TryParseGroupNodeId(selectedGroupContext));
     }
 
     public override string ToString()
     {
         return $"{nameof(DesktopPreUploadCheckRequestPreview)} {{ FileName = {FileName}, "
             + $"SizeBytes = {SizeBytes}, ContentType = {ContentType}, HasSha256 = {Sha256Hex.Length == 64}, "
-            + $"BusinessObjectKeyPreview = {BusinessObjectKeyPreview}, CapturedAtUtc = {CapturedAtUtc} }}";
+            + $"BusinessObjectKeyPreview = {BusinessObjectKeyPreview}, CapturedAtUtc = {CapturedAtUtc}, "
+            + $"HasGroupNodeId = {GroupNodeId.HasValue} }}";
     }
 
     private static bool IsLowercaseSha256Hex(string? value)
@@ -101,6 +109,13 @@ public sealed class DesktopPreUploadCheckRequestPreview
         }
 
         return true;
+    }
+
+    private static Guid? TryParseGroupNodeId(DesktopSelectedGroupContext? selectedGroupContext)
+    {
+        return Guid.TryParse(selectedGroupContext?.Id, out Guid groupNodeId)
+            ? groupNodeId
+            : null;
     }
 }
 
@@ -165,6 +180,50 @@ public sealed class DesktopPreUploadCheckResult
         return new DesktopPreUploadCheckResult(status, decision, message);
     }
 
+    public static DesktopPreUploadCheckResult FromLiveDecision(DesktopPreUploadCheckDecision decision)
+    {
+        string message = decision switch
+        {
+            DesktopPreUploadCheckDecision.Allow => DesktopUploadSectionText.PreUploadCheckAllowedLiveMessage,
+            DesktopPreUploadCheckDecision.AllowWithReview =>
+                DesktopUploadSectionText.PreUploadCheckAllowWithReviewLiveMessage,
+            DesktopPreUploadCheckDecision.BlockHardDuplicate =>
+                DesktopUploadSectionText.PreUploadCheckBlockHardDuplicateLiveMessage,
+            DesktopPreUploadCheckDecision.BlockPossibleFalsification =>
+                DesktopUploadSectionText.PreUploadCheckBlockPossibleFalsificationLiveMessage,
+            _ => DesktopUploadSectionText.PreUploadCheckLiveMalformedMessage
+        };
+
+        DesktopPreUploadCheckStatus status = decision switch
+        {
+            DesktopPreUploadCheckDecision.Allow => DesktopPreUploadCheckStatus.Allowed,
+            DesktopPreUploadCheckDecision.AllowWithReview => DesktopPreUploadCheckStatus.AllowedWithReview,
+            _ => DesktopPreUploadCheckStatus.Blocked
+        };
+
+        return new DesktopPreUploadCheckResult(status, decision, message);
+    }
+
+    public static DesktopPreUploadCheckResult LiveUnavailable { get; } = new(
+        DesktopPreUploadCheckStatus.Unavailable,
+        decision: null,
+        DesktopUploadSectionText.PreUploadCheckLiveUnavailableMessage);
+
+    public static DesktopPreUploadCheckResult LiveUnauthorized { get; } = new(
+        DesktopPreUploadCheckStatus.Unauthorized,
+        decision: null,
+        DesktopUploadSectionText.PreUploadCheckLiveUnauthorizedMessage);
+
+    public static DesktopPreUploadCheckResult LiveFailed { get; } = new(
+        DesktopPreUploadCheckStatus.Failed,
+        decision: null,
+        DesktopUploadSectionText.PreUploadCheckLiveFailedMessage);
+
+    public static DesktopPreUploadCheckResult LiveMalformed { get; } = new(
+        DesktopPreUploadCheckStatus.Malformed,
+        decision: null,
+        DesktopUploadSectionText.PreUploadCheckLiveMalformedMessage);
+
     public override string ToString()
     {
         return $"{nameof(DesktopPreUploadCheckResult)} {{ Status = {Status}, Decision = {DecisionPreview ?? "<none>"}, "
@@ -178,7 +237,11 @@ public enum DesktopPreUploadCheckStatus
     Allowed,
     AllowedWithReview,
     Blocked,
-    Canceled
+    Canceled,
+    Unavailable,
+    Unauthorized,
+    Failed,
+    Malformed
 }
 
 public enum DesktopPreUploadCheckDecision

--- a/src/App.Desktop/Services/Upload/DesktopUploadSectionOptions.cs
+++ b/src/App.Desktop/Services/Upload/DesktopUploadSectionOptions.cs
@@ -21,6 +21,7 @@ public sealed class DesktopUploadSectionOptions
         "AA_DESKTOP_DEV_FAKE_UPLOAD_RECEIPT_ENABLED";
 
     private DesktopUploadSectionOptions(
+        bool isLiveControlPlanePreUploadCheckEnabled,
         bool isDevFakeUploadFileEnabled,
         bool isDevFakeUploadHashEnabled,
         bool isDevFakeBusinessObjectKeyEnabled,
@@ -28,6 +29,7 @@ public sealed class DesktopUploadSectionOptions
         bool isDevFakeSiteUploadEnabled,
         bool isDevFakeUploadReceiptEnabled)
     {
+        IsLiveControlPlanePreUploadCheckEnabled = isLiveControlPlanePreUploadCheckEnabled;
         IsDevFakeUploadFileEnabled = isDevFakeUploadFileEnabled;
         IsDevFakeUploadHashEnabled = isDevFakeUploadHashEnabled;
         IsDevFakeBusinessObjectKeyEnabled = isDevFakeBusinessObjectKeyEnabled;
@@ -37,6 +39,7 @@ public sealed class DesktopUploadSectionOptions
     }
 
     public static DesktopUploadSectionOptions Disabled { get; } = new(
+        isLiveControlPlanePreUploadCheckEnabled: false,
         isDevFakeUploadFileEnabled: false,
         isDevFakeUploadHashEnabled: false,
         isDevFakeBusinessObjectKeyEnabled: false,
@@ -46,6 +49,7 @@ public sealed class DesktopUploadSectionOptions
 
 #if DEBUG
     public static DesktopUploadSectionOptions EnabledForDevFakeFileSelection { get; } = new(
+        isLiveControlPlanePreUploadCheckEnabled: false,
         isDevFakeUploadFileEnabled: true,
         isDevFakeUploadHashEnabled: false,
         isDevFakeBusinessObjectKeyEnabled: false,
@@ -54,6 +58,7 @@ public sealed class DesktopUploadSectionOptions
         isDevFakeUploadReceiptEnabled: false);
 
     public static DesktopUploadSectionOptions EnabledForDevFakeFileSelectionAndHash { get; } = new(
+        isLiveControlPlanePreUploadCheckEnabled: false,
         isDevFakeUploadFileEnabled: true,
         isDevFakeUploadHashEnabled: true,
         isDevFakeBusinessObjectKeyEnabled: false,
@@ -62,6 +67,7 @@ public sealed class DesktopUploadSectionOptions
         isDevFakeUploadReceiptEnabled: false);
 
     public static DesktopUploadSectionOptions EnabledForDevFakeBusinessObjectKey { get; } = new(
+        isLiveControlPlanePreUploadCheckEnabled: false,
         isDevFakeUploadFileEnabled: false,
         isDevFakeUploadHashEnabled: false,
         isDevFakeBusinessObjectKeyEnabled: true,
@@ -70,6 +76,7 @@ public sealed class DesktopUploadSectionOptions
         isDevFakeUploadReceiptEnabled: false);
 
     public static DesktopUploadSectionOptions EnabledForDevFakePreUploadCheck { get; } = new(
+        isLiveControlPlanePreUploadCheckEnabled: false,
         isDevFakeUploadFileEnabled: false,
         isDevFakeUploadHashEnabled: false,
         isDevFakeBusinessObjectKeyEnabled: false,
@@ -78,6 +85,7 @@ public sealed class DesktopUploadSectionOptions
         isDevFakeUploadReceiptEnabled: false);
 
     public static DesktopUploadSectionOptions EnabledForDevFakeSiteUpload { get; } = new(
+        isLiveControlPlanePreUploadCheckEnabled: false,
         isDevFakeUploadFileEnabled: false,
         isDevFakeUploadHashEnabled: false,
         isDevFakeBusinessObjectKeyEnabled: false,
@@ -86,6 +94,7 @@ public sealed class DesktopUploadSectionOptions
         isDevFakeUploadReceiptEnabled: false);
 
     public static DesktopUploadSectionOptions EnabledForDevFakeUploadReceipt { get; } = new(
+        isLiveControlPlanePreUploadCheckEnabled: false,
         isDevFakeUploadFileEnabled: false,
         isDevFakeUploadHashEnabled: false,
         isDevFakeBusinessObjectKeyEnabled: false,
@@ -105,6 +114,8 @@ public sealed class DesktopUploadSectionOptions
 
     public static DesktopUploadSectionOptions EnabledForDevFakeUploadReceipt => Disabled;
 #endif
+
+    public bool IsLiveControlPlanePreUploadCheckEnabled { get; }
 
     public bool IsDevFakeUploadFileEnabled { get; }
 
@@ -206,20 +217,35 @@ public sealed class DesktopUploadSectionOptions
         bool isFakeUploadReceiptEnabled = IsDevFakeUploadReceiptEnabledValue(devFakeUploadReceiptEnabled);
 
         return new DesktopUploadSectionOptions(
-            isFakeFileEnabled,
-            isFakeHashEnabled,
-            isFakeBusinessObjectKeyEnabled,
-            isFakePreUploadCheckEnabled,
-            isFakeSiteUploadEnabled,
-            isFakeUploadReceiptEnabled);
+            isLiveControlPlanePreUploadCheckEnabled: false,
+            isDevFakeUploadFileEnabled: isFakeFileEnabled,
+            isDevFakeUploadHashEnabled: isFakeHashEnabled,
+            isDevFakeBusinessObjectKeyEnabled: isFakeBusinessObjectKeyEnabled,
+            isDevFakePreUploadCheckEnabled: isFakePreUploadCheckEnabled,
+            isDevFakeSiteUploadEnabled: isFakeSiteUploadEnabled,
+            isDevFakeUploadReceiptEnabled: isFakeUploadReceiptEnabled);
 #else
         return Disabled;
 #endif
     }
 
+    public DesktopUploadSectionOptions WithLiveControlPlanePreUploadCheck()
+    {
+        return new DesktopUploadSectionOptions(
+            isLiveControlPlanePreUploadCheckEnabled: true,
+            isDevFakeUploadFileEnabled: IsDevFakeUploadFileEnabled,
+            isDevFakeUploadHashEnabled: IsDevFakeUploadHashEnabled,
+            isDevFakeBusinessObjectKeyEnabled: IsDevFakeBusinessObjectKeyEnabled,
+            isDevFakePreUploadCheckEnabled: false,
+            isDevFakeSiteUploadEnabled: IsDevFakeSiteUploadEnabled,
+            isDevFakeUploadReceiptEnabled: IsDevFakeUploadReceiptEnabled);
+    }
+
     public override string ToString()
     {
-        return $"{nameof(DesktopUploadSectionOptions)} {{ IsDevFakeUploadFileEnabled = {IsDevFakeUploadFileEnabled}, "
+        return $"{nameof(DesktopUploadSectionOptions)} {{ "
+            + $"IsLiveControlPlanePreUploadCheckEnabled = {IsLiveControlPlanePreUploadCheckEnabled}, "
+            + $"IsDevFakeUploadFileEnabled = {IsDevFakeUploadFileEnabled}, "
             + $"IsDevFakeUploadHashEnabled = {IsDevFakeUploadHashEnabled}, "
             + $"IsDevFakeBusinessObjectKeyEnabled = {IsDevFakeBusinessObjectKeyEnabled}, "
             + $"IsDevFakePreUploadCheckEnabled = {IsDevFakePreUploadCheckEnabled}, "

--- a/src/App.Desktop/Services/Upload/DesktopUploadSectionViewModel.cs
+++ b/src/App.Desktop/Services/Upload/DesktopUploadSectionViewModel.cs
@@ -141,6 +141,9 @@ public sealed class DesktopUploadSectionViewModel(
     public bool IsDevFakePreUploadCheckEnabled =>
         _uploadSectionOptions.IsDevFakePreUploadCheckEnabled;
 
+    public bool IsLiveControlPlanePreUploadCheckEnabled =>
+        _uploadSectionOptions.IsLiveControlPlanePreUploadCheckEnabled;
+
     public bool IsDevFakeSiteUploadEnabled =>
         _uploadSectionOptions.IsDevFakeSiteUploadEnabled;
 
@@ -159,7 +162,11 @@ public sealed class DesktopUploadSectionViewModel(
         DesktopUploadSectionText.BusinessObjectKeyEmptyValidationMessage;
 
     public DesktopPreUploadCheckRequestPreview? PreUploadCheckRequestPreview =>
-        DesktopPreUploadCheckRequestPreview.TryCreate(SelectedFile, Sha256Hex, BusinessObjectKey);
+        DesktopPreUploadCheckRequestPreview.TryCreate(
+            SelectedFile,
+            Sha256Hex,
+            BusinessObjectKey,
+            SelectedGroupContext);
 
     public bool HasPreUploadCheckRequestPreview => PreUploadCheckRequestPreview is not null;
 
@@ -390,7 +397,7 @@ public sealed class DesktopUploadSectionViewModel(
             return null;
         }
 
-        if (!IsDevFakePreUploadCheckEnabled)
+        if (!IsDevFakePreUploadCheckEnabled && !IsLiveControlPlanePreUploadCheckEnabled)
         {
             PreUploadCheckResult = DesktopPreUploadCheckResult.Deferred;
             PreUploadCheckStatusMessage = DesktopUploadSectionText.PreUploadCheckDeferredMessage;
@@ -400,7 +407,9 @@ public sealed class DesktopUploadSectionViewModel(
 
         IsCheckingPreUpload = true;
         PreUploadCheckResult = null;
-        PreUploadCheckStatusMessage = DesktopUploadSectionText.PreUploadCheckInProgressMessage;
+        PreUploadCheckStatusMessage = IsLiveControlPlanePreUploadCheckEnabled
+            ? DesktopUploadSectionText.PreUploadCheckLiveInProgressMessage
+            : DesktopUploadSectionText.PreUploadCheckInProgressMessage;
         ResetSiteUploadState();
 
         try
@@ -566,7 +575,7 @@ public sealed class DesktopUploadSectionViewModel(
         }
 
         PreUploadCheckStatusMessage = HasPreUploadCheckRequestPreview
-            ? DesktopUploadSectionText.PreUploadCheckReadyMessage
+            ? GetPreUploadCheckReadyMessage()
             : DesktopUploadSectionText.PreUploadCheckNotReadyMessage;
     }
 
@@ -616,5 +625,12 @@ public sealed class DesktopUploadSectionViewModel(
             or DesktopPreUploadCheckDecision.BlockPossibleFalsification
             ? DesktopUploadSectionText.SiteUploadBlockedByPreUploadCheckMessage
             : DesktopUploadSectionText.SiteUploadNotReadyMessage;
+    }
+
+    private string GetPreUploadCheckReadyMessage()
+    {
+        return IsLiveControlPlanePreUploadCheckEnabled
+            ? DesktopUploadSectionText.PreUploadCheckLiveReadyMessage
+            : DesktopUploadSectionText.PreUploadCheckReadyMessage;
     }
 }

--- a/src/App.Desktop/Services/Upload/HttpDesktopPreUploadCheckClient.cs
+++ b/src/App.Desktop/Services/Upload/HttpDesktopPreUploadCheckClient.cs
@@ -1,0 +1,213 @@
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+using App.Desktop.Boundaries;
+
+namespace App.Desktop.Services.Upload;
+
+public sealed class HttpDesktopPreUploadCheckClient : IDesktopPreUploadCheckClient
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly HttpClient _httpClient;
+    private readonly IDesktopControlPlaneAccessTokenProvider _accessTokenProvider;
+    private readonly IDesktopSessionState _sessionState;
+    private readonly Uri _preUploadCheckEndpoint;
+
+    public HttpDesktopPreUploadCheckClient(
+        HttpClient httpClient,
+        IDesktopControlPlaneAccessTokenProvider accessTokenProvider,
+        IDesktopSessionState sessionState)
+        : this(
+            httpClient,
+            accessTokenProvider,
+            sessionState,
+            new Uri("/api/video/pre-upload-check", UriKind.Relative))
+    {
+    }
+
+    public HttpDesktopPreUploadCheckClient(
+        HttpClient httpClient,
+        IDesktopControlPlaneAccessTokenProvider accessTokenProvider,
+        IDesktopSessionState sessionState,
+        Uri preUploadCheckEndpoint)
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
+        ArgumentNullException.ThrowIfNull(accessTokenProvider);
+        ArgumentNullException.ThrowIfNull(sessionState);
+        ArgumentNullException.ThrowIfNull(preUploadCheckEndpoint);
+
+        _httpClient = httpClient;
+        _accessTokenProvider = accessTokenProvider;
+        _sessionState = sessionState;
+        _preUploadCheckEndpoint = preUploadCheckEndpoint;
+    }
+
+    public async ValueTask<DesktopPreUploadCheckResult> CheckAsync(
+        DesktopPreUploadCheckRequestPreview requestPreview,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(requestPreview);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        try
+        {
+            DesktopControlPlaneAccessTokenSnapshot accessToken =
+                await _accessTokenProvider.GetCurrentAccessTokenAsync(cancellationToken);
+            DesktopSessionSnapshot session = _sessionState.Current;
+
+            if (!accessToken.HasAccessToken || !session.IsSignedIn || session.UserId is null)
+            {
+                return DesktopPreUploadCheckResult.LiveUnauthorized;
+            }
+
+            using var request = new HttpRequestMessage(HttpMethod.Post, _preUploadCheckEndpoint);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken.AccessToken);
+            request.Content = JsonContent.Create(
+                new PreUploadCheckRequestPayload(
+                    UserId: session.UserId.Value,
+                    DeviceId: session.DeviceId,
+                    GroupNodeId: requestPreview.GroupNodeId,
+                    BusinessObjectKey: requestPreview.BusinessObjectKeyPreview,
+                    FileName: requestPreview.FileName,
+                    SizeBytes: requestPreview.SizeBytes,
+                    ByteSha256: requestPreview.Sha256Hex,
+                    ContentType: CreateSafeNullableContentType(requestPreview.ContentType),
+                    CapturedAtUtc: DateTimeOffset.UtcNow),
+                options: JsonOptions);
+
+            using HttpResponseMessage response = await _httpClient.SendAsync(
+                request,
+                HttpCompletionOption.ResponseHeadersRead,
+                cancellationToken);
+
+            if (response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
+            {
+                return DesktopPreUploadCheckResult.LiveUnauthorized;
+            }
+
+            if (response.StatusCode == HttpStatusCode.ServiceUnavailable)
+            {
+                return DesktopPreUploadCheckResult.LiveUnavailable;
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                return DesktopPreUploadCheckResult.LiveFailed;
+            }
+
+            PreUploadCheckResponsePayload? payload =
+                await response.Content.ReadFromJsonAsync<PreUploadCheckResponsePayload>(
+                    JsonOptions,
+                    cancellationToken);
+
+            return TryMapResponse(payload);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            return DesktopPreUploadCheckResult.LiveUnavailable;
+        }
+        catch (HttpRequestException)
+        {
+            return DesktopPreUploadCheckResult.LiveUnavailable;
+        }
+        catch (InvalidOperationException)
+        {
+            return DesktopPreUploadCheckResult.LiveUnavailable;
+        }
+        catch (JsonException)
+        {
+            return DesktopPreUploadCheckResult.LiveMalformed;
+        }
+        catch (NotSupportedException)
+        {
+            return DesktopPreUploadCheckResult.LiveMalformed;
+        }
+    }
+
+    private static DesktopPreUploadCheckResult TryMapResponse(PreUploadCheckResponsePayload? payload)
+    {
+        if (payload is null
+            || payload.PreUploadCheckId is null
+            || payload.PreUploadCheckId == Guid.Empty
+            || string.IsNullOrWhiteSpace(payload.Decision)
+            || payload.CanUploadToSite is null
+            || string.IsNullOrWhiteSpace(payload.ReasonCode)
+            || payload.RequiredNextSteps is null
+            || payload.CheckedAtUtc is null)
+        {
+            return DesktopPreUploadCheckResult.LiveMalformed;
+        }
+
+        DesktopPreUploadCheckDecision? decision = payload.Decision.Trim() switch
+        {
+            "ALLOW" when payload.CanUploadToSite.Value => DesktopPreUploadCheckDecision.Allow,
+            "ALLOW_WITH_REVIEW" when payload.CanUploadToSite.Value => DesktopPreUploadCheckDecision.AllowWithReview,
+            "BLOCK_HARD_DUPLICATE" when !payload.CanUploadToSite.Value =>
+                DesktopPreUploadCheckDecision.BlockHardDuplicate,
+            "BLOCK_POSSIBLE_FALSIFICATION" when !payload.CanUploadToSite.Value =>
+                DesktopPreUploadCheckDecision.BlockPossibleFalsification,
+            _ => null
+        };
+
+        return decision is null
+            ? DesktopPreUploadCheckResult.LiveMalformed
+            : DesktopPreUploadCheckResult.FromLiveDecision(decision.Value);
+    }
+
+    private static string? CreateSafeNullableContentType(string contentType)
+    {
+        return string.Equals(
+            contentType,
+            DesktopUploadSectionText.UnknownContentTypeValue,
+            StringComparison.Ordinal)
+            ? null
+            : contentType;
+    }
+
+    private sealed record PreUploadCheckRequestPayload(
+        Guid UserId,
+        Guid? DeviceId,
+        Guid? GroupNodeId,
+        string BusinessObjectKey,
+        string FileName,
+        long SizeBytes,
+        string ByteSha256,
+        string? ContentType,
+        DateTimeOffset CapturedAtUtc);
+
+    private sealed class PreUploadCheckResponsePayload
+    {
+        public Guid? PreUploadCheckId { get; init; }
+
+        public string? Decision { get; init; }
+
+        public bool? CanUploadToSite { get; init; }
+
+        public string? ReasonCode { get; init; }
+
+        public string? Message { get; init; }
+
+        public string? ExistingPreUploadCheckId { get; init; }
+
+        public IReadOnlyCollection<string>? RequiredNextSteps { get; init; }
+
+        public PreUploadSitePlanPayload? SitePlan { get; init; }
+
+        public DateTimeOffset? CheckedAtUtc { get; init; }
+    }
+
+    private sealed class PreUploadSitePlanPayload
+    {
+        public string? Provider { get; init; }
+
+        public string? ExternalVideoId { get; init; }
+
+        public string? StorageKey { get; init; }
+
+        public string? RequiredReceiptEndpoint { get; init; }
+    }
+}

--- a/tests/Unit/App.Desktop.Tests/DesktopCompositionRootTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopCompositionRootTests.cs
@@ -24,6 +24,7 @@ public sealed class DesktopCompositionRootTests
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsLiveControlPlanePreUploadCheckEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeSiteUploadEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadReceiptEnabled);
@@ -61,6 +62,7 @@ public sealed class DesktopCompositionRootTests
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadFileEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsLiveControlPlanePreUploadCheckEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeSiteUploadEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadReceiptEnabled);
@@ -472,10 +474,16 @@ public sealed class DesktopCompositionRootTests
 
         Assert.IsType<HttpDesktopAuthClient>(services.GetRequiredService<IDesktopAuthClient>());
         Assert.IsType<HttpDesktopGroupTreeClient>(services.GetRequiredService<IDesktopGroupTreeClient>());
+        Assert.IsType<HttpDesktopPreUploadCheckClient>(
+            services.GetRequiredService<IDesktopPreUploadCheckClient>());
         Assert.IsType<DisabledDesktopSessionStore>(services.GetRequiredService<IDesktopSessionStore>());
         Assert.True(services.GetRequiredService<DesktopAuthOptions>().IsControlPlaneSignInConfigured);
         Assert.True(services.GetRequiredService<DesktopGroupTreeOptions>().IsLiveControlPlaneGroupTreeEnabled);
         Assert.False(services.GetRequiredService<DesktopGroupTreeOptions>().IsDevFakeGroupTreeEnabled);
+        Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsLiveControlPlanePreUploadCheckEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
+        Assert.True(services.GetRequiredService<DesktopUploadSectionViewModel>().IsLiveControlPlanePreUploadCheckEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakePreUploadCheckEnabled);
         Assert.Equal(
             new Uri("https://control-plane.local"),
             services.GetRequiredService<HttpClient>().BaseAddress);
@@ -532,6 +540,26 @@ public sealed class DesktopCompositionRootTests
         Assert.False(services.GetRequiredService<DesktopGroupTreeViewModel>().IsDevFakeGroupTreeEnabled);
         Assert.IsType<HttpDesktopAuthClient>(services.GetRequiredService<IDesktopAuthClient>());
         Assert.IsType<HttpDesktopGroupTreeClient>(services.GetRequiredService<IDesktopGroupTreeClient>());
+    }
+
+    [Fact]
+    public void ExplicitFakePreUploadCheckFlagDoesNotReplaceConfiguredLivePreUploadCheckClient()
+    {
+        using var environment = new EnvironmentVariableScope()
+            .Set(DesktopAuthOptions.ControlPlaneBaseAddressEnvironmentVariable, "https://control-plane.local")
+            .Set(DesktopAuthOptions.DevFakeAuthEnabledEnvironmentVariable, "true")
+            .Set(DesktopUploadSectionOptions.DevFakePreUploadCheckEnabledEnvironmentVariable, "true");
+
+        using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
+
+        Assert.False(services.GetRequiredService<DesktopAuthOptions>().IsDevFakeAuthEnabled);
+        Assert.True(services.GetRequiredService<DesktopAuthOptions>().IsControlPlaneSignInConfigured);
+        Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsLiveControlPlanePreUploadCheckEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
+        Assert.True(services.GetRequiredService<DesktopUploadSectionViewModel>().IsLiveControlPlanePreUploadCheckEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakePreUploadCheckEnabled);
+        Assert.IsType<HttpDesktopPreUploadCheckClient>(
+            services.GetRequiredService<IDesktopPreUploadCheckClient>());
     }
 
     [Fact]

--- a/tests/Unit/App.Desktop.Tests/DesktopUploadSectionTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopUploadSectionTests.cs
@@ -1,4 +1,11 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
 using App.Desktop.Boundaries;
+using App.Desktop.Services.Auth;
+using App.Desktop.Services.GroupTree;
 using App.Desktop.Services.Upload;
 
 namespace App.Desktop.Tests;
@@ -99,7 +106,7 @@ public sealed class DesktopUploadSectionTests
             "Выполняется предварительная проверка в desktop-local dev boundary.",
             DesktopUploadSectionText.PreUploadCheckInProgressMessage);
         Assert.Equal(
-            "Предварительная проверка пока доступна только в dev-smoke режиме. Реальный вызов App.Api будет добавлен отдельным approved slice.",
+            "Предварительная проверка недоступна: задайте live control-plane base address или включите dev-smoke guard.",
             DesktopUploadSectionText.PreUploadCheckDeferredMessage);
         Assert.Equal(
             "Предварительная проверка: загрузка разрешена в dev-smoke режиме.",
@@ -231,17 +238,51 @@ public sealed class DesktopUploadSectionTests
     }
 
     [Fact]
+    public void PreUploadCheckClientUsesOnlyApprovedEndpointAndDoesNotReadRawBodiesOrBytes()
+    {
+        string[] sourceFiles =
+        [
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "DesktopPreUploadCheck.cs"),
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "DisabledDesktopPreUploadCheckClient.cs"),
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "FakeDesktopPreUploadCheckClient.cs"),
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "HttpDesktopPreUploadCheckClient.cs"),
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Boundaries", "DesktopPreUploadCheckBoundary.cs")
+        ];
+
+        foreach (string sourceFile in sourceFiles)
+        {
+            string source = File.ReadAllText(sourceFile);
+
+            Assert.DoesNotContain("ReadAsStringAsync", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("ReadAllBytes", source, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("ReadAllBytesAsync", source, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("WriteLine", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("Log", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("/api/video/upload-receipt", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("/api/video/upload-receipt-sync", source, StringComparison.Ordinal);
+        }
+
+        string liveClientSource = File.ReadAllText(
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "HttpDesktopPreUploadCheckClient.cs"));
+
+        Assert.Contains("/api/video/pre-upload-check", liveClientSource, StringComparison.Ordinal);
+        Assert.DoesNotContain("/api/video/pre-upload-check/", liveClientSource, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void FakeUploadFileSelectionHashBusinessObjectKeyPreUploadCheckSiteUploadAndUploadReceiptAreDevOnlyAndDisabledByDefault()
     {
         Assert.False(DesktopUploadSectionOptions.Disabled.IsDevFakeUploadFileEnabled);
         Assert.False(DesktopUploadSectionOptions.Disabled.IsDevFakeUploadHashEnabled);
         Assert.False(DesktopUploadSectionOptions.Disabled.IsDevFakeBusinessObjectKeyEnabled);
+        Assert.False(DesktopUploadSectionOptions.Disabled.IsLiveControlPlanePreUploadCheckEnabled);
         Assert.False(DesktopUploadSectionOptions.Disabled.IsDevFakePreUploadCheckEnabled);
         Assert.False(DesktopUploadSectionOptions.Disabled.IsDevFakeSiteUploadEnabled);
         Assert.False(DesktopUploadSectionOptions.Disabled.IsDevFakeUploadReceiptEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue(null).IsDevFakeUploadFileEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue(null).IsDevFakeUploadHashEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue(null).IsDevFakeBusinessObjectKeyEnabled);
+        Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue(null).IsLiveControlPlanePreUploadCheckEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue(null).IsDevFakePreUploadCheckEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue(null).IsDevFakeSiteUploadEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue(null).IsDevFakeUploadReceiptEnabled);
@@ -729,6 +770,230 @@ public sealed class DesktopUploadSectionTests
 
         Assert.Equal(decision, result.Decision);
         Assert.Equal(expectedDecisionPreview, result.DecisionPreview);
+    }
+
+    [Fact]
+    public async Task HttpPreUploadCheckClientUsesExistingEndpointAndSafeRequestPayload()
+    {
+        string accessToken = CreateSensitiveValue("access");
+        Guid userId = Guid.NewGuid();
+        Guid deviceId = Guid.NewGuid();
+        Guid groupNodeId = Guid.NewGuid();
+        DesktopSessionState sessionState = await CreateSignedInSessionStateAsync(userId, deviceId, accessToken);
+        var groupSelectionState = new DesktopGroupSelectionState();
+        Assert.True(groupSelectionState.TrySelect(new DesktopGroupTreeNode(
+            groupNodeId.ToString("D"),
+            "Safe Group",
+            Depth: 1,
+            CanSelect: true)));
+        DesktopPreUploadCheckRequestPreview requestPreview =
+            DesktopPreUploadCheckRequestPreview.TryCreate(
+                DesktopUploadSelectedFile.VisualSmokeFile,
+                FakeDesktopVideoHashService.VisualSmokeSha256Hex,
+                new DesktopUploadBusinessObjectKey(DesktopUploadBusinessObjectKey.VisualSmokeValue),
+                groupSelectionState.SelectedGroup)
+            ?? throw new InvalidOperationException("Preview was not created.");
+        var handler = new StubHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = JsonContent(new
+            {
+                preUploadCheckId = Guid.NewGuid(),
+                decision = "ALLOW",
+                canUploadToSite = true,
+                reasonCode = "fast_path_clear",
+                message = $"server-message-{CreateSensitiveValue("refresh")}",
+                existingPreUploadCheckId = (string?)null,
+                requiredNextSteps = new[] { "UPLOAD_TO_SITE_DIRECT", "SEND_UPLOAD_RECEIPT" },
+                sitePlan = new
+                {
+                    provider = "Stub",
+                    externalVideoId = "site-video-001",
+                    storageKey = "videos/site-video-001.mp4",
+                    requiredReceiptEndpoint = "/api/video/upload-receipt"
+                },
+                checkedAtUtc = DateTimeOffset.UtcNow
+            })
+        });
+        var client = new HttpDesktopPreUploadCheckClient(
+            new HttpClient(handler)
+            {
+                BaseAddress = new Uri("https://control-plane.local")
+            },
+            sessionState,
+            sessionState);
+
+        DesktopPreUploadCheckResult result = await client.CheckAsync(requestPreview, CancellationToken.None);
+
+        Assert.Equal(DesktopPreUploadCheckStatus.Allowed, result.Status);
+        Assert.Equal(DesktopPreUploadCheckDecision.Allow, result.Decision);
+        Assert.NotNull(handler.LastRequest);
+        Assert.Equal(HttpMethod.Post, handler.LastRequest.Method);
+        Assert.Equal("/api/video/pre-upload-check", handler.LastRequest.RequestUri?.AbsolutePath);
+        Assert.Equal("Bearer", handler.LastRequest.Headers.Authorization?.Scheme);
+        Assert.Equal(accessToken, handler.LastRequest.Headers.Authorization?.Parameter);
+
+        JsonNode body = JsonNode.Parse(handler.LastRequestBody ?? string.Empty)
+            ?? throw new InvalidOperationException("Request JSON was not captured.");
+        Assert.Equal(userId, body["userId"]?.GetValue<Guid>());
+        Assert.Equal(deviceId, body["deviceId"]?.GetValue<Guid>());
+        Assert.Equal(groupNodeId, body["groupNodeId"]?.GetValue<Guid>());
+        Assert.Equal(DesktopUploadBusinessObjectKey.VisualSmokeValue, body["businessObjectKey"]?.GetValue<string>());
+        Assert.Equal(DesktopUploadSelectedFile.VisualSmokeFileName, body["fileName"]?.GetValue<string>());
+        Assert.Equal(DesktopUploadSelectedFile.VisualSmokeFileSizeBytes, body["sizeBytes"]?.GetValue<long>());
+        Assert.Equal(FakeDesktopVideoHashService.VisualSmokeSha256Hex, body["byteSha256"]?.GetValue<string>());
+        Assert.Equal(DesktopUploadSelectedFile.VisualSmokeContentType, body["contentType"]?.GetValue<string>());
+        Assert.NotNull(body["capturedAtUtc"]);
+        Assert.DoesNotContain(accessToken, handler.LastRequestBody ?? string.Empty, StringComparison.Ordinal);
+        Assert.DoesNotContain(accessToken, result.ToString(), StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("ALLOW", true, DesktopPreUploadCheckStatus.Allowed, DesktopPreUploadCheckDecision.Allow, "ALLOW")]
+    [InlineData("ALLOW_WITH_REVIEW", true, DesktopPreUploadCheckStatus.AllowedWithReview, DesktopPreUploadCheckDecision.AllowWithReview, "ALLOW_WITH_REVIEW")]
+    [InlineData("BLOCK_HARD_DUPLICATE", false, DesktopPreUploadCheckStatus.Blocked, DesktopPreUploadCheckDecision.BlockHardDuplicate, "BLOCK_HARD_DUPLICATE")]
+    [InlineData("BLOCK_POSSIBLE_FALSIFICATION", false, DesktopPreUploadCheckStatus.Blocked, DesktopPreUploadCheckDecision.BlockPossibleFalsification, "BLOCK_POSSIBLE_FALSIFICATION")]
+    public async Task HttpPreUploadCheckClientMapsExistingResponseDecisionsSafely(
+        string apiDecision,
+        bool canUploadToSite,
+        DesktopPreUploadCheckStatus expectedStatus,
+        DesktopPreUploadCheckDecision expectedDecision,
+        string expectedDecisionPreview)
+    {
+        DesktopSessionState sessionState = await CreateSignedInSessionStateAsync(
+            Guid.NewGuid(),
+            deviceId: null,
+            CreateSensitiveValue("access"));
+        var handler = new StubHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = JsonContent(new
+            {
+                preUploadCheckId = Guid.NewGuid(),
+                decision = apiDecision,
+                canUploadToSite,
+                reasonCode = "mapped",
+                message = "safe server message is intentionally not surfaced",
+                existingPreUploadCheckId = (string?)null,
+                requiredNextSteps = canUploadToSite
+                    ? new[] { "UPLOAD_TO_SITE_DIRECT", "SEND_UPLOAD_RECEIPT" }
+                    : new[] { "DO_NOT_UPLOAD", "SHOW_DECISION_TO_USER" },
+                sitePlan = canUploadToSite
+                    ? new
+                    {
+                        provider = "Stub",
+                        externalVideoId = "site-video-001",
+                        storageKey = "videos/site-video-001.mp4",
+                        requiredReceiptEndpoint = "/api/video/upload-receipt"
+                    }
+                    : null,
+                checkedAtUtc = DateTimeOffset.UtcNow
+            })
+        });
+        var client = new HttpDesktopPreUploadCheckClient(
+            new HttpClient(handler)
+            {
+                BaseAddress = new Uri("https://control-plane.local")
+            },
+            sessionState,
+            sessionState);
+
+        DesktopPreUploadCheckResult result = await client.CheckAsync(CreateVisualSmokePreUploadPreview(), CancellationToken.None);
+
+        Assert.Equal(expectedStatus, result.Status);
+        Assert.Equal(expectedDecision, result.Decision);
+        Assert.Equal(expectedDecisionPreview, result.DecisionPreview);
+        Assert.DoesNotContain("safe server message", result.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task HttpPreUploadCheckClientHandlesUnavailableUnauthorizedFailedAndMalformedResponsesSafely()
+    {
+        string accessToken = CreateSensitiveValue("access");
+        DesktopSessionState sessionState = await CreateSignedInSessionStateAsync(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            accessToken);
+        DesktopPreUploadCheckRequestPreview requestPreview = CreateVisualSmokePreUploadPreview();
+
+        var unauthorized = new HttpDesktopPreUploadCheckClient(
+            CreateHttpClient(_ => new HttpResponseMessage(HttpStatusCode.Unauthorized)),
+            sessionState,
+            sessionState);
+        DesktopPreUploadCheckResult unauthorizedResult =
+            await unauthorized.CheckAsync(requestPreview, CancellationToken.None);
+        Assert.Equal(DesktopPreUploadCheckStatus.Unauthorized, unauthorizedResult.Status);
+        Assert.Equal(DesktopUploadSectionText.PreUploadCheckLiveUnauthorizedMessage, unauthorizedResult.Message);
+
+        var unavailable = new HttpDesktopPreUploadCheckClient(
+            new HttpClient(new StubHttpMessageHandler(_ => throw new HttpRequestException(
+                $"transport failed {accessToken}")))
+            {
+                BaseAddress = new Uri("https://control-plane.local")
+            },
+            sessionState,
+            sessionState);
+        DesktopPreUploadCheckResult unavailableResult =
+            await unavailable.CheckAsync(requestPreview, CancellationToken.None);
+        Assert.Equal(DesktopPreUploadCheckStatus.Unavailable, unavailableResult.Status);
+        Assert.Equal(DesktopUploadSectionText.PreUploadCheckLiveUnavailableMessage, unavailableResult.Message);
+
+        string rawFailureBody = $"{{\"accessToken\":\"{CreateSensitiveValue("response")}\"}}";
+        var failed = new HttpDesktopPreUploadCheckClient(
+            CreateHttpClient(_ => new HttpResponseMessage(HttpStatusCode.InternalServerError)
+            {
+                Content = new StringContent(rawFailureBody, Encoding.UTF8, "application/json")
+            }),
+            sessionState,
+            sessionState);
+        DesktopPreUploadCheckResult failedResult =
+            await failed.CheckAsync(requestPreview, CancellationToken.None);
+        Assert.Equal(DesktopPreUploadCheckStatus.Failed, failedResult.Status);
+        Assert.Equal(DesktopUploadSectionText.PreUploadCheckLiveFailedMessage, failedResult.Message);
+        Assert.DoesNotContain(rawFailureBody, failedResult.ToString(), StringComparison.Ordinal);
+
+        var malformed = new HttpDesktopPreUploadCheckClient(
+            CreateHttpClient(_ => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"decision\":\"ALLOW\",", Encoding.UTF8, "application/json")
+            }),
+            sessionState,
+            sessionState);
+        DesktopPreUploadCheckResult malformedResult =
+            await malformed.CheckAsync(requestPreview, CancellationToken.None);
+        Assert.Equal(DesktopPreUploadCheckStatus.Malformed, malformedResult.Status);
+        Assert.Equal(DesktopUploadSectionText.PreUploadCheckLiveMalformedMessage, malformedResult.Message);
+
+        foreach (DesktopPreUploadCheckResult result in
+            new[] { unauthorizedResult, unavailableResult, failedResult, malformedResult })
+        {
+            Assert.Null(result.Decision);
+            Assert.DoesNotContain(accessToken, result.ToString(), StringComparison.Ordinal);
+            Assert.DoesNotContain("accessToken", result.ToString(), StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("refreshToken", result.ToString(), StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("Authorization", result.ToString(), StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("raw response", result.ToString(), StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    [Fact]
+    public async Task HttpPreUploadCheckClientWithoutSessionDoesNotSendRequest()
+    {
+        var handler = new StubHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = JsonContent(new { })
+        });
+        var client = new HttpDesktopPreUploadCheckClient(
+            new HttpClient(handler)
+            {
+                BaseAddress = new Uri("https://control-plane.local")
+            },
+            new StaticDesktopControlPlaneAccessTokenProvider(accessToken: null),
+            new StaticDesktopSessionState(DesktopSessionSnapshot.SignedOut));
+
+        DesktopPreUploadCheckResult result =
+            await client.CheckAsync(CreateVisualSmokePreUploadPreview(), CancellationToken.None);
+
+        Assert.Equal(DesktopPreUploadCheckStatus.Unauthorized, result.Status);
+        Assert.Null(handler.LastRequest);
     }
 
     [Fact]
@@ -1424,12 +1689,22 @@ public sealed class DesktopUploadSectionTests
             DesktopUploadSectionText.StepFourTitle,
             DesktopUploadSectionText.PreUploadCheckNotReadyMessage,
             DesktopUploadSectionText.PreUploadCheckReadyMessage,
+            DesktopUploadSectionText.PreUploadCheckLiveReadyMessage,
             DesktopUploadSectionText.PreUploadCheckInProgressMessage,
+            DesktopUploadSectionText.PreUploadCheckLiveInProgressMessage,
             DesktopUploadSectionText.PreUploadCheckDeferredMessage,
             DesktopUploadSectionText.PreUploadCheckAllowedDevMessage,
             DesktopUploadSectionText.PreUploadCheckAllowWithReviewDevMessage,
             DesktopUploadSectionText.PreUploadCheckBlockHardDuplicateDevMessage,
             DesktopUploadSectionText.PreUploadCheckBlockPossibleFalsificationDevMessage,
+            DesktopUploadSectionText.PreUploadCheckAllowedLiveMessage,
+            DesktopUploadSectionText.PreUploadCheckAllowWithReviewLiveMessage,
+            DesktopUploadSectionText.PreUploadCheckBlockHardDuplicateLiveMessage,
+            DesktopUploadSectionText.PreUploadCheckBlockPossibleFalsificationLiveMessage,
+            DesktopUploadSectionText.PreUploadCheckLiveUnauthorizedMessage,
+            DesktopUploadSectionText.PreUploadCheckLiveUnavailableMessage,
+            DesktopUploadSectionText.PreUploadCheckLiveFailedMessage,
+            DesktopUploadSectionText.PreUploadCheckLiveMalformedMessage,
             DesktopUploadSectionText.PreUploadCheckCanceledMessage,
             DesktopUploadSectionText.PreUploadCheckButton,
             DesktopUploadSectionText.PreUploadCheckBusyButton,
@@ -1604,6 +1879,60 @@ public sealed class DesktopUploadSectionTests
         return await viewModel.UploadToSiteAsync(CancellationToken.None);
     }
 
+    private static DesktopPreUploadCheckRequestPreview CreateVisualSmokePreUploadPreview()
+    {
+        return DesktopPreUploadCheckRequestPreview.TryCreate(
+            DesktopUploadSelectedFile.VisualSmokeFile,
+            FakeDesktopVideoHashService.VisualSmokeSha256Hex,
+            new DesktopUploadBusinessObjectKey(DesktopUploadBusinessObjectKey.VisualSmokeValue))
+            ?? throw new InvalidOperationException("Preview was not created.");
+    }
+
+    private static async Task<DesktopSessionState> CreateSignedInSessionStateAsync(
+        Guid userId,
+        Guid? deviceId,
+        string accessToken)
+    {
+        var sessionState = new DesktopSessionState(new DisabledDesktopSessionStore());
+        DateTimeOffset issuedAtUtc = DateTimeOffset.UtcNow;
+
+        await sessionState.SetSignedInAsync(
+            DesktopAuthenticatedSession.Create(
+                Guid.NewGuid(),
+                userId,
+                deviceId,
+                "Live User",
+                accessToken,
+                refreshToken: null,
+                issuedAtUtc,
+                issuedAtUtc.AddMinutes(15),
+                isOfflineRestricted: false),
+            CancellationToken.None);
+
+        return sessionState;
+    }
+
+    private static HttpClient CreateHttpClient(Func<HttpRequestMessage, HttpResponseMessage> responseFactory)
+    {
+        return new HttpClient(new StubHttpMessageHandler(responseFactory))
+        {
+            BaseAddress = new Uri("https://control-plane.local")
+        };
+    }
+
+    private static StringContent JsonContent<T>(T value)
+    {
+        return new StringContent(
+            JsonSerializer.Serialize(value),
+            Encoding.UTF8,
+            "application/json");
+    }
+
+    private static string CreateSensitiveValue(string prefix)
+    {
+        return $"{prefix}-{Guid.NewGuid():N}";
+    }
+
     private sealed class CancelingDesktopVideoFilePicker : IDesktopVideoFilePicker
     {
         public ValueTask<DesktopVideoFilePickerResult> PickVideoFileAsync(CancellationToken cancellationToken)
@@ -1658,6 +1987,72 @@ public sealed class DesktopUploadSectionTests
         {
             CallCount++;
             throw new InvalidOperationException("Disabled fake UploadReceipt boundary should not be called.");
+        }
+    }
+
+    private sealed class StaticDesktopControlPlaneAccessTokenProvider(string? accessToken) :
+        IDesktopControlPlaneAccessTokenProvider
+    {
+        public ValueTask<DesktopControlPlaneAccessTokenSnapshot> GetCurrentAccessTokenAsync(
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            return ValueTask.FromResult(new DesktopControlPlaneAccessTokenSnapshot(
+                IsAuthenticated: !string.IsNullOrWhiteSpace(accessToken),
+                accessToken));
+        }
+    }
+
+    private sealed class StaticDesktopSessionState(DesktopSessionSnapshot current) : IDesktopSessionState
+    {
+        public DesktopSessionSnapshot Current { get; private set; } = current;
+
+        public ValueTask<DesktopSessionSnapshot> LoadAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            return ValueTask.FromResult(Current);
+        }
+
+        public ValueTask<DesktopSessionSnapshot> SetSignedInAsync(
+            DesktopAuthenticatedSession session,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            Current = DesktopSessionSnapshot.FromSession(session);
+            return ValueTask.FromResult(Current);
+        }
+
+        public ValueTask<DesktopSessionSnapshot> SignOutAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            Current = DesktopSessionSnapshot.SignedOut;
+            return ValueTask.FromResult(Current);
+        }
+    }
+
+    private sealed class StubHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> responseFactory) :
+        HttpMessageHandler
+    {
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        public string? LastRequestBody { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            LastRequest = request;
+            LastRequestBody = request.Content is null
+                ? null
+                : await request.Content.ReadAsStringAsync(cancellationToken);
+
+            return responseFactory(request);
         }
     }
 


### PR DESCRIPTION
## Coder
Coder 1 acting as Coder 2 / Desktop Client

## Task ID
S2-69 Desktop PreUploadCheck Control-Plane Client Probe / Existing API Boundary

## Module
App.Desktop / PreUploadCheck control-plane client probe

## Scope
Added an App.Desktop-local live `IDesktopPreUploadCheckClient` boundary only after confirming the existing approved App.Api surface. Preserved the fake/dev PreUploadCheck visual-smoke path and the existing fake/dev downstream site upload/receipt chain.

## Changed Areas
- `docs/task-cards/S2-69_desktop-preuploadcheck-control-plane-client-probe-task-card.txt`
- `src/App.Desktop/**`
- `tests/Unit/App.Desktop.Tests/**`

## Base Main SHA
`cadb9b3867dae9b03c833c222530a0113a98b8c4`

## Coordination Log Entries Reviewed
Issue #89 metadata/comments reviewed. Relevant entries reviewed: S2-64 `4e54ffd0fcfbe53724ff8dca096e6a7015667d30`, S2-65 `8eaac3d07dd8ba647054d2469ae6233d7b490930`, S2-66 `7e59b6c02b5dacef8b49b94f5ceeb676ac89bf7a`, S2-67 `9947757cb9bbb364c721793ab52e951c6ec1e228`, S2-68 `cadb9b3867dae9b03c833c222530a0113a98b8c4`.

## Handoff / Task Cards Reviewed
S2-58 through S2-68 desktop task cards reviewed, including the S2-68 GroupTree live control-plane client probe handoff.

## Existing PreUploadCheck API / Contract Found
Yes. Read-only inspection found `POST /api/video/pre-upload-check` in `src/Modules/VideoUpload/VideoUploadModule.cs`, with DTO shape in `src/BuildingBlocks/Contracts/VideoUpload/PreUploadCheckDtos.cs` and authorization coverage in integration tests.

## Contracts
None changed.

## Migrations
None.

## Feature Flags / Env Guard
Uses existing `AA_DESKTOP_DEV_FAKE_PREUPLOAD_CHECK_ENABLED` for fake/dev visual smoke when no live base address is configured. Uses existing `AA_DESKTOP_CONTROL_PLANE_BASE_ADDRESS` to select the live PreUploadCheck client. If live base address is configured, fake PreUploadCheck is not selected.

## API Impact
No App.Api behavior, endpoint, DTO, contract, migration, deploy, or server behavior changes. Desktop uses the existing approved endpoint only. Video bytes still do not go through App.Api.

## Web Impact
None.

## Android Impact
None.

## Offline Behavior
None.

## Rollback
Revert the S2-69 PR.

## Validation
- `git diff --check` PASS
- `dotnet restore AnalyticsAutomation-Core.sln -nologo` PASS
- `dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore` PASS
- `dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal` PASS
- `dotnet build AnalyticsAutomation-Core.sln -nologo -v minimal` PASS
- `dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal` PASS, 174 passed
- hidden/control Unicode scan over changed text files PASS
- App.Desktop fake-auth/fake-group-tree/fake-upload-chain visual smoke PASS

## Visual Smoke Screenshot Folder / Files
`C:\CODEX\Temp\S2-69_DESKTOP_PREUPLOADCHECK_CLIENT_PROBE_VISUAL_SMOKE_20260501_174708\`
- `01_baseline_signin.png`
- `02_signed_in_shell.png`
- `03_upload_section_before_preuploadcheck.png`
- `04_preuploadcheck_request_preview.png`
- `05_after_fake_preuploadcheck_allow.png`
- `06_after_sign_out.png`

## Handoff Docs / Task Card
`docs/task-cards/S2-69_desktop-preuploadcheck-control-plane-client-probe-task-card.txt`

## Next Step
Approved follow-up slice for production businessObjectKey/report-draft source of truth and any real site upload / real UploadReceipt integration.

## NO-GO / Deferred
NO-GO: none for S2-69 because the existing PreUploadCheck API/contract was found. Deferred: production businessObjectKey source of truth, report-draft binding, real site upload, and real UploadReceipt remain outside this slice.