### PR TITLE
docs(desktop): add S2-74 direct site provider contract design

### DIFF
--- a/docs/design/S2-74_desktop-direct-site-provider-contract-design.md
+++ b/docs/design/S2-74_desktop-direct-site-provider-contract-design.md
@@ -1,0 +1,303 @@
+# S2-74 Desktop Direct Site Provider Request / Response Contract Design
+
+Status: design proposal.
+
+This document proposes the request/response boundary for a future direct-site provider upload.
+
+It does not implement DTO code, shared contracts, App.Api endpoints, provider client code, or byte transfer.
+
+## Background
+
+S2-71 found no approved direct-site provider/config/contract.
+
+S2-72 defined the direct-site provider boundary design.
+
+S2-73 added the App.Desktop provider config/options boundary and kept the live provider disabled/unavailable.
+
+S2-74 defines the proposed contract shape that owner/platform/backend must review before implementation.
+
+## Architecture rule
+
+App.Api remains control plane.
+
+Video bytes must not go through App.Api.
+
+The desktop client may upload bytes only to an approved direct-site provider endpoint in a later task.
+
+PreUploadCheck remains the gate before upload.
+
+UploadReceipt remains the server-side authoritative post-upload control-plane record.
+
+## Contract levels
+
+There are three distinct levels and they must not be confused:
+
+1. Desktop internal request model
+
+Used by App.Desktop to describe a direct-site upload attempt before calling a provider client.
+
+2. Provider wire request
+
+The provider-specific HTTP request sent to the direct-site provider.
+
+3. UploadReceipt request
+
+The control-plane request sent to App.Api after a provider upload succeeds.
+
+S2-74 does not add any of these as code.
+
+## Proposed desktop internal upload request fields
+
+A future desktop internal request should contain only safe, necessary fields:
+
+- PreUploadCheckId
+- UserId or user context reference if already available from desktop session
+- DeviceId if required by control plane
+- GroupNodeId
+- BusinessObjectKey
+- Local file handle or stream abstraction
+- File display name without full local path
+- SizeBytes
+- ByteSha256
+- ContentType
+- IdempotencyKey
+- ProviderKey
+- ProviderUploadTarget reference
+- ExternalVideoId if assigned by PreUploadCheck / SitePlan
+- StorageKey if assigned by PreUploadCheck / SitePlan
+- CorrelationId
+
+Fields that must not be present:
+
+- password
+- accessToken value
+- refreshToken value
+- Authorization header value
+- provider credential value
+- signed URL query secret
+- raw local file path in UI/log/debug output
+- raw request body
+- raw response body
+
+## Proposed provider upload target
+
+A future provider target should be designed as a redacted value object.
+
+Possible fields:
+
+- ProviderKey
+- EndpointBaseAddress or UploadUri
+- Method
+- RequiredHeaders metadata
+- CredentialKind
+- ExpiresAtUtc if temporary
+- MaxSizeBytes if provider-limited
+- AllowedContentTypes
+- CorrelationId
+- RedactedDisplayUri
+
+Sensitive fields must be separated from display/diagnostic fields.
+
+## Proposed provider wire request rules
+
+A future provider wire request must define:
+
+- HTTP method
+- upload URL shape
+- required headers
+- allowed credential kind
+- stream behavior
+- timeout
+- cancellation
+- retry policy
+- checksum requirement
+- content-type behavior
+- size validation
+- idempotency propagation
+- correlation propagation
+
+The provider wire request must never be logged as raw text.
+
+## Proposed provider response fields
+
+A future provider response should contain:
+
+- ProviderKey
+- ProviderUploadId or provider receipt id
+- ExternalVideoId
+- StorageKey
+- ProviderStatus
+- UploadedAtUtc
+- SizeBytes
+- ByteSha256 if provider confirms it
+- ETag or checksum echo if provider returns one
+- CorrelationId
+- Retryable flag for failures
+- FailureCode
+- FailureMessageRedacted
+- RawBodyRedacted indicator
+
+Provider response must not expose raw response body in logs or UI.
+
+## Provider status normalization
+
+A future implementation must define provider status mapping.
+
+Minimum proposed normalized statuses:
+
+- Accepted
+- Completed
+- Rejected
+- DuplicateSuspected
+- FailedRetryable
+- FailedTerminal
+- Unknown
+
+Status normalization must be reviewed before UploadReceipt linkage.
+
+## Error and retry classification
+
+A future implementation must define:
+
+- retryable network error
+- retryable provider temporary error
+- non-retryable validation error
+- auth/credential error
+- provider unavailable
+- checksum mismatch
+- size mismatch
+- unsupported media type
+- unknown provider response
+
+Retry behavior must not create duplicate uploads without idempotency guard.
+
+## Idempotency requirements
+
+A future implementation must define:
+
+- IdempotencyKey source
+- whether key is generated before provider upload
+- whether key is reused after app restart
+- whether key is scoped to PreUploadCheckId
+- whether key is scoped to file hash
+- whether key is sent to provider
+- whether key is sent to UploadReceipt
+- how duplicate provider response is handled
+
+Idempotency behavior must be approved before real upload.
+
+## UploadReceipt linkage
+
+A future provider response may be used for UploadReceipt only after approved mapping.
+
+Required linkage decisions:
+
+- PreUploadCheckId source
+- GroupNodeId source
+- BusinessObjectKey source
+- ExternalVideoId source
+- StorageKey source
+- UploadedAtUtc source
+- SiteStatus mapping
+- SizeBytes verification
+- ByteSha256 verification
+- IdempotencyKey propagation
+- Provider correlation id propagation
+- behavior when provider upload succeeds but UploadReceipt fails
+- behavior when UploadReceipt succeeds but later reconcile disagrees
+
+Fake/dev site upload must not produce a live UploadReceipt in configured live control-plane mode.
+
+## Security and redaction
+
+Required redaction rules:
+
+- no password
+- no accessToken
+- no refreshToken
+- no Authorization header
+- no provider credential
+- no signed URL query secret
+- no raw local file path
+- no raw request body
+- no raw response body
+- no screenshots containing secrets
+- no full local path in request preview
+- no provider credential in ToString
+
+Allowed diagnostic examples:
+
+- provider key
+- status enum
+- retry classification
+- correlation id
+- size bucket
+- elapsed time
+- redacted host if approved
+- redacted display URI if approved
+
+## Offline behavior
+
+S2-74 does not implement offline behavior.
+
+Future real upload should default to online-only unless a separate offline/late-sync design is approved.
+
+Offline mode must not claim absolute duplicate prevention while the server is unavailable.
+
+## Proposed review questions
+
+Owner/platform/backend should answer:
+
+1. Is provider upload target issued by App.Api or configured locally?
+2. Is provider credential required?
+3. If credential is required, who issues it and how long does it live?
+4. Is provider upload single-use?
+5. Is IdempotencyKey required by provider?
+6. Which field is authoritative for ExternalVideoId?
+7. Which field is authoritative for StorageKey?
+8. Does provider confirm checksum?
+9. What statuses can provider return?
+10. What response fields can be safely used for UploadReceipt?
+11. What fields must be redacted in diagnostics and UI?
+12. What is the retry policy?
+13. What is the terminal failure policy?
+14. What is the reconcile policy after UploadReceipt?
+
+## NO-GO before implementation
+
+Do not implement real direct-site upload while any of these are unresolved:
+
+- provider target source not approved
+- credential boundary not approved
+- request shape not approved
+- response shape not approved
+- UploadReceipt mapping not approved
+- idempotency not approved
+- retry policy not approved
+- redaction not approved
+- provider status mapping not approved
+- security owner/platform owner has not approved
+- implementation would send video bytes through App.Api
+
+## Recommended next slices after approval
+
+Possible sequence:
+
+1. S2-75 App.Desktop provider upload target value objects and redacted diagnostics.
+2. S2-76 provider request/response model implementation if approved.
+3. S2-77 provider client boundary with no live secrets in tests.
+4. S2-78 UploadReceipt linkage after provider response.
+5. S2-79 controlled live smoke with approved provider and redaction.
+
+## Review checklist
+
+Reviewer should verify:
+
+- this doc does not sneak in runtime implementation
+- App.Api remains control plane
+- video bytes never go through App.Api
+- UploadReceipt remains server-authoritative
+- fake/dev path remains isolated
+- secrets are explicitly prohibited
+- provider credential behavior is not assumed without approval
+- next runtime slices remain separate

