### PR TITLE
Feature/s2 73 desktop direct site provider config options

### DIFF
--- a/docs/task-cards/S2-73_desktop-direct-site-provider-config-options-task-card.txt
+++ b/docs/task-cards/S2-73_desktop-direct-site-provider-config-options-task-card.txt
@@ -1,0 +1,113 @@
+TASK CARD: S2-73 Desktop Direct Site Provider Config / Options Boundary
+
+Module:
+App.Desktop / direct-site provider configuration
+
+Owner:
+Coder 2 / Desktop Client
+
+Client form:
+desktop standalone
+
+Type:
+narrow runtime implementation task after S2-72 design
+
+Goal:
+Add the App.Desktop provider config/options boundary and disabled/live selection plumbing for a future real direct-site provider.
+
+This task must not implement real byte upload.
+
+Background:
+S2-71 proved that no approved direct-site provider/config/contract exists.
+S2-72 defined the provider boundary design.
+S2-73 starts the implementation sequence with configuration/options and safe selection behavior only.
+
+Allowed changed areas for implementation:
+- src/App.Desktop/**
+- tests/Unit/App.Desktop.Tests/**
+- docs/task-cards/S2-73_desktop-direct-site-provider-config-options-task-card.txt
+
+Forbidden changed areas:
+- src/App.Api/**
+- src/Modules/**
+- src/BuildingBlocks/Contracts/**
+- src/App.Web/**
+- src/App.Mobile.Android/**
+- src/App.UI.Shared/**
+- DB migrations
+- .github/workflows/**
+- deploy scripts
+- docs/ops/**
+- committed screenshots or runtime artifacts
+
+Contracts:
+No shared contract change.
+
+Feature flag / env guard:
+Define or reuse App.Desktop-only configuration inputs for direct-site provider availability.
+No provider secrets may be stored or logged.
+No signed URL or provider credential behavior is implemented in S2-73 unless explicitly approved.
+
+Migration:
+No migration.
+
+Events:
+None.
+
+Offline behavior:
+No runtime offline upload behavior change.
+Real provider upload remains unavailable offline unless later explicitly designed.
+
+Security:
+- Do not print or log password.
+- Do not print or log accessToken.
+- Do not print or log refreshToken.
+- Do not print or log Authorization header.
+- Do not print or log provider credential values.
+- Do not print or log signed URL query secrets.
+- Do not print or log raw local file paths.
+- Do not print or log raw request/response bodies.
+
+Implementation scope:
+- Add provider config/options model for App.Desktop only.
+- Add tests for default disabled provider state.
+- Add tests for missing/invalid provider config.
+- Add tests for live-control-plane mode selecting disabled provider when provider config is absent.
+- Keep IDesktopDirectSiteUploadClient disabled/unavailable when provider config is missing or invalid.
+- Keep fake/dev site upload isolated from configured live control-plane mode.
+- Do not add HttpDesktopDirectSiteUploadClient real upload behavior.
+- Do not send real video bytes.
+- Do not change UploadReceipt contract.
+- Do not change App.Api.
+
+Definition of done:
+- App.Desktop options/config boundary exists and is testable.
+- Missing config produces disabled/unavailable direct-site provider behavior.
+- Invalid config produces disabled/unavailable direct-site provider behavior.
+- Configured live control-plane mode does not enable fake site upload.
+- No real direct-site byte upload is implemented.
+- No App.Api/backend/contracts files are changed.
+- App.Desktop unit tests cover the new config/options behavior.
+- Targeted App.Desktop build/test/format passes.
+
+Validation:
+- dotnet restore src/App.Desktop/App.Desktop.csproj
+- dotnet restore tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj
+- dotnet format whitespace src/App.Desktop/App.Desktop.csproj --verify-no-changes --no-restore
+- dotnet format whitespace tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj --verify-no-changes --no-restore
+- dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal
+- dotnet build tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal
+- dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal --no-build
+- git diff --check
+
+Rollback:
+Revert S2-73 PR.
+
+NO-GO:
+- Do not implement real HTTP upload.
+- Do not invent provider request/response contract.
+- Do not add App.Api endpoint.
+- Do not add backend/module code.
+- Do not send video bytes through App.Api.
+- Do not add provider credentials or tokens.
+- Do not run live Korobochka smoke for this task.

--- a/src/App.Desktop/Composition/DesktopCompositionRoot.cs
+++ b/src/App.Desktop/Composition/DesktopCompositionRoot.cs
@@ -24,7 +24,8 @@ public static class DesktopCompositionRoot
         return BuildServices(
             authOptions,
             DesktopUploadSectionOptions.FromEnvironment(),
-            DesktopGroupTreeOptions.FromAuthOptions(authOptions));
+            DesktopGroupTreeOptions.FromAuthOptions(authOptions),
+            DesktopDirectSiteProviderOptions.FromEnvironment());
     }
 
     public static ServiceProvider BuildServices(DesktopAuthOptions authOptions)
@@ -32,7 +33,8 @@ public static class DesktopCompositionRoot
         return BuildServices(
             authOptions,
             DesktopUploadSectionOptions.Disabled,
-            DesktopGroupTreeOptions.FromAuthOptions(authOptions, devFakeGroupTreeEnabled: null));
+            DesktopGroupTreeOptions.FromAuthOptions(authOptions, devFakeGroupTreeEnabled: null),
+            DesktopDirectSiteProviderOptions.Disabled);
     }
 
     public static ServiceProvider BuildServices(
@@ -42,7 +44,8 @@ public static class DesktopCompositionRoot
         return BuildServices(
             authOptions,
             uploadSectionOptions,
-            DesktopGroupTreeOptions.FromAuthOptions(authOptions, devFakeGroupTreeEnabled: null));
+            DesktopGroupTreeOptions.FromAuthOptions(authOptions, devFakeGroupTreeEnabled: null),
+            DesktopDirectSiteProviderOptions.Disabled);
     }
 
     public static ServiceProvider BuildServices(
@@ -50,9 +53,23 @@ public static class DesktopCompositionRoot
         DesktopUploadSectionOptions uploadSectionOptions,
         DesktopGroupTreeOptions groupTreeOptions)
     {
+        return BuildServices(
+            authOptions,
+            uploadSectionOptions,
+            groupTreeOptions,
+            DesktopDirectSiteProviderOptions.Disabled);
+    }
+
+    public static ServiceProvider BuildServices(
+        DesktopAuthOptions authOptions,
+        DesktopUploadSectionOptions uploadSectionOptions,
+        DesktopGroupTreeOptions groupTreeOptions,
+        DesktopDirectSiteProviderOptions directSiteProviderOptions)
+    {
         ArgumentNullException.ThrowIfNull(authOptions);
         ArgumentNullException.ThrowIfNull(uploadSectionOptions);
         ArgumentNullException.ThrowIfNull(groupTreeOptions);
+        ArgumentNullException.ThrowIfNull(directSiteProviderOptions);
 
         DesktopGroupTreeOptions effectiveGroupTreeOptions = authOptions.IsControlPlaneSignInConfigured
             ? DesktopGroupTreeOptions.EnabledForLiveControlPlane
@@ -74,6 +91,7 @@ public static class DesktopCompositionRoot
         services.AddSingleton(authOptions);
         services.AddSingleton(effectiveUploadSectionOptions);
         services.AddSingleton(effectiveGroupTreeOptions);
+        services.AddSingleton(directSiteProviderOptions);
         services.AddSingleton<IDesktopShellLifecycle, PlaceholderDesktopShellLifecycle>();
         services.AddSingleton<IDesktopSessionStore, DisabledDesktopSessionStore>();
         services.AddSingleton<DesktopSessionState>();

--- a/src/App.Desktop/Services/Upload/DesktopDirectSiteProviderOptions.cs
+++ b/src/App.Desktop/Services/Upload/DesktopDirectSiteProviderOptions.cs
@@ -1,0 +1,152 @@
+namespace App.Desktop.Services.Upload;
+
+public sealed class DesktopDirectSiteProviderOptions
+{
+    public const string ProviderKeyEnvironmentVariable =
+        "AA_DESKTOP_DIRECT_SITE_PROVIDER_KEY";
+
+    public const string ProviderBaseAddressEnvironmentVariable =
+        "AA_DESKTOP_DIRECT_SITE_PROVIDER_BASE_ADDRESS";
+
+    private static readonly string[] TokenLikeProviderKeySegments =
+    [
+        "authorization",
+        "credential",
+        "password",
+        "refresh",
+        "secret",
+        "token"
+    ];
+
+    private DesktopDirectSiteProviderOptions(
+        bool isProviderConfigPresent,
+        string? providerKey,
+        Uri? providerBaseAddress)
+    {
+        IsProviderConfigPresent = isProviderConfigPresent;
+        ProviderKey = providerKey;
+        ProviderBaseAddress = providerBaseAddress;
+    }
+
+    public static DesktopDirectSiteProviderOptions Disabled { get; } = new(
+        isProviderConfigPresent: false,
+        providerKey: null,
+        providerBaseAddress: null);
+
+    public bool IsProviderConfigPresent { get; }
+
+    public bool IsProviderConfigValid => ProviderKey is not null && ProviderBaseAddress is not null;
+
+    public bool IsDirectSiteUploadAvailable { get; }
+
+    public string? ProviderKey { get; }
+
+    public Uri? ProviderBaseAddress { get; }
+
+    public static DesktopDirectSiteProviderOptions FromEnvironment()
+    {
+        return FromEnvironmentValues(
+            Environment.GetEnvironmentVariable(ProviderKeyEnvironmentVariable),
+            Environment.GetEnvironmentVariable(ProviderBaseAddressEnvironmentVariable));
+    }
+
+    public static DesktopDirectSiteProviderOptions FromEnvironmentValues(
+        string? providerKey,
+        string? providerBaseAddress)
+    {
+        bool isProviderConfigPresent = !string.IsNullOrWhiteSpace(providerKey)
+            || !string.IsNullOrWhiteSpace(providerBaseAddress);
+
+        if (!isProviderConfigPresent)
+        {
+            return Disabled;
+        }
+
+        return new DesktopDirectSiteProviderOptions(
+            isProviderConfigPresent,
+            NormalizeProviderKey(providerKey),
+            ParseProviderBaseAddress(providerBaseAddress));
+    }
+
+    public override string ToString()
+    {
+        return $"{nameof(DesktopDirectSiteProviderOptions)} {{ "
+            + $"IsProviderConfigPresent = {IsProviderConfigPresent}, "
+            + $"IsProviderConfigValid = {IsProviderConfigValid}, "
+            + $"IsDirectSiteUploadAvailable = {IsDirectSiteUploadAvailable}, "
+            + $"ProviderKey = {ProviderKey ?? "<none>"}, "
+            + $"Scheme = {ProviderBaseAddress?.Scheme ?? "<none>"}, "
+            + $"Host = {ProviderBaseAddress?.Host ?? "<none>"} }}";
+    }
+
+    private static string? NormalizeProviderKey(string? providerKey)
+    {
+        if (string.IsNullOrWhiteSpace(providerKey))
+        {
+            return null;
+        }
+
+        string trimmed = providerKey.Trim();
+
+        if (trimmed.Length is < 3 or > 64 || !char.IsLetterOrDigit(trimmed[0]))
+        {
+            return null;
+        }
+
+        foreach (char character in trimmed)
+        {
+            if (!char.IsLetterOrDigit(character)
+                && character is not '-' and not '_' and not '.')
+            {
+                return null;
+            }
+        }
+
+        foreach (string tokenLikeSegment in TokenLikeProviderKeySegments)
+        {
+            if (trimmed.Contains(tokenLikeSegment, StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+        }
+
+        return trimmed;
+    }
+
+    private static Uri? ParseProviderBaseAddress(string? providerBaseAddress)
+    {
+        if (string.IsNullOrWhiteSpace(providerBaseAddress)
+            || !Uri.TryCreate(providerBaseAddress.Trim(), UriKind.Absolute, out Uri? parsed)
+            || !IsSafeProviderBaseAddress(parsed))
+        {
+            return null;
+        }
+
+        return parsed;
+    }
+
+    private static bool IsSafeProviderBaseAddress(Uri providerBaseAddress)
+    {
+        if (!providerBaseAddress.IsAbsoluteUri || string.IsNullOrWhiteSpace(providerBaseAddress.Host))
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(providerBaseAddress.UserInfo))
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrEmpty(providerBaseAddress.Query) || !string.IsNullOrEmpty(providerBaseAddress.Fragment))
+        {
+            return false;
+        }
+
+        if (providerBaseAddress.AbsolutePath is not "" and not "/")
+        {
+            return false;
+        }
+
+        return providerBaseAddress.Scheme == Uri.UriSchemeHttps;
+    }
+}

--- a/tests/Unit/App.Desktop.Tests/DesktopCompositionRootTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopCompositionRootTests.cs
@@ -55,7 +55,9 @@ public sealed class DesktopCompositionRootTests
             .Set(DesktopUploadSectionOptions.DevFakePreUploadCheckEnabledEnvironmentVariable, null)
             .Set(DesktopUploadSectionOptions.DevFakeSiteUploadEnabledEnvironmentVariable, null)
             .Set(DesktopUploadSectionOptions.DevFakeUploadReceiptEnabledEnvironmentVariable, null)
-            .Set(DesktopGroupTreeOptions.DevFakeGroupTreeEnabledEnvironmentVariable, null);
+            .Set(DesktopGroupTreeOptions.DevFakeGroupTreeEnabledEnvironmentVariable, null)
+            .Set(DesktopDirectSiteProviderOptions.ProviderKeyEnvironmentVariable, null)
+            .Set(DesktopDirectSiteProviderOptions.ProviderBaseAddressEnvironmentVariable, null);
 
         using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
 
@@ -583,7 +585,9 @@ public sealed class DesktopCompositionRootTests
             .Set(DesktopAuthOptions.ControlPlaneBaseAddressEnvironmentVariable, "https://control-plane.local")
             .Set(DesktopAuthOptions.DevFakeAuthEnabledEnvironmentVariable, "true")
             .Set(DesktopUploadSectionOptions.DevFakeSiteUploadEnabledEnvironmentVariable, "true")
-            .Set(DesktopUploadSectionOptions.DevFakeUploadReceiptEnabledEnvironmentVariable, "true");
+            .Set(DesktopUploadSectionOptions.DevFakeUploadReceiptEnabledEnvironmentVariable, "true")
+            .Set(DesktopDirectSiteProviderOptions.ProviderKeyEnvironmentVariable, "korobochka-direct")
+            .Set(DesktopDirectSiteProviderOptions.ProviderBaseAddressEnvironmentVariable, "https://upload.korobochka.local");
 
         using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
 
@@ -597,6 +601,9 @@ public sealed class DesktopCompositionRootTests
         Assert.True(services.GetRequiredService<DesktopUploadSectionViewModel>().IsLiveControlPlaneUploadReceiptEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakeSiteUploadEnabled);
         Assert.False(services.GetRequiredService<DesktopUploadSectionViewModel>().IsDevFakeUploadReceiptEnabled);
+        Assert.True(services.GetRequiredService<DesktopDirectSiteProviderOptions>().IsProviderConfigPresent);
+        Assert.True(services.GetRequiredService<DesktopDirectSiteProviderOptions>().IsProviderConfigValid);
+        Assert.False(services.GetRequiredService<DesktopDirectSiteProviderOptions>().IsDirectSiteUploadAvailable);
         Assert.IsType<HttpDesktopPreUploadCheckClient>(
             services.GetRequiredService<IDesktopPreUploadCheckClient>());
         Assert.IsType<DisabledDesktopDirectSiteUploadClient>(
@@ -605,6 +612,62 @@ public sealed class DesktopCompositionRootTests
             services.GetRequiredService<IDesktopUploadReceiptClient>());
     }
 
+    [Fact]
+    public void MissingDirectSiteProviderEnvironmentKeepsProviderDisabled()
+    {
+        using var environment = new EnvironmentVariableScope()
+            .Set(DesktopAuthOptions.ControlPlaneBaseAddressEnvironmentVariable, null)
+            .Set(DesktopDirectSiteProviderOptions.ProviderKeyEnvironmentVariable, null)
+            .Set(DesktopDirectSiteProviderOptions.ProviderBaseAddressEnvironmentVariable, null);
+
+        using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
+
+        DesktopDirectSiteProviderOptions options = services.GetRequiredService<DesktopDirectSiteProviderOptions>();
+
+        Assert.False(options.IsProviderConfigPresent);
+        Assert.False(options.IsProviderConfigValid);
+        Assert.False(options.IsDirectSiteUploadAvailable);
+        Assert.IsType<DisabledDesktopDirectSiteUploadClient>(
+            services.GetRequiredService<IDesktopDirectSiteUploadClient>());
+    }
+
+    [Fact]
+    public void InvalidDirectSiteProviderEnvironmentDoesNotEscapeCompositionRoot()
+    {
+        using var environment = new EnvironmentVariableScope()
+            .Set(DesktopAuthOptions.ControlPlaneBaseAddressEnvironmentVariable, "https://control-plane.local")
+            .Set(DesktopDirectSiteProviderOptions.ProviderKeyEnvironmentVariable, "korobochka-direct")
+            .Set(DesktopDirectSiteProviderOptions.ProviderBaseAddressEnvironmentVariable, "not a uri");
+
+        using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
+
+        DesktopDirectSiteProviderOptions options = services.GetRequiredService<DesktopDirectSiteProviderOptions>();
+
+        Assert.True(options.IsProviderConfigPresent);
+        Assert.False(options.IsProviderConfigValid);
+        Assert.False(options.IsDirectSiteUploadAvailable);
+        Assert.IsType<DisabledDesktopDirectSiteUploadClient>(
+            services.GetRequiredService<IDesktopDirectSiteUploadClient>());
+    }
+
+    [Fact]
+    public void ValidDirectSiteProviderConfigIsConfigOnlyAndKeepsDisabledClient()
+    {
+        using var environment = new EnvironmentVariableScope()
+            .Set(DesktopAuthOptions.ControlPlaneBaseAddressEnvironmentVariable, null)
+            .Set(DesktopDirectSiteProviderOptions.ProviderKeyEnvironmentVariable, "korobochka-direct")
+            .Set(DesktopDirectSiteProviderOptions.ProviderBaseAddressEnvironmentVariable, "https://upload.korobochka.local");
+
+        using var services = DesktopCompositionRoot.BuildServicesFromEnvironment();
+
+        DesktopDirectSiteProviderOptions options = services.GetRequiredService<DesktopDirectSiteProviderOptions>();
+
+        Assert.True(options.IsProviderConfigPresent);
+        Assert.True(options.IsProviderConfigValid);
+        Assert.False(options.IsDirectSiteUploadAvailable);
+        Assert.IsType<DisabledDesktopDirectSiteUploadClient>(
+            services.GetRequiredService<IDesktopDirectSiteUploadClient>());
+    }
     [Fact]
     public void ExplicitFakeUploadReceiptFlagDoesNotReplaceConfiguredLiveUploadReceiptClient()
     {

--- a/tests/Unit/App.Desktop.Tests/DesktopDirectSiteProviderOptionsTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopDirectSiteProviderOptionsTests.cs
@@ -1,0 +1,100 @@
+using App.Desktop.Services.Upload;
+
+namespace App.Desktop.Tests;
+
+public sealed class DesktopDirectSiteProviderOptionsTests
+{
+    [Fact]
+    public void MissingProviderConfigKeepsProviderDisabled()
+    {
+        DesktopDirectSiteProviderOptions options = DesktopDirectSiteProviderOptions.FromEnvironmentValues(
+            providerKey: null,
+            providerBaseAddress: null);
+
+        Assert.Same(DesktopDirectSiteProviderOptions.Disabled, options);
+        Assert.False(options.IsProviderConfigPresent);
+        Assert.False(options.IsProviderConfigValid);
+        Assert.False(options.IsDirectSiteUploadAvailable);
+        Assert.Null(options.ProviderKey);
+        Assert.Null(options.ProviderBaseAddress);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not a uri")]
+    [InlineData("ftp://upload.korobochka.local")]
+    [InlineData("http://upload.korobochka.local")]
+    [InlineData("https://operator:secret@upload.korobochka.local")]
+    [InlineData("https://upload.korobochka.local?preview=1")]
+    [InlineData("https://upload.korobochka.local#secret")]
+    [InlineData("https://upload.korobochka.local/video")]
+    public void InvalidProviderBaseAddressKeepsProviderDisabled(string providerBaseAddress)
+    {
+        DesktopDirectSiteProviderOptions options = DesktopDirectSiteProviderOptions.FromEnvironmentValues(
+            "korobochka-direct",
+            providerBaseAddress);
+
+        Assert.True(options.IsProviderConfigPresent);
+        Assert.False(options.IsProviderConfigValid);
+        Assert.False(options.IsDirectSiteUploadAvailable);
+        Assert.Equal("korobochka-direct", options.ProviderKey);
+        Assert.Null(options.ProviderBaseAddress);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("ab")]
+    [InlineData("provider key")]
+    [InlineData("provider/key")]
+    [InlineData("access-token")]
+    [InlineData("secret-provider")]
+    [InlineData("token-provider")]
+    public void InvalidProviderKeyKeepsProviderDisabled(string? providerKey)
+    {
+        DesktopDirectSiteProviderOptions options = DesktopDirectSiteProviderOptions.FromEnvironmentValues(
+            providerKey,
+            "https://upload.korobochka.local");
+
+        Assert.True(options.IsProviderConfigPresent);
+        Assert.False(options.IsProviderConfigValid);
+        Assert.False(options.IsDirectSiteUploadAvailable);
+        Assert.Null(options.ProviderKey);
+        Assert.NotNull(options.ProviderBaseAddress);
+    }
+
+    [Fact]
+    public void ValidProviderConfigIsRecognizedAsConfigOnlyBoundary()
+    {
+        DesktopDirectSiteProviderOptions options = DesktopDirectSiteProviderOptions.FromEnvironmentValues(
+            "korobochka-direct",
+            "https://upload.korobochka.local");
+
+        Assert.True(options.IsProviderConfigPresent);
+        Assert.True(options.IsProviderConfigValid);
+        Assert.False(options.IsDirectSiteUploadAvailable);
+        Assert.Equal("korobochka-direct", options.ProviderKey);
+        Assert.Equal(new Uri("https://upload.korobochka.local"), options.ProviderBaseAddress);
+    }
+
+    [Fact]
+    public void ToStringKeepsProviderDiagnosticsRedactedAndSecretFree()
+    {
+        DesktopDirectSiteProviderOptions invalidOptions = DesktopDirectSiteProviderOptions.FromEnvironmentValues(
+            "token-provider",
+            "https://upload.korobochka.local?preview=1");
+        DesktopDirectSiteProviderOptions validOptions = DesktopDirectSiteProviderOptions.FromEnvironmentValues(
+            "korobochka-direct",
+            "https://upload.korobochka.local");
+
+        string invalidText = invalidOptions.ToString();
+        string validText = validOptions.ToString();
+
+        Assert.DoesNotContain("preview", invalidText, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("token-provider", invalidText, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("https://", validText, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("/", validText, StringComparison.Ordinal);
+        Assert.Contains("ProviderKey = korobochka-direct", validText, StringComparison.Ordinal);
+        Assert.Contains("Host = upload.korobochka.local", validText, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Related issue / task card

Task card:
docs/task-cards/S2-73_desktop-direct-site-provider-config-options-task-card.txt

Follow-up from:
- S2-71 PR #140 desktop direct-site provider probe
- S2-72 PR #141 desktop direct-site provider boundary design

Closes: N/A

## Purpose

Add the App.Desktop-only direct-site provider config/options boundary and disabled/live selection plumbing.

This is the first implementation slice after S2-72 design.

S2-73 intentionally does not implement real direct-site HTTP upload.

## Scope

Implemented:
- App.Desktop-only direct-site provider options model
- provider config validation
- default disabled/unavailable provider state
- missing/invalid config remains disabled
- valid config is recognized as config-only boundary
- IDesktopDirectSiteUploadClient remains disabled/unavailable in S2-73
- configured live control-plane mode still suppresses dev fake site upload
- unit test coverage for options and composition behavior

Not implemented:
- no real HTTP upload
- no HttpDesktopDirectSiteUploadClient
- no provider request/response contract
- no video bytes sent anywhere
- no UploadReceipt contract change

## Changed areas

- docs/task-cards/S2-73_desktop-direct-site-provider-config-options-task-card.txt
- src/App.Desktop/Composition/DesktopCompositionRoot.cs
- src/App.Desktop/Services/Upload/DesktopDirectSiteProviderOptions.cs
- tests/Unit/App.Desktop.Tests/DesktopCompositionRootTests.cs
- tests/Unit/App.Desktop.Tests/DesktopDirectSiteProviderOptionsTests.cs

## Validation

- dotnet restore src/App.Desktop/App.Desktop.csproj: PASS
- dotnet restore tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj: PASS
- dotnet format whitespace src/App.Desktop/App.Desktop.csproj --verify-no-changes --no-restore: PASS
- dotnet format whitespace tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj --verify-no-changes --no-restore: PASS
- dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal: PASS
- dotnet build tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal: PASS
- dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal --no-build: PASS, 204 passed
- git diff --check: PASS

## NO-GO / Deferred

- No real direct-site upload implementation.
- No HttpDesktopDirectSiteUploadClient.
- No App.Api endpoint.
- No backend/module code.
- No BuildingBlocks.Contracts changes.
- No video bytes through App.Api.
- No provider credentials or tokens.
- No live Korobochka smoke.

## Notes for reviewers

Review focus:
- provider config/options boundary remains App.Desktop-only
- real upload remains disabled/unavailable
- valid config is config-only in S2-73
- no App.Api/backend/contracts changes
- no fake site upload in configured live control-plane mode

Recent commits:
ef03420 feat(desktop): add direct site provider config options boundary
af183a5 docs(desktop): add S2-73 direct site provider config options task card
