### PR TITLE
[codex] S2-70 Desktop UploadReceipt Control-Plane Client Probe

### DIFF
--- a/docs/task-cards/S2-70_desktop-upload-receipt-control-plane-client-probe-task-card.txt
+++ b/docs/task-cards/S2-70_desktop-upload-receipt-control-plane-client-probe-task-card.txt
@@ -1,0 +1,173 @@
+Title:
+S2-70 Desktop UploadReceipt Control-Plane Client Probe / Existing API Boundary
+
+Module:
+App.Desktop / UploadReceipt control-plane client probe
+
+Owner:
+Coder 1 acting as Coder 2 / Desktop Client
+
+Client form:
+desktop standalone
+
+Type:
+narrow runtime desktop-only client boundary slice after S2-69 PreUploadCheck control-plane probe
+
+Status:
+Runtime task card created with implementation.
+
+Goal:
+Probe the existing App.Api / Modules.VideoUpload / contracts UploadReceipt surface read-only and, only because an existing approved endpoint was found, add an App.Desktop-local live UploadReceipt client boundary without backend, contract, migration, deploy, Web, or Android changes.
+
+Existing UploadReceipt API endpoint/contract found:
+Yes.
+
+Read-only sources inspected:
+- src/App.Api/Program.cs
+- src/App.Api/appsettings.json
+- src/Modules/VideoUpload/VideoUploadModule.cs
+- src/Modules/VideoUpload/UploadReceiptSyncService.cs
+- src/BuildingBlocks/Contracts/VideoUpload/PreUploadCheckDtos.cs
+- src/BuildingBlocks/Contracts/VideoUpload/UploadReceiptDtosV1.cs
+- tests/Integration/App.Api/UploadControlPlaneAuthorizationTests.cs
+- tests/Integration/VideoUpload/UploadReceiptServiceTests.cs
+- tests/Integration/WorkerPipeline/UploadReceiptPipelineBridgeTests.cs
+- tests/Integration/** references found by repository search
+
+Existing approved surface used:
+- POST /api/video/upload-receipt
+- Authorization: bearer session access token from existing desktop sign-in session
+- Request shape derived from existing code only:
+  VideoUploadReceiptRequestDto with preUploadCheckId, userId, deviceId, groupNodeId, externalVideoId, storageKey, siteStatus, sizeBytes, byteSha256, idempotencyKey, uploadedAtUtc
+- Response shape derived from existing code only:
+  VideoUploadReceiptResponseDto with uploadReceiptId, preUploadCheckId, status, accepted, wasAlreadyAccepted, message, analysisJobStatus, receivedAtUtc
+
+Scope:
+- Keep the current Russian SignIn UI before authentication.
+- After SignIn, keep the signed-in shell.
+- Preserve S2-68 GroupTree live/fake behavior.
+- Preserve S2-69 PreUploadCheck live/fake behavior.
+- Preserve S2-66 fake/dev UploadReceipt visual smoke when no live control-plane base address is configured.
+- Add HttpDesktopUploadReceiptClient as an App.Desktop-local IDesktopUploadReceiptClient implementation.
+- Select the live client only when AA_DESKTOP_CONTROL_PLANE_BASE_ADDRESS is configured.
+- Do not select fake UploadReceipt when a live base address is configured.
+- Keep selected group context preview-only in the upload section.
+- Keep direct site upload as the existing desktop fake/dev boundary; production site provider remains deferred.
+- Clear UploadReceipt preview/result state on back and sign-out.
+
+Allowed changed areas:
+- docs/task-cards/S2-70_desktop-upload-receipt-control-plane-client-probe-task-card.txt
+- src/App.Desktop/**
+- tests/Unit/App.Desktop.Tests/**
+
+Forbidden changed areas:
+- src/App.Api/**
+- src/App.Worker/**
+- src/App.Web/**
+- src/App.Mobile.Android/**
+- src/App.UI.Shared/**
+- src/BuildingBlocks.Contracts/**
+- src/Modules/**
+- DB migrations
+- .github/workflows/**
+- deploy scripts
+- docs/ops/**
+- committed screenshots or runtime artifacts
+
+Contracts:
+none
+
+Migrations:
+none
+
+Feature flags/env guard:
+- Existing AA_DESKTOP_DEV_FAKE_UPLOAD_RECEIPT_ENABLED=true keeps the fake/dev UploadReceipt visual-smoke path when no live control-plane base address is configured.
+- Existing AA_DESKTOP_CONTROL_PLANE_BASE_ADDRESS enables the live App.Api UploadReceipt client.
+- If AA_DESKTOP_CONTROL_PLANE_BASE_ADDRESS is configured, fake UploadReceipt is not selected even when AA_DESKTOP_DEV_FAKE_UPLOAD_RECEIPT_ENABLED=true.
+- If AA_DESKTOP_CONTROL_PLANE_BASE_ADDRESS is absent and fake guard is off, UploadReceipt remains disabled/unavailable with a safe Russian message.
+
+Events:
+none
+
+Offline behavior:
+none
+
+Security guardrails:
+- The live client sends the bearer access token only in the request header.
+- Do not log or display accessToken, refreshToken, Authorization, password, raw session id, raw response body, token-like values, or full local file paths.
+- The live client sends only safe fields from the existing request contract.
+- The live client does not read, log, or surface raw response bodies.
+- Unavailable, failed, unauthorized, and malformed responses produce safe Russian status messages.
+- Video bytes do not go through App.Api.
+- Screenshots and runtime artifacts stay under C:\CODEX\Temp and are not committed.
+
+Explicitly out of scope:
+- App.Api changes.
+- Modules changes.
+- BuildingBlocks.Contracts changes.
+- Backend endpoint/DTO/contract additions.
+- DB migrations.
+- Deploy/workflow changes.
+- App.Web changes.
+- App.Mobile.Android changes.
+- Real site upload changes.
+- Video bytes through App.Api.
+- Offline queue.
+- Report draft runtime.
+
+Deferred:
+Real UploadReceipt endpoint/contract was found, so the desktop HTTP client boundary is implemented in S2-70. Production site provider and any real direct-site upload behavior remain deferred to a separate approved slice. Production source of truth for businessObjectKey/report-draft binding remains deferred to a separate approved slice.
+
+Rollback:
+revert S2-70 PR
+
+Validation:
+- git diff --check
+- dotnet restore AnalyticsAutomation-Core.sln -nologo
+- dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore
+- dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal
+- dotnet build AnalyticsAutomation-Core.sln -nologo -v minimal
+- dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal
+- hidden/control Unicode scan over changed text files
+- App.Desktop fake-auth/fake-group-tree/fake-upload-chain visual smoke with screenshots
+
+Definition of done:
+- Existing UploadReceipt API/contract is documented as found.
+- HttpDesktopUploadReceiptClient uses only POST /api/video/upload-receipt and the existing VideoUploadReceipt request/response shape.
+- Live UploadReceipt client requires AA_DESKTOP_CONTROL_PLANE_BASE_ADDRESS.
+- Fake UploadReceipt remains disabled by default and enabled only by AA_DESKTOP_DEV_FAKE_UPLOAD_RECEIPT_ENABLED=true when live base address is absent.
+- Fake UploadReceipt is not selected when live base address is configured.
+- Disabled/no-base/no-fake state shows a safe Russian disabled/deferred message.
+- Live unavailable, failed, unauthorized, and malformed responses show safe Russian messages.
+- Tokens/passwords/Authorization/raw bodies/full local paths are not visible in UI/result diagnostics.
+- Request preview remains safe and does not show raw request/response body.
+- Back/sign-out clear UploadReceipt preview and result state.
+- No App.Api, contracts, migrations, deploy, App.Web, or App.Mobile.Android files are changed.
+- No real site upload behavior changes are introduced beyond the existing fake/dev chain.
+- Automated App.Desktop unit tests cover guards, live endpoint request construction, safe response mapping, safe failures, fake preservation, reset behavior, no video bytes through App.Api, and visible-string safety.
+- Required visual-smoke screenshots are saved under C:\CODEX\Temp and kept out of git.
+
+Visual-smoke definition of done:
+- Run App.Desktop with:
+  AA_DESKTOP_DEV_FAKE_AUTH_ENABLED=true
+  AA_DESKTOP_DEV_FAKE_GROUP_TREE_ENABLED=true
+  AA_DESKTOP_DEV_FAKE_UPLOAD_FILE_ENABLED=true
+  AA_DESKTOP_DEV_FAKE_UPLOAD_HASH_ENABLED=true
+  AA_DESKTOP_DEV_FAKE_BUSINESS_OBJECT_KEY_ENABLED=true
+  AA_DESKTOP_DEV_FAKE_PREUPLOAD_CHECK_ENABLED=true
+  AA_DESKTOP_DEV_FAKE_SITE_UPLOAD_ENABLED=true
+  AA_DESKTOP_DEV_FAKE_UPLOAD_RECEIPT_ENABLED=true
+- Do not set AA_DESKTOP_CONTROL_PLANE_BASE_ADDRESS for fake-auth visual smoke.
+- Use non-secret fake-auth visual-smoke data:
+  login: visual-smoke-user
+  password: visual-smoke-password
+- Capture screenshots under C:\CODEX\Temp\S2-70_DESKTOP_UPLOAD_RECEIPT_CLIENT_PROBE_VISUAL_SMOKE_<timestamp>\.
+- Required screenshots:
+  01_baseline_signin.png
+  02_signed_in_shell.png
+  03_upload_section_after_fake_site_upload_success.png
+  04_upload_receipt_request_preview.png
+  05_after_fake_upload_receipt_accepted.png
+  06_after_sign_out.png
+- Confirm no password, accessToken, refreshToken, Authorization, raw session id, raw response body, raw path, or real secret is visible.
+- Confirm screenshots and runtime artifacts are not committed.

--- a/src/App.Desktop/Boundaries/DesktopSignInBoundary.cs
+++ b/src/App.Desktop/Boundaries/DesktopSignInBoundary.cs
@@ -259,12 +259,28 @@ public static class DesktopUploadSectionText
         "Нужны выбранный файл, SHA-256, businessObjectKey, решение ALLOW или ALLOW_WITH_REVIEW и успешная загрузка на сайт.";
     public const string UploadReceiptReadyMessage =
         "Preview квитанции загрузки готов. В этом slice доступен только desktop-local dev boundary.";
+    public const string UploadReceiptLiveReadyMessage =
+        "Preview квитанции загрузки готов. Будет использован существующий control-plane endpoint UploadReceipt.";
     public const string UploadReceiptInProgressMessage =
         "Формируется квитанция загрузки в desktop-local dev boundary.";
+    public const string UploadReceiptLiveInProgressMessage =
+        "Формируется квитанция загрузки через control-plane boundary.";
     public const string UploadReceiptDeferredMessage =
-        "Квитанция загрузки пока доступна только в dev-smoke режиме. Реальный вызов App.Api будет добавлен отдельным approved slice.";
+        "Квитанция загрузки недоступна: задайте live control-plane base address или включите dev-smoke guard.";
     public const string UploadReceiptAcceptedDevMessage =
         "Квитанция загрузки сформирована в dev-smoke режиме.";
+    public const string UploadReceiptAcceptedLiveMessage =
+        "Квитанция загрузки принята control-plane.";
+    public const string UploadReceiptAlreadyAcceptedLiveMessage =
+        "Квитанция загрузки уже была принята control-plane.";
+    public const string UploadReceiptLiveUnauthorizedMessage =
+        "Квитанция загрузки недоступна: требуется повторный вход.";
+    public const string UploadReceiptLiveUnavailableMessage =
+        "Квитанция загрузки временно недоступна. Проверьте подключение или настройку.";
+    public const string UploadReceiptLiveFailedMessage =
+        "Квитанция загрузки не принята. Проверьте состояние загрузки и попробуйте ещё раз.";
+    public const string UploadReceiptLiveMalformedMessage =
+        "Квитанция загрузки вернула неподдерживаемый ответ.";
     public const string UploadReceiptCanceledMessage = "Формирование квитанции загрузки отменено.";
     public const string UploadReceiptButton = "Сформировать квитанцию";
     public const string UploadReceiptBusyButton = "Формируется...";
@@ -282,7 +298,7 @@ public static class DesktopUploadSectionText
     public const string UploadReceiptResultReceiptIdLabel = "receiptId";
     public const string UploadReceiptResultServerCorrelationIdLabel = "serverCorrelationId";
     public const string NextStepDeferredMessage =
-        "Следующий шаг отложен: реальный control-plane UploadReceipt client будет добавлен отдельным approved desktop slice.";
+        "Следующий шаг отложен: production site provider остаётся отдельным approved desktop slice.";
 }
 
 public sealed record DesktopUploadSelectedFile(

--- a/src/App.Desktop/Composition/DesktopCompositionRoot.cs
+++ b/src/App.Desktop/Composition/DesktopCompositionRoot.cs
@@ -58,7 +58,9 @@ public static class DesktopCompositionRoot
             ? DesktopGroupTreeOptions.EnabledForLiveControlPlane
             : groupTreeOptions;
         DesktopUploadSectionOptions effectiveUploadSectionOptions = authOptions.IsControlPlaneSignInConfigured
-            ? uploadSectionOptions.WithLiveControlPlanePreUploadCheck()
+            ? uploadSectionOptions
+                .WithLiveControlPlanePreUploadCheck()
+                .WithLiveControlPlaneUploadReceipt()
             : uploadSectionOptions;
 
         var services = new ServiceCollection();
@@ -158,7 +160,12 @@ public static class DesktopCompositionRoot
             services.AddSingleton<IDesktopDirectSiteUploadClient, DisabledDesktopDirectSiteUploadClient>();
         }
 
-        if (effectiveUploadSectionOptions.IsDevFakeUploadReceiptEnabled)
+        if (effectiveUploadSectionOptions.IsLiveControlPlaneUploadReceiptEnabled
+            && authOptions.IsControlPlaneSignInConfigured)
+        {
+            services.AddSingleton<IDesktopUploadReceiptClient, HttpDesktopUploadReceiptClient>();
+        }
+        else if (effectiveUploadSectionOptions.IsDevFakeUploadReceiptEnabled)
         {
             services.AddSingleton<IDesktopUploadReceiptClient, FakeDesktopUploadReceiptClient>();
         }

--- a/src/App.Desktop/Services/Upload/DesktopPreUploadCheck.cs
+++ b/src/App.Desktop/Services/Upload/DesktopPreUploadCheck.cs
@@ -124,11 +124,17 @@ public sealed class DesktopPreUploadCheckResult
     private DesktopPreUploadCheckResult(
         DesktopPreUploadCheckStatus status,
         DesktopPreUploadCheckDecision? decision,
-        string message)
+        string message,
+        Guid? preUploadCheckId,
+        string? sitePlanExternalVideoId,
+        string? sitePlanStorageKey)
     {
         Status = status;
         Decision = decision;
         Message = message;
+        PreUploadCheckId = preUploadCheckId;
+        SitePlanExternalVideoId = sitePlanExternalVideoId;
+        SitePlanStorageKey = sitePlanStorageKey;
     }
 
     public DesktopPreUploadCheckStatus Status { get; }
@@ -146,15 +152,27 @@ public sealed class DesktopPreUploadCheckResult
 
     public string Message { get; }
 
+    public Guid? PreUploadCheckId { get; }
+
+    public string? SitePlanExternalVideoId { get; }
+
+    public string? SitePlanStorageKey { get; }
+
     public static DesktopPreUploadCheckResult Deferred { get; } = new(
         DesktopPreUploadCheckStatus.Deferred,
         decision: null,
-        DesktopUploadSectionText.PreUploadCheckDeferredMessage);
+        DesktopUploadSectionText.PreUploadCheckDeferredMessage,
+        preUploadCheckId: null,
+        sitePlanExternalVideoId: null,
+        sitePlanStorageKey: null);
 
     public static DesktopPreUploadCheckResult Canceled { get; } = new(
         DesktopPreUploadCheckStatus.Canceled,
         decision: null,
-        DesktopUploadSectionText.PreUploadCheckCanceledMessage);
+        DesktopUploadSectionText.PreUploadCheckCanceledMessage,
+        preUploadCheckId: null,
+        sitePlanExternalVideoId: null,
+        sitePlanStorageKey: null);
 
     public static DesktopPreUploadCheckResult FromFakeDecision(DesktopPreUploadCheckDecision decision)
     {
@@ -177,10 +195,20 @@ public sealed class DesktopPreUploadCheckResult
             _ => DesktopPreUploadCheckStatus.Blocked
         };
 
-        return new DesktopPreUploadCheckResult(status, decision, message);
+        return new DesktopPreUploadCheckResult(
+            status,
+            decision,
+            message,
+            preUploadCheckId: null,
+            sitePlanExternalVideoId: null,
+            sitePlanStorageKey: null);
     }
 
-    public static DesktopPreUploadCheckResult FromLiveDecision(DesktopPreUploadCheckDecision decision)
+    public static DesktopPreUploadCheckResult FromLiveDecision(
+        DesktopPreUploadCheckDecision decision,
+        Guid preUploadCheckId,
+        string? sitePlanExternalVideoId,
+        string? sitePlanStorageKey)
     {
         string message = decision switch
         {
@@ -201,32 +229,52 @@ public sealed class DesktopPreUploadCheckResult
             _ => DesktopPreUploadCheckStatus.Blocked
         };
 
-        return new DesktopPreUploadCheckResult(status, decision, message);
+        return new DesktopPreUploadCheckResult(
+            status,
+            decision,
+            message,
+            preUploadCheckId,
+            sitePlanExternalVideoId,
+            sitePlanStorageKey);
     }
 
     public static DesktopPreUploadCheckResult LiveUnavailable { get; } = new(
         DesktopPreUploadCheckStatus.Unavailable,
         decision: null,
-        DesktopUploadSectionText.PreUploadCheckLiveUnavailableMessage);
+        DesktopUploadSectionText.PreUploadCheckLiveUnavailableMessage,
+        preUploadCheckId: null,
+        sitePlanExternalVideoId: null,
+        sitePlanStorageKey: null);
 
     public static DesktopPreUploadCheckResult LiveUnauthorized { get; } = new(
         DesktopPreUploadCheckStatus.Unauthorized,
         decision: null,
-        DesktopUploadSectionText.PreUploadCheckLiveUnauthorizedMessage);
+        DesktopUploadSectionText.PreUploadCheckLiveUnauthorizedMessage,
+        preUploadCheckId: null,
+        sitePlanExternalVideoId: null,
+        sitePlanStorageKey: null);
 
     public static DesktopPreUploadCheckResult LiveFailed { get; } = new(
         DesktopPreUploadCheckStatus.Failed,
         decision: null,
-        DesktopUploadSectionText.PreUploadCheckLiveFailedMessage);
+        DesktopUploadSectionText.PreUploadCheckLiveFailedMessage,
+        preUploadCheckId: null,
+        sitePlanExternalVideoId: null,
+        sitePlanStorageKey: null);
 
     public static DesktopPreUploadCheckResult LiveMalformed { get; } = new(
         DesktopPreUploadCheckStatus.Malformed,
         decision: null,
-        DesktopUploadSectionText.PreUploadCheckLiveMalformedMessage);
+        DesktopUploadSectionText.PreUploadCheckLiveMalformedMessage,
+        preUploadCheckId: null,
+        sitePlanExternalVideoId: null,
+        sitePlanStorageKey: null);
 
     public override string ToString()
     {
         return $"{nameof(DesktopPreUploadCheckResult)} {{ Status = {Status}, Decision = {DecisionPreview ?? "<none>"}, "
+            + $"HasPreUploadCheckId = {PreUploadCheckId.HasValue}, "
+            + $"HasSitePlan = {!string.IsNullOrWhiteSpace(SitePlanExternalVideoId) && !string.IsNullOrWhiteSpace(SitePlanStorageKey)}, "
             + $"Message = {Message} }}";
     }
 }

--- a/src/App.Desktop/Services/Upload/DesktopSiteUpload.cs
+++ b/src/App.Desktop/Services/Upload/DesktopSiteUpload.cs
@@ -11,7 +11,11 @@ public sealed class DesktopSiteUploadRequestPreview
         string sha256Hex,
         string businessObjectKeyPreview,
         string preUploadCheckDecisionPreview,
-        string capturedAtUtc)
+        string capturedAtUtc,
+        Guid? preUploadCheckId,
+        Guid? groupNodeId,
+        string? plannedExternalVideoId,
+        string? plannedSiteStorageKey)
     {
         FileName = fileName;
         SizeBytes = sizeBytes;
@@ -20,6 +24,10 @@ public sealed class DesktopSiteUploadRequestPreview
         BusinessObjectKeyPreview = businessObjectKeyPreview;
         PreUploadCheckDecisionPreview = preUploadCheckDecisionPreview;
         CapturedAtUtc = capturedAtUtc;
+        PreUploadCheckId = preUploadCheckId;
+        GroupNodeId = groupNodeId;
+        PlannedExternalVideoId = plannedExternalVideoId;
+        PlannedSiteStorageKey = plannedSiteStorageKey;
     }
 
     public string FileName { get; }
@@ -35,6 +43,14 @@ public sealed class DesktopSiteUploadRequestPreview
     public string PreUploadCheckDecisionPreview { get; }
 
     public string CapturedAtUtc { get; }
+
+    public Guid? PreUploadCheckId { get; }
+
+    public Guid? GroupNodeId { get; }
+
+    public string? PlannedExternalVideoId { get; }
+
+    public string? PlannedSiteStorageKey { get; }
 
     public static DesktopSiteUploadRequestPreview? TryCreate(
         DesktopPreUploadCheckRequestPreview? preUploadCheckRequestPreview,
@@ -64,7 +80,11 @@ public sealed class DesktopSiteUploadRequestPreview
             preUploadCheckRequestPreview.Sha256Hex,
             preUploadCheckRequestPreview.BusinessObjectKeyPreview,
             decisionPreview,
-            preUploadCheckRequestPreview.CapturedAtUtc);
+            preUploadCheckRequestPreview.CapturedAtUtc,
+            preUploadCheckResult.PreUploadCheckId,
+            preUploadCheckRequestPreview.GroupNodeId,
+            preUploadCheckResult.SitePlanExternalVideoId,
+            preUploadCheckResult.SitePlanStorageKey);
     }
 
     public override string ToString()
@@ -73,6 +93,8 @@ public sealed class DesktopSiteUploadRequestPreview
             + $"SizeBytes = {SizeBytes}, ContentType = {ContentType}, HasSha256 = {Sha256Hex.Length == 64}, "
             + $"BusinessObjectKeyPreview = {BusinessObjectKeyPreview}, "
             + $"PreUploadCheckDecisionPreview = {PreUploadCheckDecisionPreview}, "
+            + $"HasPreUploadCheckId = {PreUploadCheckId.HasValue}, HasGroupNodeId = {GroupNodeId.HasValue}, "
+            + $"HasPlannedSiteTarget = {!string.IsNullOrWhiteSpace(PlannedExternalVideoId) && !string.IsNullOrWhiteSpace(PlannedSiteStorageKey)}, "
             + $"CapturedAtUtc = {CapturedAtUtc} }}";
     }
 
@@ -128,6 +150,21 @@ public sealed class DesktopSiteUploadResult
         DesktopUploadSectionText.SiteUploadSuccessDevMessage,
         externalVideoId: "visual-smoke-external-video-001",
         siteStorageKey: "visual-smoke/site/video-001");
+
+    public static DesktopSiteUploadResult FromFakeSuccess(DesktopSiteUploadRequestPreview requestPreview)
+    {
+        ArgumentNullException.ThrowIfNull(requestPreview);
+
+        return new DesktopSiteUploadResult(
+            DesktopSiteUploadStatus.Succeeded,
+            DesktopUploadSectionText.SiteUploadSuccessDevMessage,
+            string.IsNullOrWhiteSpace(requestPreview.PlannedExternalVideoId)
+                ? FakeSuccess.ExternalVideoId
+                : requestPreview.PlannedExternalVideoId,
+            string.IsNullOrWhiteSpace(requestPreview.PlannedSiteStorageKey)
+                ? FakeSuccess.SiteStorageKey
+                : requestPreview.PlannedSiteStorageKey);
+    }
 
     public override string ToString()
     {

--- a/src/App.Desktop/Services/Upload/DesktopUploadReceipt.cs
+++ b/src/App.Desktop/Services/Upload/DesktopUploadReceipt.cs
@@ -16,7 +16,9 @@ public sealed class DesktopUploadReceiptRequestPreview
         string externalVideoId,
         string siteStorageKey,
         string siteUploadStatusPreview,
-        string capturedAtUtc)
+        string capturedAtUtc,
+        Guid? preUploadCheckId,
+        Guid? groupNodeId)
     {
         FileName = fileName;
         SizeBytes = sizeBytes;
@@ -28,6 +30,8 @@ public sealed class DesktopUploadReceiptRequestPreview
         SiteStorageKey = siteStorageKey;
         SiteUploadStatusPreview = siteUploadStatusPreview;
         CapturedAtUtc = capturedAtUtc;
+        PreUploadCheckId = preUploadCheckId;
+        GroupNodeId = groupNodeId;
     }
 
     public string FileName { get; }
@@ -49,6 +53,10 @@ public sealed class DesktopUploadReceiptRequestPreview
     public string SiteUploadStatusPreview { get; }
 
     public string CapturedAtUtc { get; }
+
+    public Guid? PreUploadCheckId { get; }
+
+    public Guid? GroupNodeId { get; }
 
     public static DesktopUploadReceiptRequestPreview? TryCreate(
         DesktopSiteUploadRequestPreview? siteUploadRequestPreview,
@@ -73,7 +81,9 @@ public sealed class DesktopUploadReceiptRequestPreview
             externalVideoId,
             siteStorageKey,
             siteUploadStatusPreview,
-            siteUploadRequestPreview.CapturedAtUtc);
+            siteUploadRequestPreview.CapturedAtUtc,
+            siteUploadRequestPreview.PreUploadCheckId,
+            siteUploadRequestPreview.GroupNodeId);
     }
 
     public override string ToString()
@@ -83,7 +93,9 @@ public sealed class DesktopUploadReceiptRequestPreview
             + $"BusinessObjectKeyPreview = {BusinessObjectKeyPreview}, "
             + $"PreUploadCheckDecisionPreview = {PreUploadCheckDecisionPreview}, "
             + $"ExternalVideoId = {ExternalVideoId}, SiteStorageKey = {SiteStorageKey}, "
-            + $"SiteUploadStatusPreview = {SiteUploadStatusPreview}, CapturedAtUtc = {CapturedAtUtc} }}";
+            + $"SiteUploadStatusPreview = {SiteUploadStatusPreview}, "
+            + $"HasPreUploadCheckId = {PreUploadCheckId.HasValue}, HasGroupNodeId = {GroupNodeId.HasValue}, "
+            + $"CapturedAtUtc = {CapturedAtUtc} }}";
     }
 
     private static bool TryCreateSafeReceiptValue(string? value, bool allowSlash, out string safeValue)
@@ -158,6 +170,7 @@ public sealed class DesktopUploadReceiptResult
     public string? StatusPreview => Status switch
     {
         DesktopUploadReceiptStatus.Accepted => "ACCEPTED",
+        DesktopUploadReceiptStatus.AlreadyAccepted => "ALREADY_ACCEPTED",
         _ => null
     };
 
@@ -185,6 +198,45 @@ public sealed class DesktopUploadReceiptResult
         receiptId: "visual-smoke-upload-receipt-001",
         serverCorrelationId: "visual-smoke-correlation-001");
 
+    public static DesktopUploadReceiptResult FromLiveAccepted(
+        Guid uploadReceiptId,
+        bool wasAlreadyAccepted)
+    {
+        return new DesktopUploadReceiptResult(
+            wasAlreadyAccepted
+                ? DesktopUploadReceiptStatus.AlreadyAccepted
+                : DesktopUploadReceiptStatus.Accepted,
+            wasAlreadyAccepted
+                ? DesktopUploadSectionText.UploadReceiptAlreadyAcceptedLiveMessage
+                : DesktopUploadSectionText.UploadReceiptAcceptedLiveMessage,
+            uploadReceiptId.ToString("D"),
+            serverCorrelationId: null);
+    }
+
+    public static DesktopUploadReceiptResult LiveUnavailable { get; } = new(
+        DesktopUploadReceiptStatus.Unavailable,
+        DesktopUploadSectionText.UploadReceiptLiveUnavailableMessage,
+        receiptId: null,
+        serverCorrelationId: null);
+
+    public static DesktopUploadReceiptResult LiveUnauthorized { get; } = new(
+        DesktopUploadReceiptStatus.Unauthorized,
+        DesktopUploadSectionText.UploadReceiptLiveUnauthorizedMessage,
+        receiptId: null,
+        serverCorrelationId: null);
+
+    public static DesktopUploadReceiptResult LiveFailed { get; } = new(
+        DesktopUploadReceiptStatus.Failed,
+        DesktopUploadSectionText.UploadReceiptLiveFailedMessage,
+        receiptId: null,
+        serverCorrelationId: null);
+
+    public static DesktopUploadReceiptResult LiveMalformed { get; } = new(
+        DesktopUploadReceiptStatus.Malformed,
+        DesktopUploadSectionText.UploadReceiptLiveMalformedMessage,
+        receiptId: null,
+        serverCorrelationId: null);
+
     public override string ToString()
     {
         return $"{nameof(DesktopUploadReceiptResult)} {{ Status = {StatusPreview ?? Status.ToString()}, "
@@ -197,5 +249,10 @@ public enum DesktopUploadReceiptStatus
 {
     Deferred,
     Accepted,
-    Canceled
+    AlreadyAccepted,
+    Canceled,
+    Unavailable,
+    Unauthorized,
+    Failed,
+    Malformed
 }

--- a/src/App.Desktop/Services/Upload/DesktopUploadSectionOptions.cs
+++ b/src/App.Desktop/Services/Upload/DesktopUploadSectionOptions.cs
@@ -22,6 +22,7 @@ public sealed class DesktopUploadSectionOptions
 
     private DesktopUploadSectionOptions(
         bool isLiveControlPlanePreUploadCheckEnabled,
+        bool isLiveControlPlaneUploadReceiptEnabled,
         bool isDevFakeUploadFileEnabled,
         bool isDevFakeUploadHashEnabled,
         bool isDevFakeBusinessObjectKeyEnabled,
@@ -30,6 +31,7 @@ public sealed class DesktopUploadSectionOptions
         bool isDevFakeUploadReceiptEnabled)
     {
         IsLiveControlPlanePreUploadCheckEnabled = isLiveControlPlanePreUploadCheckEnabled;
+        IsLiveControlPlaneUploadReceiptEnabled = isLiveControlPlaneUploadReceiptEnabled;
         IsDevFakeUploadFileEnabled = isDevFakeUploadFileEnabled;
         IsDevFakeUploadHashEnabled = isDevFakeUploadHashEnabled;
         IsDevFakeBusinessObjectKeyEnabled = isDevFakeBusinessObjectKeyEnabled;
@@ -40,6 +42,7 @@ public sealed class DesktopUploadSectionOptions
 
     public static DesktopUploadSectionOptions Disabled { get; } = new(
         isLiveControlPlanePreUploadCheckEnabled: false,
+        isLiveControlPlaneUploadReceiptEnabled: false,
         isDevFakeUploadFileEnabled: false,
         isDevFakeUploadHashEnabled: false,
         isDevFakeBusinessObjectKeyEnabled: false,
@@ -50,6 +53,7 @@ public sealed class DesktopUploadSectionOptions
 #if DEBUG
     public static DesktopUploadSectionOptions EnabledForDevFakeFileSelection { get; } = new(
         isLiveControlPlanePreUploadCheckEnabled: false,
+        isLiveControlPlaneUploadReceiptEnabled: false,
         isDevFakeUploadFileEnabled: true,
         isDevFakeUploadHashEnabled: false,
         isDevFakeBusinessObjectKeyEnabled: false,
@@ -59,6 +63,7 @@ public sealed class DesktopUploadSectionOptions
 
     public static DesktopUploadSectionOptions EnabledForDevFakeFileSelectionAndHash { get; } = new(
         isLiveControlPlanePreUploadCheckEnabled: false,
+        isLiveControlPlaneUploadReceiptEnabled: false,
         isDevFakeUploadFileEnabled: true,
         isDevFakeUploadHashEnabled: true,
         isDevFakeBusinessObjectKeyEnabled: false,
@@ -68,6 +73,7 @@ public sealed class DesktopUploadSectionOptions
 
     public static DesktopUploadSectionOptions EnabledForDevFakeBusinessObjectKey { get; } = new(
         isLiveControlPlanePreUploadCheckEnabled: false,
+        isLiveControlPlaneUploadReceiptEnabled: false,
         isDevFakeUploadFileEnabled: false,
         isDevFakeUploadHashEnabled: false,
         isDevFakeBusinessObjectKeyEnabled: true,
@@ -77,6 +83,7 @@ public sealed class DesktopUploadSectionOptions
 
     public static DesktopUploadSectionOptions EnabledForDevFakePreUploadCheck { get; } = new(
         isLiveControlPlanePreUploadCheckEnabled: false,
+        isLiveControlPlaneUploadReceiptEnabled: false,
         isDevFakeUploadFileEnabled: false,
         isDevFakeUploadHashEnabled: false,
         isDevFakeBusinessObjectKeyEnabled: false,
@@ -86,6 +93,7 @@ public sealed class DesktopUploadSectionOptions
 
     public static DesktopUploadSectionOptions EnabledForDevFakeSiteUpload { get; } = new(
         isLiveControlPlanePreUploadCheckEnabled: false,
+        isLiveControlPlaneUploadReceiptEnabled: false,
         isDevFakeUploadFileEnabled: false,
         isDevFakeUploadHashEnabled: false,
         isDevFakeBusinessObjectKeyEnabled: false,
@@ -95,6 +103,7 @@ public sealed class DesktopUploadSectionOptions
 
     public static DesktopUploadSectionOptions EnabledForDevFakeUploadReceipt { get; } = new(
         isLiveControlPlanePreUploadCheckEnabled: false,
+        isLiveControlPlaneUploadReceiptEnabled: false,
         isDevFakeUploadFileEnabled: false,
         isDevFakeUploadHashEnabled: false,
         isDevFakeBusinessObjectKeyEnabled: false,
@@ -116,6 +125,8 @@ public sealed class DesktopUploadSectionOptions
 #endif
 
     public bool IsLiveControlPlanePreUploadCheckEnabled { get; }
+
+    public bool IsLiveControlPlaneUploadReceiptEnabled { get; }
 
     public bool IsDevFakeUploadFileEnabled { get; }
 
@@ -218,6 +229,7 @@ public sealed class DesktopUploadSectionOptions
 
         return new DesktopUploadSectionOptions(
             isLiveControlPlanePreUploadCheckEnabled: false,
+            isLiveControlPlaneUploadReceiptEnabled: false,
             isDevFakeUploadFileEnabled: isFakeFileEnabled,
             isDevFakeUploadHashEnabled: isFakeHashEnabled,
             isDevFakeBusinessObjectKeyEnabled: isFakeBusinessObjectKeyEnabled,
@@ -233,6 +245,7 @@ public sealed class DesktopUploadSectionOptions
     {
         return new DesktopUploadSectionOptions(
             isLiveControlPlanePreUploadCheckEnabled: true,
+            isLiveControlPlaneUploadReceiptEnabled: IsLiveControlPlaneUploadReceiptEnabled,
             isDevFakeUploadFileEnabled: IsDevFakeUploadFileEnabled,
             isDevFakeUploadHashEnabled: IsDevFakeUploadHashEnabled,
             isDevFakeBusinessObjectKeyEnabled: IsDevFakeBusinessObjectKeyEnabled,
@@ -241,10 +254,24 @@ public sealed class DesktopUploadSectionOptions
             isDevFakeUploadReceiptEnabled: IsDevFakeUploadReceiptEnabled);
     }
 
+    public DesktopUploadSectionOptions WithLiveControlPlaneUploadReceipt()
+    {
+        return new DesktopUploadSectionOptions(
+            isLiveControlPlanePreUploadCheckEnabled: IsLiveControlPlanePreUploadCheckEnabled,
+            isLiveControlPlaneUploadReceiptEnabled: true,
+            isDevFakeUploadFileEnabled: IsDevFakeUploadFileEnabled,
+            isDevFakeUploadHashEnabled: IsDevFakeUploadHashEnabled,
+            isDevFakeBusinessObjectKeyEnabled: IsDevFakeBusinessObjectKeyEnabled,
+            isDevFakePreUploadCheckEnabled: IsDevFakePreUploadCheckEnabled,
+            isDevFakeSiteUploadEnabled: IsDevFakeSiteUploadEnabled,
+            isDevFakeUploadReceiptEnabled: false);
+    }
+
     public override string ToString()
     {
         return $"{nameof(DesktopUploadSectionOptions)} {{ "
             + $"IsLiveControlPlanePreUploadCheckEnabled = {IsLiveControlPlanePreUploadCheckEnabled}, "
+            + $"IsLiveControlPlaneUploadReceiptEnabled = {IsLiveControlPlaneUploadReceiptEnabled}, "
             + $"IsDevFakeUploadFileEnabled = {IsDevFakeUploadFileEnabled}, "
             + $"IsDevFakeUploadHashEnabled = {IsDevFakeUploadHashEnabled}, "
             + $"IsDevFakeBusinessObjectKeyEnabled = {IsDevFakeBusinessObjectKeyEnabled}, "

--- a/src/App.Desktop/Services/Upload/DesktopUploadSectionViewModel.cs
+++ b/src/App.Desktop/Services/Upload/DesktopUploadSectionViewModel.cs
@@ -150,6 +150,9 @@ public sealed class DesktopUploadSectionViewModel(
     public bool IsDevFakeUploadReceiptEnabled =>
         _uploadSectionOptions.IsDevFakeUploadReceiptEnabled;
 
+    public bool IsLiveControlPlaneUploadReceiptEnabled =>
+        _uploadSectionOptions.IsLiveControlPlaneUploadReceiptEnabled;
+
     public string BusinessObjectKeyInput { get; set; } = string.Empty;
 
     public DesktopUploadBusinessObjectKey? BusinessObjectKey { get; private set; }
@@ -222,7 +225,8 @@ public sealed class DesktopUploadSectionViewModel(
 
     public DesktopUploadReceiptResult? UploadReceiptResult { get; private set; }
 
-    public bool HasUploadReceiptResult => UploadReceiptResult?.Status == DesktopUploadReceiptStatus.Accepted;
+    public bool HasUploadReceiptResult => UploadReceiptResult?.Status is
+        DesktopUploadReceiptStatus.Accepted or DesktopUploadReceiptStatus.AlreadyAccepted;
 
     public string? UploadReceiptStatusPreview => UploadReceiptResult?.StatusPreview;
 
@@ -493,7 +497,7 @@ public sealed class DesktopUploadSectionViewModel(
             return null;
         }
 
-        if (!IsDevFakeUploadReceiptEnabled)
+        if (!IsDevFakeUploadReceiptEnabled && !IsLiveControlPlaneUploadReceiptEnabled)
         {
             UploadReceiptResult = DesktopUploadReceiptResult.Deferred;
             UploadReceiptStatusMessage = DesktopUploadSectionText.UploadReceiptDeferredMessage;
@@ -502,7 +506,9 @@ public sealed class DesktopUploadSectionViewModel(
 
         IsCreatingUploadReceipt = true;
         UploadReceiptResult = null;
-        UploadReceiptStatusMessage = DesktopUploadSectionText.UploadReceiptInProgressMessage;
+        UploadReceiptStatusMessage = IsLiveControlPlaneUploadReceiptEnabled
+            ? DesktopUploadSectionText.UploadReceiptLiveInProgressMessage
+            : DesktopUploadSectionText.UploadReceiptInProgressMessage;
 
         try
         {
@@ -615,7 +621,7 @@ public sealed class DesktopUploadSectionViewModel(
         }
 
         UploadReceiptStatusMessage = UploadReceiptRequestPreview is not null
-            ? DesktopUploadSectionText.UploadReceiptReadyMessage
+            ? GetUploadReceiptReadyMessage()
             : DesktopUploadSectionText.UploadReceiptNotReadyMessage;
     }
 
@@ -632,5 +638,12 @@ public sealed class DesktopUploadSectionViewModel(
         return IsLiveControlPlanePreUploadCheckEnabled
             ? DesktopUploadSectionText.PreUploadCheckLiveReadyMessage
             : DesktopUploadSectionText.PreUploadCheckReadyMessage;
+    }
+
+    private string GetUploadReceiptReadyMessage()
+    {
+        return IsLiveControlPlaneUploadReceiptEnabled
+            ? DesktopUploadSectionText.UploadReceiptLiveReadyMessage
+            : DesktopUploadSectionText.UploadReceiptReadyMessage;
     }
 }

--- a/src/App.Desktop/Services/Upload/FakeDesktopDirectSiteUploadClient.cs
+++ b/src/App.Desktop/Services/Upload/FakeDesktopDirectSiteUploadClient.cs
@@ -11,6 +11,6 @@ public sealed class FakeDesktopDirectSiteUploadClient : IDesktopDirectSiteUpload
         ArgumentNullException.ThrowIfNull(requestPreview);
         cancellationToken.ThrowIfCancellationRequested();
 
-        return ValueTask.FromResult(DesktopSiteUploadResult.FakeSuccess);
+        return ValueTask.FromResult(DesktopSiteUploadResult.FromFakeSuccess(requestPreview));
     }
 }

--- a/src/App.Desktop/Services/Upload/HttpDesktopPreUploadCheckClient.cs
+++ b/src/App.Desktop/Services/Upload/HttpDesktopPreUploadCheckClient.cs
@@ -153,9 +153,38 @@ public sealed class HttpDesktopPreUploadCheckClient : IDesktopPreUploadCheckClie
             _ => null
         };
 
-        return decision is null
-            ? DesktopPreUploadCheckResult.LiveMalformed
-            : DesktopPreUploadCheckResult.FromLiveDecision(decision.Value);
+        if (decision is null)
+        {
+            return DesktopPreUploadCheckResult.LiveMalformed;
+        }
+
+        string? sitePlanExternalVideoId = null;
+        string? sitePlanStorageKey = null;
+        if (decision is DesktopPreUploadCheckDecision.Allow or DesktopPreUploadCheckDecision.AllowWithReview)
+        {
+            if (payload.SitePlan is null
+                || !string.Equals(
+                    payload.SitePlan.RequiredReceiptEndpoint,
+                    "/api/video/upload-receipt",
+                    StringComparison.Ordinal)
+                || !TryCreateSafeControlPlaneValue(
+                    payload.SitePlan.ExternalVideoId,
+                    allowSlash: false,
+                    out sitePlanExternalVideoId)
+                || !TryCreateSafeControlPlaneValue(
+                    payload.SitePlan.StorageKey,
+                    allowSlash: true,
+                    out sitePlanStorageKey))
+            {
+                return DesktopPreUploadCheckResult.LiveMalformed;
+            }
+        }
+
+        return DesktopPreUploadCheckResult.FromLiveDecision(
+            decision.Value,
+            payload.PreUploadCheckId.Value,
+            sitePlanExternalVideoId,
+            sitePlanStorageKey);
     }
 
     private static string? CreateSafeNullableContentType(string contentType)
@@ -166,6 +195,58 @@ public sealed class HttpDesktopPreUploadCheckClient : IDesktopPreUploadCheckClie
             StringComparison.Ordinal)
             ? null
             : contentType;
+    }
+
+    private static bool TryCreateSafeControlPlaneValue(string? value, bool allowSlash, out string? safeValue)
+    {
+        safeValue = null;
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        string trimmed = value.Trim();
+        if (trimmed.Length > 200)
+        {
+            return false;
+        }
+
+        string lower = trimmed.ToLowerInvariant();
+        string[] blockedFragments =
+        [
+            "authorization",
+            "bearer",
+            "password",
+            "token",
+            "sessionid",
+            "session_id",
+            "access_token",
+            "refreshtoken",
+            "refresh_token"
+        ];
+
+        foreach (string blockedFragment in blockedFragments)
+        {
+            if (lower.Contains(blockedFragment, StringComparison.Ordinal))
+            {
+                return false;
+            }
+        }
+
+        foreach (char character in trimmed)
+        {
+            if (char.IsControl(character)
+                || character == '\\'
+                || character == ':'
+                || (!allowSlash && character == '/'))
+            {
+                return false;
+            }
+        }
+
+        safeValue = trimmed;
+        return true;
     }
 
     private sealed record PreUploadCheckRequestPayload(

--- a/src/App.Desktop/Services/Upload/HttpDesktopUploadReceiptClient.cs
+++ b/src/App.Desktop/Services/Upload/HttpDesktopUploadReceiptClient.cs
@@ -1,0 +1,203 @@
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+using App.Desktop.Boundaries;
+
+namespace App.Desktop.Services.Upload;
+
+public sealed class HttpDesktopUploadReceiptClient : IDesktopUploadReceiptClient
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly HttpClient _httpClient;
+    private readonly IDesktopControlPlaneAccessTokenProvider _accessTokenProvider;
+    private readonly IDesktopSessionState _sessionState;
+    private readonly Uri _uploadReceiptEndpoint;
+
+    public HttpDesktopUploadReceiptClient(
+        HttpClient httpClient,
+        IDesktopControlPlaneAccessTokenProvider accessTokenProvider,
+        IDesktopSessionState sessionState)
+        : this(
+            httpClient,
+            accessTokenProvider,
+            sessionState,
+            new Uri("/api/video/upload-receipt", UriKind.Relative))
+    {
+    }
+
+    public HttpDesktopUploadReceiptClient(
+        HttpClient httpClient,
+        IDesktopControlPlaneAccessTokenProvider accessTokenProvider,
+        IDesktopSessionState sessionState,
+        Uri uploadReceiptEndpoint)
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
+        ArgumentNullException.ThrowIfNull(accessTokenProvider);
+        ArgumentNullException.ThrowIfNull(sessionState);
+        ArgumentNullException.ThrowIfNull(uploadReceiptEndpoint);
+
+        _httpClient = httpClient;
+        _accessTokenProvider = accessTokenProvider;
+        _sessionState = sessionState;
+        _uploadReceiptEndpoint = uploadReceiptEndpoint;
+    }
+
+    public async ValueTask<DesktopUploadReceiptResult> CreateAsync(
+        DesktopUploadReceiptRequestPreview requestPreview,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(requestPreview);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (requestPreview.PreUploadCheckId is null || requestPreview.PreUploadCheckId == Guid.Empty)
+        {
+            return DesktopUploadReceiptResult.LiveMalformed;
+        }
+
+        try
+        {
+            DesktopControlPlaneAccessTokenSnapshot accessToken =
+                await _accessTokenProvider.GetCurrentAccessTokenAsync(cancellationToken);
+            DesktopSessionSnapshot session = _sessionState.Current;
+
+            if (!accessToken.HasAccessToken || !session.IsSignedIn || session.UserId is null)
+            {
+                return DesktopUploadReceiptResult.LiveUnauthorized;
+            }
+
+            using var request = new HttpRequestMessage(HttpMethod.Post, _uploadReceiptEndpoint);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken.AccessToken);
+            request.Content = JsonContent.Create(
+                new UploadReceiptRequestPayload(
+                    PreUploadCheckId: requestPreview.PreUploadCheckId.Value,
+                    UserId: session.UserId.Value,
+                    DeviceId: session.DeviceId,
+                    GroupNodeId: requestPreview.GroupNodeId,
+                    ExternalVideoId: requestPreview.ExternalVideoId,
+                    StorageKey: requestPreview.SiteStorageKey,
+                    SiteStatus: requestPreview.SiteUploadStatusPreview,
+                    SizeBytes: requestPreview.SizeBytes,
+                    ByteSha256: requestPreview.Sha256Hex,
+                    IdempotencyKey: CreateIdempotencyKey(requestPreview.PreUploadCheckId.Value),
+                    UploadedAtUtc: DateTimeOffset.UtcNow),
+                options: JsonOptions);
+
+            using HttpResponseMessage response = await _httpClient.SendAsync(
+                request,
+                HttpCompletionOption.ResponseHeadersRead,
+                cancellationToken);
+
+            if (response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
+            {
+                return DesktopUploadReceiptResult.LiveUnauthorized;
+            }
+
+            if (response.StatusCode == HttpStatusCode.ServiceUnavailable)
+            {
+                return DesktopUploadReceiptResult.LiveUnavailable;
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                return DesktopUploadReceiptResult.LiveFailed;
+            }
+
+            UploadReceiptResponsePayload? payload =
+                await response.Content.ReadFromJsonAsync<UploadReceiptResponsePayload>(
+                    JsonOptions,
+                    cancellationToken);
+
+            return TryMapResponse(payload, requestPreview);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            return DesktopUploadReceiptResult.LiveUnavailable;
+        }
+        catch (HttpRequestException)
+        {
+            return DesktopUploadReceiptResult.LiveUnavailable;
+        }
+        catch (InvalidOperationException)
+        {
+            return DesktopUploadReceiptResult.LiveUnavailable;
+        }
+        catch (JsonException)
+        {
+            return DesktopUploadReceiptResult.LiveMalformed;
+        }
+        catch (NotSupportedException)
+        {
+            return DesktopUploadReceiptResult.LiveMalformed;
+        }
+    }
+
+    private static DesktopUploadReceiptResult TryMapResponse(
+        UploadReceiptResponsePayload? payload,
+        DesktopUploadReceiptRequestPreview requestPreview)
+    {
+        if (payload is null
+            || payload.UploadReceiptId is null
+            || payload.UploadReceiptId == Guid.Empty
+            || payload.PreUploadCheckId is null
+            || payload.PreUploadCheckId == Guid.Empty
+            || payload.PreUploadCheckId != requestPreview.PreUploadCheckId
+            || string.IsNullOrWhiteSpace(payload.Status)
+            || payload.Accepted is null
+            || payload.WasAlreadyAccepted is null
+            || string.IsNullOrWhiteSpace(payload.AnalysisJobStatus)
+            || payload.ReceivedAtUtc is null)
+        {
+            return DesktopUploadReceiptResult.LiveMalformed;
+        }
+
+        return payload.Status.Trim() switch
+        {
+            "ACCEPTED" when payload.Accepted.Value && !payload.WasAlreadyAccepted.Value =>
+                DesktopUploadReceiptResult.FromLiveAccepted(payload.UploadReceiptId.Value, wasAlreadyAccepted: false),
+            "ALREADY_ACCEPTED" when payload.Accepted.Value && payload.WasAlreadyAccepted.Value =>
+                DesktopUploadReceiptResult.FromLiveAccepted(payload.UploadReceiptId.Value, wasAlreadyAccepted: true),
+            _ => DesktopUploadReceiptResult.LiveMalformed
+        };
+    }
+
+    private static string CreateIdempotencyKey(Guid preUploadCheckId)
+    {
+        return $"desktop-upload-receipt-{preUploadCheckId:N}";
+    }
+
+    private sealed record UploadReceiptRequestPayload(
+        Guid PreUploadCheckId,
+        Guid UserId,
+        Guid? DeviceId,
+        Guid? GroupNodeId,
+        string ExternalVideoId,
+        string StorageKey,
+        string SiteStatus,
+        long SizeBytes,
+        string ByteSha256,
+        string IdempotencyKey,
+        DateTimeOffset UploadedAtUtc);
+
+    private sealed class UploadReceiptResponsePayload
+    {
+        public Guid? UploadReceiptId { get; init; }
+
+        public Guid? PreUploadCheckId { get; init; }
+
+        public string? Status { get; init; }
+
+        public bool? Accepted { get; init; }
+
+        public bool? WasAlreadyAccepted { get; init; }
+
+        public string? Message { get; init; }
+
+        public string? AnalysisJobStatus { get; init; }
+
+        public DateTimeOffset? ReceivedAtUtc { get; init; }
+    }
+}

--- a/tests/Unit/App.Desktop.Tests/DesktopCompositionRootTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopCompositionRootTests.cs
@@ -25,6 +25,7 @@ public sealed class DesktopCompositionRootTests
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsLiveControlPlanePreUploadCheckEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsLiveControlPlaneUploadReceiptEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeSiteUploadEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadReceiptEnabled);
@@ -63,6 +64,7 @@ public sealed class DesktopCompositionRootTests
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadHashEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsLiveControlPlanePreUploadCheckEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsLiveControlPlaneUploadReceiptEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeSiteUploadEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadReceiptEnabled);
@@ -354,8 +356,10 @@ public sealed class DesktopCompositionRootTests
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeBusinessObjectKeyEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeSiteUploadEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsLiveControlPlaneUploadReceiptEnabled);
         Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadReceiptEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakeSiteUploadEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionViewModel>().IsLiveControlPlaneUploadReceiptEnabled);
         Assert.True(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakeUploadReceiptEnabled);
         Assert.IsType<DisabledDesktopPreUploadCheckClient>(
             services.GetRequiredService<IDesktopPreUploadCheckClient>());
@@ -476,14 +480,20 @@ public sealed class DesktopCompositionRootTests
         Assert.IsType<HttpDesktopGroupTreeClient>(services.GetRequiredService<IDesktopGroupTreeClient>());
         Assert.IsType<HttpDesktopPreUploadCheckClient>(
             services.GetRequiredService<IDesktopPreUploadCheckClient>());
+        Assert.IsType<HttpDesktopUploadReceiptClient>(
+            services.GetRequiredService<IDesktopUploadReceiptClient>());
         Assert.IsType<DisabledDesktopSessionStore>(services.GetRequiredService<IDesktopSessionStore>());
         Assert.True(services.GetRequiredService<DesktopAuthOptions>().IsControlPlaneSignInConfigured);
         Assert.True(services.GetRequiredService<DesktopGroupTreeOptions>().IsLiveControlPlaneGroupTreeEnabled);
         Assert.False(services.GetRequiredService<DesktopGroupTreeOptions>().IsDevFakeGroupTreeEnabled);
         Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsLiveControlPlanePreUploadCheckEnabled);
+        Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsLiveControlPlaneUploadReceiptEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadReceiptEnabled);
         Assert.True(services.GetRequiredService<DesktopUploadSectionViewModel>().IsLiveControlPlanePreUploadCheckEnabled);
+        Assert.True(services.GetRequiredService<DesktopUploadSectionViewModel>().IsLiveControlPlaneUploadReceiptEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakePreUploadCheckEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakeUploadReceiptEnabled);
         Assert.Equal(
             new Uri("https://control-plane.local"),
             services.GetRequiredService<HttpClient>().BaseAddress);
@@ -560,6 +570,26 @@ public sealed class DesktopCompositionRootTests
         Assert.False(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakePreUploadCheckEnabled);
         Assert.IsType<HttpDesktopPreUploadCheckClient>(
             services.GetRequiredService<IDesktopPreUploadCheckClient>());
+    }
+
+    [Fact]
+    public void ExplicitFakeUploadReceiptFlagDoesNotReplaceConfiguredLiveUploadReceiptClient()
+    {
+        using var environment = new EnvironmentVariableScope()
+            .Set(DesktopAuthOptions.ControlPlaneBaseAddressEnvironmentVariable, "https://control-plane.local")
+            .Set(DesktopAuthOptions.DevFakeAuthEnabledEnvironmentVariable, "true")
+            .Set(DesktopUploadSectionOptions.DevFakeUploadReceiptEnabledEnvironmentVariable, "true");
+
+        using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
+
+        Assert.False(services.GetRequiredService<DesktopAuthOptions>().IsDevFakeAuthEnabled);
+        Assert.True(services.GetRequiredService<DesktopAuthOptions>().IsControlPlaneSignInConfigured);
+        Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsLiveControlPlaneUploadReceiptEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadReceiptEnabled);
+        Assert.True(services.GetRequiredService<DesktopUploadSectionViewModel>().IsLiveControlPlaneUploadReceiptEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakeUploadReceiptEnabled);
+        Assert.IsType<HttpDesktopUploadReceiptClient>(
+            services.GetRequiredService<IDesktopUploadReceiptClient>());
     }
 
     [Fact]

--- a/tests/Unit/App.Desktop.Tests/DesktopUploadSectionTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopUploadSectionTests.cs
@@ -160,14 +160,38 @@ public sealed class DesktopUploadSectionTests
             "Preview квитанции загрузки готов. В этом slice доступен только desktop-local dev boundary.",
             DesktopUploadSectionText.UploadReceiptReadyMessage);
         Assert.Equal(
+            "Preview квитанции загрузки готов. Будет использован существующий control-plane endpoint UploadReceipt.",
+            DesktopUploadSectionText.UploadReceiptLiveReadyMessage);
+        Assert.Equal(
             "Формируется квитанция загрузки в desktop-local dev boundary.",
             DesktopUploadSectionText.UploadReceiptInProgressMessage);
         Assert.Equal(
-            "Квитанция загрузки пока доступна только в dev-smoke режиме. Реальный вызов App.Api будет добавлен отдельным approved slice.",
+            "Формируется квитанция загрузки через control-plane boundary.",
+            DesktopUploadSectionText.UploadReceiptLiveInProgressMessage);
+        Assert.Equal(
+            "Квитанция загрузки недоступна: задайте live control-plane base address или включите dev-smoke guard.",
             DesktopUploadSectionText.UploadReceiptDeferredMessage);
         Assert.Equal(
             "Квитанция загрузки сформирована в dev-smoke режиме.",
             DesktopUploadSectionText.UploadReceiptAcceptedDevMessage);
+        Assert.Equal(
+            "Квитанция загрузки принята control-plane.",
+            DesktopUploadSectionText.UploadReceiptAcceptedLiveMessage);
+        Assert.Equal(
+            "Квитанция загрузки уже была принята control-plane.",
+            DesktopUploadSectionText.UploadReceiptAlreadyAcceptedLiveMessage);
+        Assert.Equal(
+            "Квитанция загрузки недоступна: требуется повторный вход.",
+            DesktopUploadSectionText.UploadReceiptLiveUnauthorizedMessage);
+        Assert.Equal(
+            "Квитанция загрузки временно недоступна. Проверьте подключение или настройку.",
+            DesktopUploadSectionText.UploadReceiptLiveUnavailableMessage);
+        Assert.Equal(
+            "Квитанция загрузки не принята. Проверьте состояние загрузки и попробуйте ещё раз.",
+            DesktopUploadSectionText.UploadReceiptLiveFailedMessage);
+        Assert.Equal(
+            "Квитанция загрузки вернула неподдерживаемый ответ.",
+            DesktopUploadSectionText.UploadReceiptLiveMalformedMessage);
         Assert.Equal("Формирование квитанции загрузки отменено.", DesktopUploadSectionText.UploadReceiptCanceledMessage);
         Assert.Equal("Сформировать квитанцию", DesktopUploadSectionText.UploadReceiptButton);
         Assert.Equal("Формируется...", DesktopUploadSectionText.UploadReceiptBusyButton);
@@ -185,12 +209,12 @@ public sealed class DesktopUploadSectionTests
         Assert.Equal("receiptId", DesktopUploadSectionText.UploadReceiptResultReceiptIdLabel);
         Assert.Equal("serverCorrelationId", DesktopUploadSectionText.UploadReceiptResultServerCorrelationIdLabel);
         Assert.Equal(
-            "Следующий шаг отложен: реальный control-plane UploadReceipt client будет добавлен отдельным approved desktop slice.",
+            "Следующий шаг отложен: production site provider остаётся отдельным approved desktop slice.",
             DesktopUploadSectionText.NextStepDeferredMessage);
     }
 
     [Fact]
-    public void UploadSectionDoesNotReferenceRealAppApiReceiptUploadOrByteSendingBoundaries()
+    public void UploadSectionDoesNotSendVideoBytesOrUseLegacyUploadOrchestrationBoundaries()
     {
         string[] sourceFiles =
         [
@@ -229,9 +253,6 @@ public sealed class DesktopUploadSectionTests
             Assert.DoesNotContain("ControlPlanePreUploadCheckRequest", source, StringComparison.Ordinal);
             Assert.DoesNotContain("RecordUploadReceiptAsync", source, StringComparison.Ordinal);
             Assert.DoesNotContain("ControlPlaneUploadReceiptDraft", source, StringComparison.Ordinal);
-            Assert.DoesNotContain("HttpDesktopUploadReceipt", source, StringComparison.OrdinalIgnoreCase);
-            Assert.DoesNotContain("PostAsync", source, StringComparison.OrdinalIgnoreCase);
-            Assert.DoesNotContain("SendAsync", source, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("ReadAllBytes", source, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("ReadAllBytesAsync", source, StringComparison.OrdinalIgnoreCase);
         }
@@ -258,7 +279,6 @@ public sealed class DesktopUploadSectionTests
             Assert.DoesNotContain("ReadAllBytesAsync", source, StringComparison.OrdinalIgnoreCase);
             Assert.DoesNotContain("WriteLine", source, StringComparison.Ordinal);
             Assert.DoesNotContain("Log", source, StringComparison.Ordinal);
-            Assert.DoesNotContain("/api/video/upload-receipt", source, StringComparison.Ordinal);
             Assert.DoesNotContain("/api/video/upload-receipt-sync", source, StringComparison.Ordinal);
         }
 
@@ -266,7 +286,41 @@ public sealed class DesktopUploadSectionTests
             Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "HttpDesktopPreUploadCheckClient.cs"));
 
         Assert.Contains("/api/video/pre-upload-check", liveClientSource, StringComparison.Ordinal);
+        Assert.Contains("/api/video/upload-receipt", liveClientSource, StringComparison.Ordinal);
         Assert.DoesNotContain("/api/video/pre-upload-check/", liveClientSource, StringComparison.Ordinal);
+        Assert.DoesNotContain("/api/video/upload-receipt/", liveClientSource, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void UploadReceiptClientUsesOnlyApprovedEndpointAndDoesNotReadRawBodiesOrBytes()
+    {
+        string[] sourceFiles =
+        [
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "DesktopUploadReceipt.cs"),
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "DisabledDesktopUploadReceiptClient.cs"),
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "FakeDesktopUploadReceiptClient.cs"),
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "HttpDesktopUploadReceiptClient.cs"),
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Boundaries", "DesktopUploadReceiptBoundary.cs")
+        ];
+
+        foreach (string sourceFile in sourceFiles)
+        {
+            string source = File.ReadAllText(sourceFile);
+
+            Assert.DoesNotContain("ReadAsStringAsync", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("ReadAllBytes", source, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("ReadAllBytesAsync", source, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("WriteLine", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("Log", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("/api/video/pre-upload-check", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("/api/video/upload-receipt-sync", source, StringComparison.Ordinal);
+        }
+
+        string liveClientSource = File.ReadAllText(
+            Path.Combine(FindRepositoryRoot(), "src", "App.Desktop", "Services", "Upload", "HttpDesktopUploadReceiptClient.cs"));
+
+        Assert.Contains("/api/video/upload-receipt", liveClientSource, StringComparison.Ordinal);
+        Assert.DoesNotContain("/api/video/upload-receipt/", liveClientSource, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -276,6 +330,7 @@ public sealed class DesktopUploadSectionTests
         Assert.False(DesktopUploadSectionOptions.Disabled.IsDevFakeUploadHashEnabled);
         Assert.False(DesktopUploadSectionOptions.Disabled.IsDevFakeBusinessObjectKeyEnabled);
         Assert.False(DesktopUploadSectionOptions.Disabled.IsLiveControlPlanePreUploadCheckEnabled);
+        Assert.False(DesktopUploadSectionOptions.Disabled.IsLiveControlPlaneUploadReceiptEnabled);
         Assert.False(DesktopUploadSectionOptions.Disabled.IsDevFakePreUploadCheckEnabled);
         Assert.False(DesktopUploadSectionOptions.Disabled.IsDevFakeSiteUploadEnabled);
         Assert.False(DesktopUploadSectionOptions.Disabled.IsDevFakeUploadReceiptEnabled);
@@ -283,6 +338,7 @@ public sealed class DesktopUploadSectionTests
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue(null).IsDevFakeUploadHashEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue(null).IsDevFakeBusinessObjectKeyEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue(null).IsLiveControlPlanePreUploadCheckEnabled);
+        Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue(null).IsLiveControlPlaneUploadReceiptEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue(null).IsDevFakePreUploadCheckEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue(null).IsDevFakeSiteUploadEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue(null).IsDevFakeUploadReceiptEnabled);
@@ -291,6 +347,8 @@ public sealed class DesktopUploadSectionTests
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "false").IsDevFakeBusinessObjectKeyEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "false", "false")
             .IsDevFakePreUploadCheckEnabled);
+        Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "false", "false")
+            .IsLiveControlPlaneUploadReceiptEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "false", "false", "false")
             .IsDevFakeSiteUploadEnabled);
         Assert.False(DesktopUploadSectionOptions.FromEnvironmentValue("false", "false", "false", "false", "false", "false")
@@ -993,6 +1051,215 @@ public sealed class DesktopUploadSectionTests
             await client.CheckAsync(CreateVisualSmokePreUploadPreview(), CancellationToken.None);
 
         Assert.Equal(DesktopPreUploadCheckStatus.Unauthorized, result.Status);
+        Assert.Null(handler.LastRequest);
+    }
+
+    [Fact]
+    public async Task HttpUploadReceiptClientUsesExistingEndpointAndSafeRequestPayload()
+    {
+        string accessToken = CreateSensitiveValue("access");
+        Guid userId = Guid.NewGuid();
+        Guid deviceId = Guid.NewGuid();
+        Guid groupNodeId = Guid.NewGuid();
+        Guid preUploadCheckId = Guid.NewGuid();
+        Guid uploadReceiptId = Guid.NewGuid();
+        DesktopSessionState sessionState = await CreateSignedInSessionStateAsync(userId, deviceId, accessToken);
+        DesktopUploadReceiptRequestPreview requestPreview =
+            CreateLiveUploadReceiptPreview(preUploadCheckId, groupNodeId);
+        var handler = new StubHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = JsonContent(new
+            {
+                uploadReceiptId,
+                preUploadCheckId,
+                status = "ACCEPTED",
+                accepted = true,
+                wasAlreadyAccepted = false,
+                message = $"server-message-{CreateSensitiveValue("refresh")}",
+                analysisJobStatus = "queued",
+                receivedAtUtc = DateTimeOffset.UtcNow
+            })
+        });
+        var client = new HttpDesktopUploadReceiptClient(
+            new HttpClient(handler)
+            {
+                BaseAddress = new Uri("https://control-plane.local")
+            },
+            sessionState,
+            sessionState);
+
+        DesktopUploadReceiptResult result = await client.CreateAsync(requestPreview, CancellationToken.None);
+
+        Assert.Equal(DesktopUploadReceiptStatus.Accepted, result.Status);
+        Assert.Equal("ACCEPTED", result.StatusPreview);
+        Assert.Equal(uploadReceiptId.ToString("D"), result.ReceiptId);
+        Assert.Null(result.ServerCorrelationId);
+        Assert.Equal(DesktopUploadSectionText.UploadReceiptAcceptedLiveMessage, result.Message);
+        Assert.NotNull(handler.LastRequest);
+        Assert.Equal(HttpMethod.Post, handler.LastRequest.Method);
+        Assert.Equal("/api/video/upload-receipt", handler.LastRequest.RequestUri?.AbsolutePath);
+        Assert.Equal("Bearer", handler.LastRequest.Headers.Authorization?.Scheme);
+        Assert.Equal(accessToken, handler.LastRequest.Headers.Authorization?.Parameter);
+
+        JsonNode body = JsonNode.Parse(handler.LastRequestBody ?? string.Empty)
+            ?? throw new InvalidOperationException("Request JSON was not captured.");
+        Assert.Equal(preUploadCheckId, body["preUploadCheckId"]?.GetValue<Guid>());
+        Assert.Equal(userId, body["userId"]?.GetValue<Guid>());
+        Assert.Equal(deviceId, body["deviceId"]?.GetValue<Guid>());
+        Assert.Equal(groupNodeId, body["groupNodeId"]?.GetValue<Guid>());
+        Assert.Equal("site-video-001", body["externalVideoId"]?.GetValue<string>());
+        Assert.Equal("videos/site-video-001.mp4", body["storageKey"]?.GetValue<string>());
+        Assert.Equal("SUCCESS", body["siteStatus"]?.GetValue<string>());
+        Assert.Equal(DesktopUploadSelectedFile.VisualSmokeFileSizeBytes, body["sizeBytes"]?.GetValue<long>());
+        Assert.Equal(FakeDesktopVideoHashService.VisualSmokeSha256Hex, body["byteSha256"]?.GetValue<string>());
+        Assert.Equal($"desktop-upload-receipt-{preUploadCheckId:N}", body["idempotencyKey"]?.GetValue<string>());
+        Assert.NotNull(body["uploadedAtUtc"]);
+        Assert.Null(body["fileName"]);
+        Assert.Null(body["contentType"]);
+        Assert.Null(body["businessObjectKey"]);
+        Assert.DoesNotContain(accessToken, handler.LastRequestBody ?? string.Empty, StringComparison.Ordinal);
+        Assert.DoesNotContain(accessToken, result.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("server-message", result.ToString(), StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("ACCEPTED", false, DesktopUploadReceiptStatus.Accepted, "ACCEPTED")]
+    [InlineData("ALREADY_ACCEPTED", true, DesktopUploadReceiptStatus.AlreadyAccepted, "ALREADY_ACCEPTED")]
+    public async Task HttpUploadReceiptClientMapsExistingResponseStatusesSafely(
+        string apiStatus,
+        bool wasAlreadyAccepted,
+        DesktopUploadReceiptStatus expectedStatus,
+        string expectedStatusPreview)
+    {
+        Guid preUploadCheckId = Guid.NewGuid();
+        Guid uploadReceiptId = Guid.NewGuid();
+        DesktopSessionState sessionState = await CreateSignedInSessionStateAsync(
+            Guid.NewGuid(),
+            deviceId: null,
+            CreateSensitiveValue("access"));
+        var handler = new StubHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = JsonContent(new
+            {
+                uploadReceiptId,
+                preUploadCheckId,
+                status = apiStatus,
+                accepted = true,
+                wasAlreadyAccepted,
+                message = "safe server message is intentionally not surfaced",
+                analysisJobStatus = "queued",
+                receivedAtUtc = DateTimeOffset.UtcNow
+            })
+        });
+        var client = new HttpDesktopUploadReceiptClient(
+            new HttpClient(handler)
+            {
+                BaseAddress = new Uri("https://control-plane.local")
+            },
+            sessionState,
+            sessionState);
+
+        DesktopUploadReceiptResult result =
+            await client.CreateAsync(CreateLiveUploadReceiptPreview(preUploadCheckId), CancellationToken.None);
+
+        Assert.Equal(expectedStatus, result.Status);
+        Assert.Equal(expectedStatusPreview, result.StatusPreview);
+        Assert.Equal(uploadReceiptId.ToString("D"), result.ReceiptId);
+        Assert.DoesNotContain("safe server message", result.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task HttpUploadReceiptClientHandlesUnavailableUnauthorizedFailedAndMalformedResponsesSafely()
+    {
+        string accessToken = CreateSensitiveValue("access");
+        DesktopSessionState sessionState = await CreateSignedInSessionStateAsync(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            accessToken);
+        DesktopUploadReceiptRequestPreview requestPreview =
+            CreateLiveUploadReceiptPreview(Guid.NewGuid());
+
+        var unauthorized = new HttpDesktopUploadReceiptClient(
+            CreateHttpClient(_ => new HttpResponseMessage(HttpStatusCode.Unauthorized)),
+            sessionState,
+            sessionState);
+        DesktopUploadReceiptResult unauthorizedResult =
+            await unauthorized.CreateAsync(requestPreview, CancellationToken.None);
+        Assert.Equal(DesktopUploadReceiptStatus.Unauthorized, unauthorizedResult.Status);
+        Assert.Equal(DesktopUploadSectionText.UploadReceiptLiveUnauthorizedMessage, unauthorizedResult.Message);
+
+        var unavailable = new HttpDesktopUploadReceiptClient(
+            new HttpClient(new StubHttpMessageHandler(_ => throw new HttpRequestException(
+                $"transport failed {accessToken}")))
+            {
+                BaseAddress = new Uri("https://control-plane.local")
+            },
+            sessionState,
+            sessionState);
+        DesktopUploadReceiptResult unavailableResult =
+            await unavailable.CreateAsync(requestPreview, CancellationToken.None);
+        Assert.Equal(DesktopUploadReceiptStatus.Unavailable, unavailableResult.Status);
+        Assert.Equal(DesktopUploadSectionText.UploadReceiptLiveUnavailableMessage, unavailableResult.Message);
+
+        string rawFailureBody = $"{{\"accessToken\":\"{CreateSensitiveValue("response")}\"}}";
+        var failed = new HttpDesktopUploadReceiptClient(
+            CreateHttpClient(_ => new HttpResponseMessage(HttpStatusCode.Conflict)
+            {
+                Content = new StringContent(rawFailureBody, Encoding.UTF8, "application/json")
+            }),
+            sessionState,
+            sessionState);
+        DesktopUploadReceiptResult failedResult =
+            await failed.CreateAsync(requestPreview, CancellationToken.None);
+        Assert.Equal(DesktopUploadReceiptStatus.Failed, failedResult.Status);
+        Assert.Equal(DesktopUploadSectionText.UploadReceiptLiveFailedMessage, failedResult.Message);
+        Assert.DoesNotContain(rawFailureBody, failedResult.ToString(), StringComparison.Ordinal);
+
+        var malformed = new HttpDesktopUploadReceiptClient(
+            CreateHttpClient(_ => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"status\":\"ACCEPTED\",", Encoding.UTF8, "application/json")
+            }),
+            sessionState,
+            sessionState);
+        DesktopUploadReceiptResult malformedResult =
+            await malformed.CreateAsync(requestPreview, CancellationToken.None);
+        Assert.Equal(DesktopUploadReceiptStatus.Malformed, malformedResult.Status);
+        Assert.Equal(DesktopUploadSectionText.UploadReceiptLiveMalformedMessage, malformedResult.Message);
+
+        foreach (DesktopUploadReceiptResult result in
+            new[] { unauthorizedResult, unavailableResult, failedResult, malformedResult })
+        {
+            Assert.Null(result.StatusPreview);
+            Assert.Null(result.ReceiptId);
+            Assert.Null(result.ServerCorrelationId);
+            Assert.DoesNotContain(accessToken, result.ToString(), StringComparison.Ordinal);
+            Assert.DoesNotContain("accessToken", result.ToString(), StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("refreshToken", result.ToString(), StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("Authorization", result.ToString(), StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("raw response", result.ToString(), StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    [Fact]
+    public async Task HttpUploadReceiptClientWithoutSessionDoesNotSendRequest()
+    {
+        var handler = new StubHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = JsonContent(new { })
+        });
+        var client = new HttpDesktopUploadReceiptClient(
+            new HttpClient(handler)
+            {
+                BaseAddress = new Uri("https://control-plane.local")
+            },
+            new StaticDesktopControlPlaneAccessTokenProvider(accessToken: null),
+            new StaticDesktopSessionState(DesktopSessionSnapshot.SignedOut));
+
+        DesktopUploadReceiptResult result =
+            await client.CreateAsync(CreateLiveUploadReceiptPreview(Guid.NewGuid()), CancellationToken.None);
+
+        Assert.Equal(DesktopUploadReceiptStatus.Unauthorized, result.Status);
         Assert.Null(handler.LastRequest);
     }
 
@@ -1738,9 +2005,17 @@ public sealed class DesktopUploadSectionTests
             DesktopUploadSectionText.StepSixTitle,
             DesktopUploadSectionText.UploadReceiptNotReadyMessage,
             DesktopUploadSectionText.UploadReceiptReadyMessage,
+            DesktopUploadSectionText.UploadReceiptLiveReadyMessage,
             DesktopUploadSectionText.UploadReceiptInProgressMessage,
+            DesktopUploadSectionText.UploadReceiptLiveInProgressMessage,
             DesktopUploadSectionText.UploadReceiptDeferredMessage,
             DesktopUploadSectionText.UploadReceiptAcceptedDevMessage,
+            DesktopUploadSectionText.UploadReceiptAcceptedLiveMessage,
+            DesktopUploadSectionText.UploadReceiptAlreadyAcceptedLiveMessage,
+            DesktopUploadSectionText.UploadReceiptLiveUnauthorizedMessage,
+            DesktopUploadSectionText.UploadReceiptLiveUnavailableMessage,
+            DesktopUploadSectionText.UploadReceiptLiveFailedMessage,
+            DesktopUploadSectionText.UploadReceiptLiveMalformedMessage,
             DesktopUploadSectionText.UploadReceiptCanceledMessage,
             DesktopUploadSectionText.UploadReceiptButton,
             DesktopUploadSectionText.UploadReceiptBusyButton,
@@ -1886,6 +2161,43 @@ public sealed class DesktopUploadSectionTests
             FakeDesktopVideoHashService.VisualSmokeSha256Hex,
             new DesktopUploadBusinessObjectKey(DesktopUploadBusinessObjectKey.VisualSmokeValue))
             ?? throw new InvalidOperationException("Preview was not created.");
+    }
+
+    private static DesktopUploadReceiptRequestPreview CreateLiveUploadReceiptPreview(
+        Guid preUploadCheckId,
+        Guid? groupNodeId = null)
+    {
+        DesktopSelectedGroupContext? selectedGroup = null;
+        if (groupNodeId.HasValue)
+        {
+            var groupSelectionState = new DesktopGroupSelectionState();
+            Assert.True(groupSelectionState.TrySelect(new DesktopGroupTreeNode(
+                groupNodeId.Value.ToString("D"),
+                "Safe Group",
+                Depth: 1,
+                CanSelect: true)));
+            selectedGroup = groupSelectionState.SelectedGroup;
+        }
+
+        DesktopPreUploadCheckRequestPreview preUploadPreview =
+            DesktopPreUploadCheckRequestPreview.TryCreate(
+                DesktopUploadSelectedFile.VisualSmokeFile,
+                FakeDesktopVideoHashService.VisualSmokeSha256Hex,
+                new DesktopUploadBusinessObjectKey(DesktopUploadBusinessObjectKey.VisualSmokeValue),
+                selectedGroup)
+            ?? throw new InvalidOperationException("PreUploadCheck preview was not created.");
+        DesktopPreUploadCheckResult preUploadResult = DesktopPreUploadCheckResult.FromLiveDecision(
+            DesktopPreUploadCheckDecision.Allow,
+            preUploadCheckId,
+            "site-video-001",
+            "videos/site-video-001.mp4");
+        DesktopSiteUploadRequestPreview siteUploadPreview =
+            DesktopSiteUploadRequestPreview.TryCreate(preUploadPreview, preUploadResult)
+            ?? throw new InvalidOperationException("SiteUpload preview was not created.");
+        DesktopSiteUploadResult siteUploadResult = DesktopSiteUploadResult.FromFakeSuccess(siteUploadPreview);
+
+        return DesktopUploadReceiptRequestPreview.TryCreate(siteUploadPreview, siteUploadResult)
+            ?? throw new InvalidOperationException("UploadReceipt preview was not created.");
     }
 
     private static async Task<DesktopSessionState> CreateSignedInSessionStateAsync(


### PR DESCRIPTION
Coder: Coder 1 acting as Coder 2 / Desktop Client

Task ID: S2-70

Module: App.Desktop / UploadReceipt control-plane client probe

Scope:
- Added a narrow App.Desktop-local UploadReceipt HTTP client boundary against the existing approved control-plane surface.
- Preserved S2-66 fake/dev UploadReceipt visual smoke and S2-68/S2-69 live/fake guard behavior.
- Kept direct site upload as the existing fake/dev boundary; production site provider remains deferred.

Changed areas:
- docs/task-cards/S2-70_desktop-upload-receipt-control-plane-client-probe-task-card.txt
- src/App.Desktop/**
- tests/Unit/App.Desktop.Tests/**

Base main SHA: 7d5a092bf2576c77be80e874f330fac995111f15

Coordination log entries reviewed:
- TEAM COORDINATION LOG issue #89 metadata/comments, including S2-64 #133, S2-65 #134, S2-66 #135, S2-67 #136, S2-68 #137, S2-69 #138.

Handoff/task cards reviewed:
- docs/task-cards/S2-58 through S2-69 desktop task cards.

Existing UploadReceipt API/contract found: yes
- POST /api/video/upload-receipt
- Request shape: VideoUploadReceiptRequestDto from src/BuildingBlocks/Contracts/VideoUpload/UploadReceiptDtosV1.cs
- Response shape: VideoUploadReceiptResponseDto from src/BuildingBlocks/Contracts/VideoUpload/UploadReceiptDtosV1.cs

Read-only sources inspected:
- src/App.Api/Program.cs
- src/App.Api/appsettings.json
- src/Modules/VideoUpload/VideoUploadModule.cs
- src/Modules/VideoUpload/UploadReceiptSyncService.cs
- src/BuildingBlocks/Contracts/VideoUpload/PreUploadCheckDtos.cs
- src/BuildingBlocks/Contracts/VideoUpload/UploadReceiptDtosV1.cs
- tests/Integration/App.Api/UploadControlPlaneAuthorizationTests.cs
- tests/Integration/VideoUpload/UploadReceiptServiceTests.cs
- tests/Integration/WorkerPipeline/UploadReceiptPipelineBridgeTests.cs
- tests/Integration/** UploadReceipt references by repository search

Contracts: none

Migrations: none

Feature flags/env guard:
- Existing AA_DESKTOP_CONTROL_PLANE_BASE_ADDRESS selects the live UploadReceipt client.
- Existing AA_DESKTOP_DEV_FAKE_UPLOAD_RECEIPT_ENABLED=true keeps fake/dev UploadReceipt only when live base address is absent.
- Fake UploadReceipt is not selected when live base address is configured.
- Without live base address and without fake guard, UploadReceipt stays disabled/unavailable with a safe Russian message.

API impact:
- No App.Api changes.
- No new backend endpoint, DTO, contract, migration, or server behavior.
- Video bytes do not go through App.Api.

Web impact: none

Android impact: none

Offline behavior: none

Rollback: revert S2-70 PR

Validation:
- PASS git diff --check
- PASS dotnet restore AnalyticsAutomation-Core.sln -nologo
- PASS dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore after formatting whitespace
- PASS dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal
- PASS dotnet build AnalyticsAutomation-Core.sln -nologo -v minimal (pre-existing warnings, 0 errors)
- PASS dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal (181 tests)
- PASS hidden/control Unicode scan over 13 changed text files including untracked before commit
- PASS App.Desktop fake-auth/fake-group-tree/fake-upload-chain visual smoke

Visual smoke screenshot folder/files:
C:\CODEX\Temp\S2-70_DESKTOP_UPLOAD_RECEIPT_CLIENT_PROBE_VISUAL_SMOKE_20260501_205638\
- 01_baseline_signin.png
- 02_signed_in_shell.png
- 03_upload_section_after_fake_site_upload_success.png
- 04_upload_receipt_request_preview.png
- 05_after_fake_upload_receipt_accepted.png
- 06_after_sign_out.png

Handoff docs/task card:
- docs/task-cards/S2-70_desktop-upload-receipt-control-plane-client-probe-task-card.txt

Security / safe-output notes:
- Bearer token is sent only in the Authorization request header.
- No accessToken, refreshToken, Authorization, password, raw session id, raw response body, or full local path is shown/logged.
- Live failures map to safe Russian unavailable/unauthorized/failed/malformed messages.
- Screenshots/runtime artifacts are under C:\CODEX\Temp and not committed.

Next step:
- Production direct-site upload provider remains a separate approved desktop slice.

NO-GO / Deferred:
- No NO-GO for UploadReceipt control-plane client: existing endpoint/contract was found and used.
- Deferred: production site provider and real direct-site upload behavior remain out of scope.