### PR TITLE
Feature/s2 75 desktop direct site provider upload target

### DIFF
--- a/docs/task-cards/S2-75_desktop-direct-site-provider-upload-target-task-card.txt
+++ b/docs/task-cards/S2-75_desktop-direct-site-provider-upload-target-task-card.txt
@@ -1,0 +1,124 @@
+TASK CARD: S2-75 Desktop Direct Site Provider Upload Target / Redacted Diagnostics
+
+Module:
+App.Desktop / direct-site provider upload target
+
+Owner:
+Coder 2 / Desktop Client
+
+Client form:
+desktop standalone
+
+Type:
+narrow runtime implementation task after S2-74 contract design
+
+Goal:
+Add App.Desktop-only provider upload target value objects and redacted diagnostics for a future direct-site provider.
+
+This task must not implement real byte upload.
+
+Background:
+S2-71 found no approved direct-site provider/config/contract.
+S2-72 defined provider boundary requirements.
+S2-73 added provider config/options boundary.
+S2-74 documented request/response contract design.
+S2-75 adds safe App.Desktop value objects for upload target and diagnostics only.
+
+Allowed changed areas for implementation:
+- src/App.Desktop/**
+- tests/Unit/App.Desktop.Tests/**
+- docs/task-cards/S2-75_desktop-direct-site-provider-upload-target-task-card.txt
+
+Forbidden changed areas:
+- src/App.Api/**
+- src/Modules/**
+- src/BuildingBlocks/Contracts/**
+- src/App.Web/**
+- src/App.Mobile.Android/**
+- src/App.UI.Shared/**
+- DB migrations
+- .github/workflows/**
+- deploy scripts
+- docs/ops/**
+- committed screenshots or runtime artifacts
+
+Contracts:
+No shared contract change.
+No provider request/response DTO code.
+
+Feature flag / env guard:
+Use only App.Desktop-side config/options boundary from S2-73.
+Do not add credentials, tokens, or signed URL behavior.
+
+Migration:
+No migration.
+
+Events:
+None.
+
+Offline behavior:
+No runtime offline upload behavior change.
+Real provider upload remains unavailable offline unless later explicitly designed.
+
+Security:
+- Do not print or log password.
+- Do not print or log accessToken.
+- Do not print or log refreshToken.
+- Do not print or log Authorization header.
+- Do not print or log provider credential values.
+- Do not print or log signed URL query secrets.
+- Do not print or log raw local file paths.
+- Do not print or log raw request/response bodies.
+- Do not include screenshots or runtime artifacts.
+
+Implementation scope:
+- Add App.Desktop upload target value object(s).
+- Add redacted display/diagnostic value(s).
+- Add validation for safe provider key / endpoint host / allowed method metadata if present.
+- Keep sensitive values out of ToString and display text.
+- Keep IDesktopDirectSiteUploadClient disabled/unavailable.
+- Keep valid config as config-only boundary.
+- Do not implement provider wire request.
+- Do not implement provider response model as shared contract.
+- Do not add HttpDesktopDirectSiteUploadClient.
+- Do not send real video bytes.
+- Do not change UploadReceipt contract.
+- Do not change App.Api.
+
+Suggested implementation files:
+- src/App.Desktop/Services/Upload/DesktopDirectSiteUploadTarget.cs
+- tests/Unit/App.Desktop.Tests/DesktopDirectSiteUploadTargetTests.cs
+- existing App.Desktop upload/options tests as needed
+
+Definition of done:
+- Upload target value object exists and is testable.
+- Redacted diagnostics/display behavior exists and is testable.
+- Unsafe provider key or endpoint metadata is rejected or produces unavailable state.
+- ToString / display text does not expose secrets, signed URL query, raw local file paths, raw request bodies, or raw response bodies.
+- Valid upload target remains value-object-only and does not enable real upload.
+- IDesktopDirectSiteUploadClient remains disabled/unavailable.
+- No App.Api/backend/contracts files are changed.
+- Targeted App.Desktop build/test/format passes.
+
+Validation:
+- dotnet restore src/App.Desktop/App.Desktop.csproj
+- dotnet restore tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj
+- dotnet format whitespace src/App.Desktop/App.Desktop.csproj --verify-no-changes --no-restore
+- dotnet format whitespace tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj --verify-no-changes --no-restore
+- dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal
+- dotnet build tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal
+- dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal --no-build
+- git diff --check
+
+Rollback:
+Revert S2-75 PR.
+
+NO-GO:
+- Do not implement real HTTP upload.
+- Do not add HttpDesktopDirectSiteUploadClient.
+- Do not add shared DTOs.
+- Do not add App.Api endpoint.
+- Do not add backend/module code.
+- Do not send video bytes through App.Api.
+- Do not add provider credentials or tokens.
+- Do not run live Korobochka smoke for this task.

--- a/src/App.Desktop/Services/Upload/DesktopDirectSiteUploadTarget.cs
+++ b/src/App.Desktop/Services/Upload/DesktopDirectSiteUploadTarget.cs
@@ -1,0 +1,245 @@
+using System.Globalization;
+
+namespace App.Desktop.Services.Upload;
+
+public sealed class DesktopDirectSiteUploadTarget
+{
+    private const string DefaultHttpMethod = "POST";
+    private const string RedactedQueryMarker = "<redacted>";
+    private const string UnavailableDisplay = "<unavailable>";
+
+    private static readonly string[] TokenLikeProviderKeySegments =
+    [
+        "authorization",
+        "credential",
+        "password",
+        "refresh",
+        "secret",
+        "token"
+    ];
+
+    private static readonly string[] AllowedHttpMethods =
+    [
+        "POST",
+        "PUT"
+    ];
+
+    private DesktopDirectSiteUploadTarget(
+        bool isMetadataPresent,
+        bool isValid,
+        string? providerKey,
+        string? endpointScheme,
+        string? endpointHost,
+        string? endpointPath,
+        bool hasEndpointQuery,
+        string? httpMethod,
+        bool hasCorrelationId,
+        string redactedDisplayUri)
+    {
+        IsMetadataPresent = isMetadataPresent;
+        IsValid = isValid;
+        ProviderKey = providerKey;
+        EndpointScheme = endpointScheme;
+        EndpointHost = endpointHost;
+        EndpointPath = endpointPath;
+        HasEndpointQuery = hasEndpointQuery;
+        HttpMethod = httpMethod;
+        HasCorrelationId = hasCorrelationId;
+        RedactedDisplayUri = redactedDisplayUri;
+    }
+
+    public static DesktopDirectSiteUploadTarget Unavailable { get; } = new(
+        isMetadataPresent: false,
+        isValid: false,
+        providerKey: null,
+        endpointScheme: null,
+        endpointHost: null,
+        endpointPath: null,
+        hasEndpointQuery: false,
+        httpMethod: null,
+        hasCorrelationId: false,
+        redactedDisplayUri: UnavailableDisplay);
+
+    public bool IsMetadataPresent { get; }
+
+    public bool IsValid { get; }
+
+    public bool EnablesRealUpload { get; }
+
+    public string? ProviderKey { get; }
+
+    public string? EndpointScheme { get; }
+
+    public string? EndpointHost { get; }
+
+    public string? EndpointPath { get; }
+
+    public bool HasEndpointQuery { get; }
+
+    public string? HttpMethod { get; }
+
+    public bool HasCorrelationId { get; }
+
+    public string RedactedDisplayUri { get; }
+
+    public string DiagnosticText => ToString();
+
+    public static DesktopDirectSiteUploadTarget FromMetadata(
+        string? providerKey,
+        string? endpointUri,
+        string? httpMethod,
+        string? correlationId)
+    {
+        bool isMetadataPresent = !string.IsNullOrWhiteSpace(providerKey)
+            || !string.IsNullOrWhiteSpace(endpointUri)
+            || !string.IsNullOrWhiteSpace(httpMethod)
+            || !string.IsNullOrWhiteSpace(correlationId);
+
+        if (!isMetadataPresent)
+        {
+            return Unavailable;
+        }
+
+        string? normalizedProviderKey = NormalizeProviderKey(providerKey);
+        Uri? parsedEndpointUri = ParseEndpointUri(endpointUri);
+        string? normalizedHttpMethod = NormalizeHttpMethod(httpMethod);
+        bool hasCorrelationId = string.IsNullOrWhiteSpace(correlationId)
+            ? false
+            : Guid.TryParse(correlationId.Trim(), out _);
+
+        if (normalizedProviderKey is null
+            || parsedEndpointUri is null
+            || normalizedHttpMethod is null
+            || (!string.IsNullOrWhiteSpace(correlationId) && !hasCorrelationId))
+        {
+            return InvalidMetadataPresent;
+        }
+
+        return new DesktopDirectSiteUploadTarget(
+            isMetadataPresent: true,
+            isValid: true,
+            normalizedProviderKey,
+            parsedEndpointUri.Scheme,
+            parsedEndpointUri.Host,
+            NormalizeEndpointPath(parsedEndpointUri),
+            !string.IsNullOrEmpty(parsedEndpointUri.Query),
+            normalizedHttpMethod,
+            hasCorrelationId,
+            BuildRedactedDisplayUri(parsedEndpointUri));
+    }
+
+    public override string ToString()
+    {
+        return $"{nameof(DesktopDirectSiteUploadTarget)} {{ "
+            + $"IsMetadataPresent = {IsMetadataPresent}, "
+            + $"IsValid = {IsValid}, "
+            + $"EnablesRealUpload = {EnablesRealUpload}, "
+            + $"ProviderKey = {ProviderKey ?? "<none>"}, "
+            + $"Endpoint = {RedactedDisplayUri}, "
+            + $"Method = {HttpMethod ?? "<none>"}, "
+            + $"HasEndpointQuery = {HasEndpointQuery}, "
+            + $"HasCorrelationId = {HasCorrelationId} }}";
+    }
+
+    private static DesktopDirectSiteUploadTarget InvalidMetadataPresent { get; } = new(
+        isMetadataPresent: true,
+        isValid: false,
+        providerKey: null,
+        endpointScheme: null,
+        endpointHost: null,
+        endpointPath: null,
+        hasEndpointQuery: false,
+        httpMethod: null,
+        hasCorrelationId: false,
+        redactedDisplayUri: UnavailableDisplay);
+
+    private static string? NormalizeProviderKey(string? providerKey)
+    {
+        if (string.IsNullOrWhiteSpace(providerKey))
+        {
+            return null;
+        }
+
+        string trimmed = providerKey.Trim();
+
+        if (trimmed.Length is < 3 or > 64 || !char.IsLetterOrDigit(trimmed[0]))
+        {
+            return null;
+        }
+
+        foreach (char character in trimmed)
+        {
+            if (!char.IsLetterOrDigit(character)
+                && character is not '-' and not '_' and not '.')
+            {
+                return null;
+            }
+        }
+
+        foreach (string tokenLikeSegment in TokenLikeProviderKeySegments)
+        {
+            if (trimmed.Contains(tokenLikeSegment, StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+        }
+
+        return trimmed;
+    }
+
+    private static Uri? ParseEndpointUri(string? endpointUri)
+    {
+        if (string.IsNullOrWhiteSpace(endpointUri)
+            || !Uri.TryCreate(endpointUri.Trim(), UriKind.Absolute, out Uri? parsed)
+            || parsed.Scheme != Uri.UriSchemeHttps
+            || string.IsNullOrWhiteSpace(parsed.Host)
+            || !string.IsNullOrWhiteSpace(parsed.UserInfo)
+            || !string.IsNullOrWhiteSpace(parsed.Fragment))
+        {
+            return null;
+        }
+
+        return parsed;
+    }
+
+    private static string? NormalizeHttpMethod(string? httpMethod)
+    {
+        if (string.IsNullOrWhiteSpace(httpMethod))
+        {
+            return DefaultHttpMethod;
+        }
+
+        string normalized = httpMethod.Trim().ToUpperInvariant();
+
+        foreach (string allowedMethod in AllowedHttpMethods)
+        {
+            if (string.Equals(normalized, allowedMethod, StringComparison.Ordinal))
+            {
+                return normalized;
+            }
+        }
+
+        return null;
+    }
+
+    private static string NormalizeEndpointPath(Uri endpointUri)
+    {
+        return endpointUri.AbsolutePath is "" or "/"
+            ? "/"
+            : endpointUri.AbsolutePath;
+    }
+
+    private static string BuildRedactedDisplayUri(Uri endpointUri)
+    {
+        string port = endpointUri.IsDefaultPort
+            ? string.Empty
+            : ":" + endpointUri.Port.ToString(CultureInfo.InvariantCulture);
+        string query = string.IsNullOrEmpty(endpointUri.Query)
+            ? string.Empty
+            : "?" + RedactedQueryMarker;
+
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"{endpointUri.Scheme}://{endpointUri.Host}{port}{NormalizeEndpointPath(endpointUri)}{query}");
+    }
+}

--- a/tests/Unit/App.Desktop.Tests/DesktopDirectSiteUploadTargetTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopDirectSiteUploadTargetTests.cs
@@ -1,0 +1,212 @@
+using App.Desktop.Boundaries;
+using App.Desktop.Composition;
+using App.Desktop.Services.Auth;
+using App.Desktop.Services.GroupTree;
+using App.Desktop.Services.Upload;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace App.Desktop.Tests;
+
+public sealed class DesktopDirectSiteUploadTargetTests
+{
+    [Fact]
+    public void EmptyMetadataKeepsUploadTargetUnavailable()
+    {
+        DesktopDirectSiteUploadTarget target = DesktopDirectSiteUploadTarget.FromMetadata(
+            providerKey: null,
+            endpointUri: null,
+            httpMethod: null,
+            correlationId: null);
+
+        Assert.Same(DesktopDirectSiteUploadTarget.Unavailable, target);
+        Assert.False(target.IsMetadataPresent);
+        Assert.False(target.IsValid);
+        Assert.False(target.EnablesRealUpload);
+        Assert.Equal("<unavailable>", target.RedactedDisplayUri);
+        AssertRedacted(target.ToString());
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("ab")]
+    [InlineData("provider key")]
+    [InlineData("provider/key")]
+    [InlineData("token-provider")]
+    public void UnsafeProviderKeyKeepsUploadTargetUnavailable(string? providerKey)
+    {
+        DesktopDirectSiteUploadTarget target = DesktopDirectSiteUploadTarget.FromMetadata(
+            providerKey,
+            "https://upload.korobochka.local/upload",
+            "POST",
+            correlationId: null);
+
+        Assert.True(target.IsMetadataPresent);
+        Assert.False(target.IsValid);
+        Assert.False(target.EnablesRealUpload);
+        Assert.Equal("<unavailable>", target.RedactedDisplayUri);
+        Assert.Null(target.ProviderKey);
+        AssertRedacted(target.ToString());
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not a uri")]
+    [InlineData("http://upload.korobochka.local/upload")]
+    [InlineData("ftp://upload.korobochka.local/upload")]
+    [InlineData("https://user-info@upload.korobochka.local/upload")]
+    [InlineData("https://upload.korobochka.local/upload#fragment")]
+    public void UnsafeEndpointKeepsUploadTargetUnavailable(string endpointUri)
+    {
+        DesktopDirectSiteUploadTarget target = DesktopDirectSiteUploadTarget.FromMetadata(
+            "korobochka-direct",
+            endpointUri,
+            "POST",
+            correlationId: null);
+
+        Assert.True(target.IsMetadataPresent);
+        Assert.False(target.IsValid);
+        Assert.False(target.EnablesRealUpload);
+        Assert.Equal("<unavailable>", target.RedactedDisplayUri);
+        AssertRedacted(target.ToString());
+    }
+
+    [Theory]
+    [InlineData("GET")]
+    [InlineData("DELETE")]
+    [InlineData("PATCH")]
+    public void UnsupportedMethodKeepsUploadTargetUnavailable(string httpMethod)
+    {
+        DesktopDirectSiteUploadTarget target = DesktopDirectSiteUploadTarget.FromMetadata(
+            "korobochka-direct",
+            "https://upload.korobochka.local/upload",
+            httpMethod,
+            correlationId: null);
+
+        Assert.True(target.IsMetadataPresent);
+        Assert.False(target.IsValid);
+        Assert.False(target.EnablesRealUpload);
+        Assert.Equal("<unavailable>", target.RedactedDisplayUri);
+        AssertRedacted(target.ToString());
+    }
+
+    [Fact]
+    public void InvalidCorrelationIdKeepsUploadTargetUnavailable()
+    {
+        DesktopDirectSiteUploadTarget target = DesktopDirectSiteUploadTarget.FromMetadata(
+            "korobochka-direct",
+            "https://upload.korobochka.local/upload",
+            "POST",
+            "not-a-guid");
+
+        Assert.True(target.IsMetadataPresent);
+        Assert.False(target.IsValid);
+        Assert.False(target.EnablesRealUpload);
+        Assert.False(target.HasCorrelationId);
+        Assert.Equal("<unavailable>", target.RedactedDisplayUri);
+        AssertRedacted(target.DiagnosticText);
+    }
+
+    [Fact]
+    public void SignedQueryIsRedactedFromDisplayAndDiagnostics()
+    {
+        string endpointUri = new UriBuilder("https", "upload.korobochka.local")
+        {
+            Path = "upload/video",
+            Query = "signature=abc&expires=123"
+        }.Uri.ToString();
+
+        DesktopDirectSiteUploadTarget target = DesktopDirectSiteUploadTarget.FromMetadata(
+            "korobochka-direct",
+            endpointUri,
+            "PUT",
+            Guid.NewGuid().ToString("D"));
+
+        Assert.True(target.IsMetadataPresent);
+        Assert.True(target.IsValid);
+        Assert.False(target.EnablesRealUpload);
+        Assert.True(target.HasEndpointQuery);
+        Assert.True(target.HasCorrelationId);
+        Assert.Equal("korobochka-direct", target.ProviderKey);
+        Assert.Equal("https", target.EndpointScheme);
+        Assert.Equal("upload.korobochka.local", target.EndpointHost);
+        Assert.Equal("PUT", target.HttpMethod);
+        Assert.Equal("https://upload.korobochka.local/upload/video?<redacted>", target.RedactedDisplayUri);
+        Assert.DoesNotContain("signature=abc", target.RedactedDisplayUri, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("expires=123", target.DiagnosticText, StringComparison.OrdinalIgnoreCase);
+        AssertRedacted(target.DiagnosticText);
+    }
+
+    [Fact]
+    public void LocalPathLikeEndpointIsNotExposedInDiagnostics()
+    {
+        string localPath = string.Concat("D:", "\\", "capture", "\\", "video.mp4");
+
+        DesktopDirectSiteUploadTarget target = DesktopDirectSiteUploadTarget.FromMetadata(
+            "korobochka-direct",
+            localPath,
+            "POST",
+            correlationId: null);
+
+        Assert.True(target.IsMetadataPresent);
+        Assert.False(target.IsValid);
+        Assert.False(target.EnablesRealUpload);
+        Assert.Equal("<unavailable>", target.RedactedDisplayUri);
+        Assert.DoesNotContain(localPath, target.DiagnosticText, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("video.mp4", target.DiagnosticText, StringComparison.OrdinalIgnoreCase);
+        AssertRedacted(target.DiagnosticText);
+    }
+
+    [Fact]
+    public void ValidTargetCreatesSafeRedactedDisplayOnly()
+    {
+        DesktopDirectSiteUploadTarget target = DesktopDirectSiteUploadTarget.FromMetadata(
+            "korobochka-direct",
+            "https://upload.korobochka.local/upload/video",
+            httpMethod: null,
+            correlationId: null);
+
+        Assert.True(target.IsMetadataPresent);
+        Assert.True(target.IsValid);
+        Assert.False(target.EnablesRealUpload);
+        Assert.Equal("korobochka-direct", target.ProviderKey);
+        Assert.Equal("https", target.EndpointScheme);
+        Assert.Equal("upload.korobochka.local", target.EndpointHost);
+        Assert.Equal("/upload/video", target.EndpointPath);
+        Assert.False(target.HasEndpointQuery);
+        Assert.Equal("POST", target.HttpMethod);
+        Assert.Equal("https://upload.korobochka.local/upload/video", target.RedactedDisplayUri);
+        AssertRedacted(target.ToString());
+    }
+
+    [Fact]
+    public void ValidTargetDoesNotReplaceDisabledDirectSiteUploadClient()
+    {
+        _ = DesktopDirectSiteUploadTarget.FromMetadata(
+            "korobochka-direct",
+            "https://upload.korobochka.local/upload/video",
+            "POST",
+            Guid.NewGuid().ToString("D"));
+
+        using ServiceProvider services = DesktopCompositionRoot.BuildServices(
+            DesktopAuthOptions.FromControlPlaneBaseAddress("https://control-plane.local"),
+            DesktopUploadSectionOptions.Disabled,
+            DesktopGroupTreeOptions.EnabledForLiveControlPlane,
+            DesktopDirectSiteProviderOptions.FromEnvironmentValues(
+                "korobochka-direct",
+                "https://upload.korobochka.local"));
+
+        Assert.IsType<DisabledDesktopDirectSiteUploadClient>(
+            services.GetRequiredService<IDesktopDirectSiteUploadClient>());
+    }
+
+    private static void AssertRedacted(string text)
+    {
+        Assert.DoesNotContain("signature=abc", text, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("expires=123", text, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("D:\\capture", text, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("raw request", text, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("raw response", text, StringComparison.OrdinalIgnoreCase);
+    }
+}


### PR DESCRIPTION
## Related issue / task card

Task card:
docs/task-cards/S2-75_desktop-direct-site-provider-upload-target-task-card.txt

Follow-up from:
- S2-71 PR #140 desktop direct-site provider probe
- S2-72 PR #141 provider boundary design
- S2-73 PR #142 provider config/options boundary
- S2-74 PR #143 request/response contract design

Closes: N/A

## Purpose

Add App.Desktop-only direct-site upload target value objects and redacted diagnostics for a future provider implementation.

This is still not a real upload implementation.

## Validation

- dotnet restore src/App.Desktop/App.Desktop.csproj: PASS
- dotnet restore tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj: PASS
- dotnet format whitespace src/App.Desktop/App.Desktop.csproj --verify-no-changes --no-restore: PASS
- dotnet format whitespace tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj --verify-no-changes --no-restore: PASS
- dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal: PASS
- dotnet build tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal: PASS
- dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal --no-build: PASS, 225 passed
- git diff --check: PASS

## NO-GO / Deferred

- No real direct-site upload implementation.
- No HttpDesktopDirectSiteUploadClient.
- No App.Api endpoint.
- No backend/module code.
- No BuildingBlocks.Contracts changes.
- No video bytes through App.Api.
- No provider credentials or tokens.
- No live Korobochka smoke.

Recent commits:
8adc62d feat(desktop): add direct site upload target redaction boundary
2003a36 docs(desktop): add S2-75 direct site provider upload target task card