--- a/docs/task-cards/S2-74_desktop-direct-site-provider-contract-design-task-card.txt
+++ b/docs/task-cards/S2-74_desktop-direct-site-provider-contract-design-task-card.txt
@@ -1,0 +1,105 @@
+TASK CARD: S2-74 Desktop Direct Site Provider Request / Response Contract Design
+
+Module:
+App.Desktop / direct-site provider contract design
+
+Owner:
+Coder 2 / Desktop Client, with owner/platform/backend review before implementation
+
+Client form:
+desktop standalone
+
+Type:
+docs-only design task after S2-73 provider config/options boundary
+
+Goal:
+Define the request/response contract boundary for a future direct-site provider upload, without implementing DTO code, App.Api endpoints, provider client code, or byte transfer.
+
+Background:
+S2-71 found no approved direct-site provider/config/contract.
+S2-72 defined provider boundary requirements.
+S2-73 added App.Desktop provider config/options boundary and kept direct-site upload disabled/unavailable.
+S2-74 defines the proposed request/response contract shape and review criteria before any implementation.
+
+Scope:
+- Define proposed direct-site upload request fields.
+- Define proposed direct-site upload response fields.
+- Define error/retry classification requirements.
+- Define idempotency and correlation requirements.
+- Define redaction/security requirements.
+- Define UploadReceipt linkage requirements.
+- Define NO-GO conditions before implementation.
+
+Allowed changed areas:
+- docs/task-cards/S2-74_desktop-direct-site-provider-contract-design-task-card.txt
+- docs/design/S2-74_desktop-direct-site-provider-contract-design.md
+
+Forbidden changed areas:
+- src/App.Desktop/**
+- src/App.Api/**
+- src/Modules/**
+- src/BuildingBlocks/Contracts/**
+- src/App.Web/**
+- src/App.Mobile.Android/**
+- src/App.UI.Shared/**
+- DB migrations
+- .github/workflows/**
+- deploy scripts
+- docs/ops/**
+- committed screenshots or runtime artifacts
+
+Contracts:
+No contract code change in this task.
+No shared DTO is added in S2-74.
+Any future BuildingBlocks.Contracts change requires separate approval and separate implementation PR.
+
+Feature flag:
+Not needed for docs-only design.
+
+Migration:
+No migration.
+
+Events:
+None.
+
+Offline behavior:
+No runtime offline behavior change.
+Future offline/late-sync behavior must be explicitly designed and must not claim absolute duplicate prevention while server is offline.
+
+Security:
+No secrets in docs.
+No token values.
+No Authorization header values.
+No provider credential values.
+No signed URL query secrets.
+No raw local file paths.
+No raw request/response bodies.
+
+Definition of done:
+- Task card exists.
+- Design doc exists.
+- Request fields are proposed.
+- Response fields are proposed.
+- Error/retry/idempotency/correlation rules are proposed.
+- UploadReceipt linkage rules are proposed.
+- Redaction/security rules are explicit.
+- NO-GO conditions are explicit.
+- No production code is changed.
+- No App.Api/backend/contracts code is changed.
+
+Validation:
+- git diff --check
+- docs-only diff scope
+
+Rollback:
+Revert S2-74 docs-only PR.
+
+NO-GO:
+- Do not implement real HTTP upload.
+- Do not add HttpDesktopDirectSiteUploadClient.
+- Do not add shared DTOs.
+- Do not add App.Api endpoint.
+- Do not add backend/module code.
+- Do not send video bytes through App.Api.
+- Do not add provider credentials or tokens.
+- Do not run live Korobochka smoke for this task.


### PR DESCRIPTION
## Related issue / task card

Task card:
docs/task-cards/S2-74_desktop-direct-site-provider-contract-design-task-card.txt

Design doc:
docs/design/S2-74_desktop-direct-site-provider-contract-design.md

Follow-up from:
- S2-71 PR #140 desktop direct-site provider probe
- S2-72 PR #141 direct-site provider boundary design
- S2-73 PR #142 provider config/options boundary

Closes: N/A

## Purpose

Add a docs-only S2-74 request/response contract design for a future Desktop direct-site provider.

This PR defines the proposed provider request/response boundary before any DTO/code/client implementation.

## Coder

Coder 2 / Desktop Client

## Task ID

S2-74

## Module

- [x] repo/process
- [ ] backend/platform
- [ ] infra/deploy
- [ ] shared contracts
- [ ] web
- [ ] mobile
- [x] docs
- [x] desktop

## Scope

Docs-only contract boundary design.

Documents:
- proposed desktop internal upload request fields
- proposed provider upload target fields
- proposed provider wire request rules
- proposed provider response fields
- error/retry classification requirements
- idempotency/correlation requirements
- UploadReceipt linkage requirements
- security/redaction rules
- NO-GO conditions before implementation

## Changed areas

- .github/workflows:
  - none

- docs:
  - docs/task-cards/S2-74_desktop-direct-site-provider-contract-design-task-card.txt
  - docs/design/S2-74_desktop-direct-site-provider-contract-design.md

- src/App.Api:
  - none

- src/App.Worker:
  - none

- src/App.Web:
  - none

- src/App.Mobile.Android:
  - none

- src/App.UI.Shared:
  - none

- src/BuildingBlocks.Contracts:
  - none

- src/Modules:
  - none

- tests:
  - none

- other:
  - none

## Contracts

- [x] no contract change
- [ ] shared DTO changed
- [ ] API request/response changed
- [ ] internal event changed

Details:

No contract code is changed. No shared DTO is added in S2-74.

Any future BuildingBlocks.Contracts change requires separate approval and separate implementation PR.

## Migrations

- [x] no migration
- [ ] additive migration required
- [ ] follow-up cleanup migration will be needed later

Details:

No DB changes.

## Feature flags

- [x] not needed
- [ ] existing flag used
- [ ] new flag required

Details:

Docs-only design task. No runtime behavior change.

## API impact

- [x] none
- [ ] additive
- [ ] breaking

Details:

App.Api remains control plane. No App.Api endpoint or DTO is added.

## Web impact

- [x] none
- [ ] UI/behavior changed
- [ ] handoff only

Details:

No App.Web changes.

## Android impact

- [x] none
- [ ] UI/behavior changed
- [ ] handoff only

Details:

No App.Mobile.Android changes.

## Offline behavior

No runtime/offline behavior change.

The design states that future offline/late-sync behavior must be explicitly designed and must not claim absolute duplicate prevention while server is offline.

## Rollback

Revert this docs-only PR.

## Validation

- git diff --check for PR diff: PASS
- docs-only diff scope: PASS
- changed files exactly match S2-74 task card and design doc.

## Handoff docs

- docs/design/S2-74_desktop-direct-site-provider-contract-design.md

## Next step

Owner/platform/backend review of request/response contract boundary.

After approval, create separate implementation slices only for the approved contract/client boundary.

## NO-GO / Deferred

- No real HTTP upload implementation.
- No HttpDesktopDirectSiteUploadClient.
- No shared DTOs.
- No App.Api endpoint.
- No backend/module code.
- No video bytes through App.Api.
- No provider credentials or tokens.
- No live Korobochka smoke.

## Security notes

The design explicitly prohibits logging/displaying:
- password
- accessToken
- refreshToken
- Authorization header
- provider credential
- signed URL query secret
- raw local file path
- raw request body
- raw response body

## Tests / build applicability

- [x] docs/workflow-only change; build/test not applicable locally
- [ ] runtime change; relevant checks listed below

Details:

Docs-only design task. No production code changed.

## Notes for reviewers

Review focus:
- design does not sneak in runtime implementation
- App.Api remains control plane
- video bytes never go through App.Api
- UploadReceipt remains server-authoritative
- request/response/idempotency/redaction rules are explicit enough for a later implementation task

Recent commits:
7708763 docs(desktop): add S2-74 direct site provider contract design
