### PR TITLE
[codex] S2-71 Desktop Direct Site Provider Probe

### DIFF
--- a/docs/task-cards/S2-71_desktop-direct-site-provider-probe-task-card.txt
+++ b/docs/task-cards/S2-71_desktop-direct-site-provider-probe-task-card.txt
@@ -1,0 +1,177 @@
+Title:
+S2-71 Desktop Direct Site Provider Probe / Existing WebsiteIntegration Boundary
+
+Module:
+App.Desktop / direct site provider probe
+
+Owner:
+Coder 1 acting as Coder 2 / Desktop Client
+
+Client form:
+desktop standalone
+
+Type:
+narrow runtime desktop-only provider probe after S2-70 UploadReceipt control-plane client probe
+
+Status:
+Runtime task card created with implementation.
+
+Goal:
+Probe the existing App.Api / Modules.WebsiteIntegration / Modules.VideoUpload / contracts direct-site provider surfaces read-only. Add a live App.Desktop direct-site upload client only if an existing approved direct-site provider boundary, config, and contract are present.
+
+Existing direct-site provider/config/contract found:
+No.
+
+Read-only sources inspected:
+- src/App.Api/Program.cs
+- src/App.Api/appsettings.json
+- src/Modules/WebsiteIntegration/WebsiteIntegrationModule.cs
+- src/Modules/VideoUpload/VideoUploadModule.cs
+- src/Modules/VideoUpload/UploadReceiptSyncService.cs
+- src/BuildingBlocks/Contracts/WebsiteIntegration/SiteGatewayDtos.cs
+- src/BuildingBlocks/Contracts/VideoUpload/PreUploadCheckDtos.cs
+- src/BuildingBlocks/Contracts/VideoUpload/UploadReceiptDtosV1.cs
+- tests/Integration/WebsiteIntegration/WebsiteIntegrationGatewayV1Tests.cs
+- tests/Integration/App.Api/UploadControlPlaneAuthorizationTests.cs
+- tests/Integration/VideoUpload/PreUploadCheckServiceTests.cs
+- tests/Integration/VideoUpload/UploadReceiptServiceTests.cs
+- repository search results for WebsiteIntegration, site gateway, SitePlan, direct site upload, externalVideoId, storageKey
+
+Probe result:
+- WebsiteIntegration currently exposes a Stub gateway for site gateway contracts, receipt preview, download intent preview, status lookup, and reconcile preview.
+- VideoUpload PreUploadCheck currently returns a SitePlan containing provider, externalVideoId, storageKey, and the required App.Api UploadReceipt endpoint.
+- Existing code does not expose an approved direct-site upload endpoint, external provider base address, upload request contract, upload response contract, or media-byte transfer boundary.
+- Therefore S2-71 does not implement HTTP upload and does not invent a production provider.
+
+Scope:
+- Keep the current Russian SignIn UI before authentication.
+- After SignIn, keep the signed-in shell.
+- Preserve S2-68 GroupTree live/fake behavior.
+- Preserve S2-69 PreUploadCheck live/fake behavior.
+- Preserve S2-70 UploadReceipt live/fake behavior.
+- Preserve the S2-65 fake/dev site upload visual-smoke path when no live control-plane base address is configured.
+- Keep IDesktopDirectSiteUploadClient testable.
+- Keep the live direct-site upload client disabled/unavailable because no approved existing provider surface was found.
+- When live control-plane mode is configured, suppress the dev fake site upload guard so a fake site upload cannot become the basis for a live UploadReceipt.
+- Keep Step 5 "Загрузка на сайт" visible with safe preview/deferred behavior.
+- Clear direct-site upload preview/result state on back and sign-out.
+
+Allowed changed areas:
+- docs/task-cards/S2-71_desktop-direct-site-provider-probe-task-card.txt
+- src/App.Desktop/**
+- tests/Unit/App.Desktop.Tests/**
+
+Forbidden changed areas:
+- src/App.Api/**
+- src/App.Worker/**
+- src/App.Web/**
+- src/App.Mobile.Android/**
+- src/App.UI.Shared/**
+- src/BuildingBlocks.Contracts/**
+- src/Modules/**
+- DB migrations
+- .github/workflows/**
+- deploy scripts
+- docs/ops/**
+- committed screenshots or runtime artifacts
+
+Contracts:
+none
+
+Migrations:
+none
+
+Feature flags/env guard:
+- Existing AA_DESKTOP_DEV_FAKE_SITE_UPLOAD_ENABLED=true keeps the fake/dev site upload visual-smoke path only when no live control-plane base address is configured.
+- No live direct-site provider env guard is added because no approved existing provider config/contract was found.
+- Existing AA_DESKTOP_CONTROL_PLANE_BASE_ADDRESS still enables live GroupTree, PreUploadCheck, and UploadReceipt clients from earlier slices.
+- With AA_DESKTOP_CONTROL_PLANE_BASE_ADDRESS configured, fake site upload is suppressed and IDesktopDirectSiteUploadClient remains disabled/unavailable.
+
+Events:
+none
+
+Offline behavior:
+none
+
+Security guardrails:
+- App.Api remains control plane.
+- Video bytes do not go through App.Api.
+- S2-71 sends no real video bytes anywhere.
+- Tests and visual smoke send no real video bytes.
+- Do not log or display accessToken, refreshToken, Authorization, password, raw session id, raw response body, token-like values, or full local file paths.
+- Do not show raw request/response bodies.
+- Screenshots and runtime artifacts stay under C:\CODEX\Temp and are not committed.
+
+Deferred:
+Real direct-site upload remains blocked. A later approved slice must provide the production site provider boundary, endpoint/base-address config, request/response contract, and security rules before App.Desktop can upload bytes to a real provider. Production UploadReceipt after real site upload remains blocked until that direct-site provider is approved.
+
+Explicitly out of scope:
+- App.Api changes.
+- Modules changes.
+- BuildingBlocks.Contracts changes.
+- Backend endpoint/DTO/contract additions.
+- DB migrations.
+- Deploy/workflow changes.
+- App.Web changes.
+- App.Mobile.Android changes.
+- Real direct-site HTTP upload.
+- Video bytes through App.Api.
+- Video bytes in tests or visual smoke.
+- Offline queue.
+- Report draft runtime.
+
+Rollback:
+revert S2-71 PR
+
+Validation:
+- git diff --check
+- dotnet restore AnalyticsAutomation-Core.sln -nologo
+- dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore
+- dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal
+- dotnet build AnalyticsAutomation-Core.sln -nologo -v minimal
+- dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal
+- hidden/control Unicode scan over changed text files
+- App.Desktop fake-auth/fake-group-tree/fake-upload-chain visual smoke with screenshots
+
+Definition of done:
+- Existing direct-site provider/config/contract probe result is documented as not found.
+- No HttpDesktopDirectSiteUploadClient is added.
+- IDesktopDirectSiteUploadClient remains fake/dev or disabled/unavailable only.
+- Fake site upload remains disabled by default.
+- Fake site upload remains enabled only by AA_DESKTOP_DEV_FAKE_SITE_UPLOAD_ENABLED=true in debug/dev-test visual smoke when no live control-plane base address is configured.
+- Configured live control-plane mode suppresses fake site upload and leaves direct-site upload disabled/unavailable.
+- Disabled/no-provider state shows the existing safe deferred Russian message.
+- Request preview remains safe and never shows a full local path or raw body.
+- PreUploadCheck decision continues to gate site upload exactly as before.
+- Back/sign-out clear direct-site upload preview and result state.
+- UploadReceipt behavior is preserved; live UploadReceipt remains available but cannot be reached from a fake site upload in configured live control-plane mode.
+- No App.Api, contracts, migrations, deploy, App.Web, or App.Mobile.Android files are changed.
+- No real video byte upload through App.Api is introduced.
+- No real site upload bytes are sent in tests or visual smoke.
+- Automated App.Desktop unit tests cover default disabled behavior, fake guard behavior, configured live control-plane fake-site suppression, deferred provider status, request-preview safety, reset behavior, and visible-string safety.
+
+Visual-smoke definition of done:
+- Run App.Desktop with:
+  AA_DESKTOP_DEV_FAKE_AUTH_ENABLED=true
+  AA_DESKTOP_DEV_FAKE_GROUP_TREE_ENABLED=true
+  AA_DESKTOP_DEV_FAKE_UPLOAD_FILE_ENABLED=true
+  AA_DESKTOP_DEV_FAKE_UPLOAD_HASH_ENABLED=true
+  AA_DESKTOP_DEV_FAKE_BUSINESS_OBJECT_KEY_ENABLED=true
+  AA_DESKTOP_DEV_FAKE_PREUPLOAD_CHECK_ENABLED=true
+  AA_DESKTOP_DEV_FAKE_SITE_UPLOAD_ENABLED=true
+  AA_DESKTOP_DEV_FAKE_UPLOAD_RECEIPT_ENABLED=true
+- Do not set AA_DESKTOP_CONTROL_PLANE_BASE_ADDRESS.
+- Do not set live site provider config.
+- Use non-secret fake-auth visual-smoke data:
+  login: visual-smoke-user
+  password: visual-smoke-password
+- Capture screenshots under C:\CODEX\Temp\S2-71_DESKTOP_DIRECT_SITE_PROVIDER_PROBE_VISUAL_SMOKE_<timestamp>\.
+- Required screenshots:
+  01_baseline_signin.png
+  02_signed_in_shell.png
+  03_upload_section_after_preuploadcheck_allow.png
+  04_direct_site_upload_request_preview.png
+  05_after_fake_site_upload_success.png
+  06_after_sign_out.png
+- Confirm no password, accessToken, refreshToken, Authorization, raw session id, raw response body, raw path, or real secret is visible.
+- Confirm screenshots and runtime artifacts are not committed.

--- a/src/App.Desktop/Composition/DesktopCompositionRoot.cs
+++ b/src/App.Desktop/Composition/DesktopCompositionRoot.cs
@@ -61,6 +61,7 @@ public static class DesktopCompositionRoot
             ? uploadSectionOptions
                 .WithLiveControlPlanePreUploadCheck()
                 .WithLiveControlPlaneUploadReceipt()
+                .WithoutDevFakeSiteUpload()
             : uploadSectionOptions;
 
         var services = new ServiceCollection();

--- a/src/App.Desktop/Services/Upload/DesktopUploadSectionOptions.cs
+++ b/src/App.Desktop/Services/Upload/DesktopUploadSectionOptions.cs
@@ -267,6 +267,19 @@ public sealed class DesktopUploadSectionOptions
             isDevFakeUploadReceiptEnabled: false);
     }
 
+    public DesktopUploadSectionOptions WithoutDevFakeSiteUpload()
+    {
+        return new DesktopUploadSectionOptions(
+            isLiveControlPlanePreUploadCheckEnabled: IsLiveControlPlanePreUploadCheckEnabled,
+            isLiveControlPlaneUploadReceiptEnabled: IsLiveControlPlaneUploadReceiptEnabled,
+            isDevFakeUploadFileEnabled: IsDevFakeUploadFileEnabled,
+            isDevFakeUploadHashEnabled: IsDevFakeUploadHashEnabled,
+            isDevFakeBusinessObjectKeyEnabled: IsDevFakeBusinessObjectKeyEnabled,
+            isDevFakePreUploadCheckEnabled: IsDevFakePreUploadCheckEnabled,
+            isDevFakeSiteUploadEnabled: false,
+            isDevFakeUploadReceiptEnabled: IsDevFakeUploadReceiptEnabled);
+    }
+
     public override string ToString()
     {
         return $"{nameof(DesktopUploadSectionOptions)} {{ "

--- a/tests/Unit/App.Desktop.Tests/DesktopCompositionRootTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopCompositionRootTests.cs
@@ -480,6 +480,8 @@ public sealed class DesktopCompositionRootTests
         Assert.IsType<HttpDesktopGroupTreeClient>(services.GetRequiredService<IDesktopGroupTreeClient>());
         Assert.IsType<HttpDesktopPreUploadCheckClient>(
             services.GetRequiredService<IDesktopPreUploadCheckClient>());
+        Assert.IsType<DisabledDesktopDirectSiteUploadClient>(
+            services.GetRequiredService<IDesktopDirectSiteUploadClient>());
         Assert.IsType<HttpDesktopUploadReceiptClient>(
             services.GetRequiredService<IDesktopUploadReceiptClient>());
         Assert.IsType<DisabledDesktopSessionStore>(services.GetRequiredService<IDesktopSessionStore>());
@@ -489,10 +491,12 @@ public sealed class DesktopCompositionRootTests
         Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsLiveControlPlanePreUploadCheckEnabled);
         Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsLiveControlPlaneUploadReceiptEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakePreUploadCheckEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeSiteUploadEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadReceiptEnabled);
         Assert.True(services.GetRequiredService<DesktopUploadSectionViewModel>().IsLiveControlPlanePreUploadCheckEnabled);
         Assert.True(services.GetRequiredService<DesktopUploadSectionViewModel>().IsLiveControlPlaneUploadReceiptEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakePreUploadCheckEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakeSiteUploadEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakeUploadReceiptEnabled);
         Assert.Equal(
             new Uri("https://control-plane.local"),
@@ -570,6 +574,35 @@ public sealed class DesktopCompositionRootTests
         Assert.False(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakePreUploadCheckEnabled);
         Assert.IsType<HttpDesktopPreUploadCheckClient>(
             services.GetRequiredService<IDesktopPreUploadCheckClient>());
+    }
+
+    [Fact]
+    public void ExplicitFakeSiteUploadFlagDoesNotRunWithConfiguredControlPlaneBecauseProviderIsDeferred()
+    {
+        using var environment = new EnvironmentVariableScope()
+            .Set(DesktopAuthOptions.ControlPlaneBaseAddressEnvironmentVariable, "https://control-plane.local")
+            .Set(DesktopAuthOptions.DevFakeAuthEnabledEnvironmentVariable, "true")
+            .Set(DesktopUploadSectionOptions.DevFakeSiteUploadEnabledEnvironmentVariable, "true")
+            .Set(DesktopUploadSectionOptions.DevFakeUploadReceiptEnabledEnvironmentVariable, "true");
+
+        using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
+
+        Assert.False(services.GetRequiredService<DesktopAuthOptions>().IsDevFakeAuthEnabled);
+        Assert.True(services.GetRequiredService<DesktopAuthOptions>().IsControlPlaneSignInConfigured);
+        Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsLiveControlPlanePreUploadCheckEnabled);
+        Assert.True(services.GetRequiredService<DesktopUploadSectionOptions>().IsLiveControlPlaneUploadReceiptEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeSiteUploadEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionOptions>().IsDevFakeUploadReceiptEnabled);
+        Assert.True(services.GetRequiredService<DesktopUploadSectionViewModel>().IsLiveControlPlanePreUploadCheckEnabled);
+        Assert.True(services.GetRequiredService<DesktopUploadSectionViewModel>().IsLiveControlPlaneUploadReceiptEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakeSiteUploadEnabled);
+        Assert.False(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakeUploadReceiptEnabled);
+        Assert.IsType<HttpDesktopPreUploadCheckClient>(
+            services.GetRequiredService<IDesktopPreUploadCheckClient>());
+        Assert.IsType<DisabledDesktopDirectSiteUploadClient>(
+            services.GetRequiredService<IDesktopDirectSiteUploadClient>());
+        Assert.IsType<HttpDesktopUploadReceiptClient>(
+            services.GetRequiredService<IDesktopUploadReceiptClient>());
     }
 
     [Fact]


### PR DESCRIPTION
## Coder
Coder 1 acting as Coder 2 / Desktop Client

## Task ID
S2-71

## Module
App.Desktop / direct site provider probe

## Scope
Desktop-only probe of existing WebsiteIntegration/site-provider surfaces and direct-site upload composition behavior.

## Changed areas
- `docs/task-cards/S2-71_desktop-direct-site-provider-probe-task-card.txt`
- `src/App.Desktop/Composition/DesktopCompositionRoot.cs`
- `src/App.Desktop/Services/Upload/DesktopUploadSectionOptions.cs`
- `tests/Unit/App.Desktop.Tests/DesktopCompositionRootTests.cs`

## Base main SHA
`f93a2e622c9a0f42a7357fd1211f100329f0e53a`

## Coordination log entries reviewed
TEAM COORDINATION LOG issue #89 reviewed, including desktop entries PR #127 through #139 (S2-58 through S2-70).

## Handoff/task cards reviewed
Desktop task cards S2-58, S2-59, S2-60, S2-61, S2-62, S2-63, S2-64, S2-65, S2-66, S2-67, S2-68, S2-69, and S2-70.

## Existing direct-site provider/config/contract found
No.

Read-only probe found WebsiteIntegration Stub gateway contracts/status/download/receipt-preview surfaces and VideoUpload SitePlan metadata, but no approved direct-site upload endpoint, provider base-address config, upload request/response contract, or media-byte transfer boundary.

## Contracts
None.

## Migrations
None.

## Feature flags/env guard
- Preserves existing `AA_DESKTOP_DEV_FAKE_SITE_UPLOAD_ENABLED=true` fake/dev visual-smoke path.
- No new live site provider env guard is added because no approved provider config/contract was found.
- In configured live control-plane mode, fake site upload is suppressed and `IDesktopDirectSiteUploadClient` stays disabled/unavailable.

## API impact
No App.Api changes. App.Api remains control plane. No new backend endpoint/DTO/contract.

## Web impact
None. No App.Web changes.

## Android impact
None. No App.Mobile.Android changes.

## Offline behavior
None.

## Rollback
Revert the S2-71 PR.

## Validation
- PASS: `git diff --check` (line-ending warnings only)
- PASS: `dotnet restore AnalyticsAutomation-Core.sln -nologo`
- PASS after formatter fix: `dotnet format whitespace AnalyticsAutomation-Core.sln --verify-no-changes --no-restore`
- PASS: `dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal`
- PASS: `dotnet build AnalyticsAutomation-Core.sln -nologo -v minimal` (existing analyzer warnings, 0 errors)
- PASS: `dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal` (182 passed)
- PASS: hidden/control Unicode scan over changed text files
- PASS: App.Desktop fake-auth/fake-group-tree/fake-upload-chain visual smoke

## Visual smoke screenshot folder/files
Folder: `C:\CODEX\Temp\S2-71_DESKTOP_DIRECT_SITE_PROVIDER_PROBE_VISUAL_SMOKE_20260502_100303\`

Files:
- `01_baseline_signin.png`
- `02_signed_in_shell.png`
- `03_upload_section_after_preuploadcheck_allow.png`
- `04_direct_site_upload_request_preview.png`
- `05_after_fake_site_upload_success.png`
- `06_after_sign_out.png`

## Handoff docs/task card
`docs/task-cards/S2-71_desktop-direct-site-provider-probe-task-card.txt`

## Next step
Approve/design the real direct-site provider boundary, provider config, upload request/response contract, and security rules before any production byte upload from App.Desktop.

## NO-GO / Deferred
Real direct-site upload remains deferred. No real video bytes were sent through App.Api, tests, or visual smoke. Production UploadReceipt after real site upload remains blocked until an approved direct-site provider exists.