### PR TITLE
Feature/s2 76 desktop direct site provider request response models

### DIFF
--- a/docs/task-cards/S2-76_desktop-direct-site-provider-request-response-models-task-card.txt
+++ b/docs/task-cards/S2-76_desktop-direct-site-provider-request-response-models-task-card.txt
@@ -1,0 +1,132 @@
+TASK CARD: S2-76 Desktop Direct Site Provider Request / Response Models
+
+Module:
+App.Desktop / direct-site provider request-response models
+
+Owner:
+Coder 2 / Desktop Client
+
+Client form:
+desktop standalone
+
+Type:
+narrow runtime implementation task after S2-75 upload target / redacted diagnostics
+
+Goal:
+Add App.Desktop-only provider request/response model value objects for a future direct-site provider.
+
+This task must not implement real byte upload.
+
+Background:
+S2-71 found no approved direct-site provider/config/contract.
+S2-72 defined provider boundary requirements.
+S2-73 added provider config/options boundary.
+S2-74 documented request/response contract design.
+S2-75 added upload target value object and redacted diagnostics.
+S2-76 adds local App.Desktop request/response model value objects only.
+
+Allowed changed areas for implementation:
+- src/App.Desktop/**
+- tests/Unit/App.Desktop.Tests/**
+- docs/task-cards/S2-76_desktop-direct-site-provider-request-response-models-task-card.txt
+
+Forbidden changed areas:
+- src/App.Api/**
+- src/Modules/**
+- src/BuildingBlocks/Contracts/**
+- src/App.Web/**
+- src/App.Mobile.Android/**
+- src/App.UI.Shared/**
+- src/App.Worker/**
+- DB migrations
+- .github/workflows/**
+- deploy scripts
+- docs/ops/**
+- committed screenshots or runtime artifacts
+
+Contracts:
+No shared contract change.
+No BuildingBlocks.Contracts DTO.
+No App.Api request/response DTO.
+Models are App.Desktop-local only.
+
+Feature flag / env guard:
+Use only App.Desktop-side config/options boundary from S2-73.
+Do not add credentials, tokens, or signed URL behavior.
+
+Migration:
+No migration.
+
+Events:
+None.
+
+Offline behavior:
+No runtime offline upload behavior change.
+Real provider upload remains unavailable offline unless later explicitly designed.
+
+Security:
+- Do not print or log password.
+- Do not print or log accessToken.
+- Do not print or log refreshToken.
+- Do not print or log Authorization header.
+- Do not print or log provider credential values.
+- Do not print or log signed URL query secrets.
+- Do not print or log raw local file paths.
+- Do not print or log raw request/response bodies.
+- Do not include screenshots or runtime artifacts.
+
+Implementation scope:
+- Add App.Desktop-local request value object(s).
+- Add App.Desktop-local response value object(s).
+- Add safe failure classification value(s) if needed.
+- Add validation for required safe fields.
+- Add redacted diagnostics/display for request and response models.
+- Integrate with DesktopDirectSiteUploadTarget only as a value-object dependency if needed.
+- Keep IDesktopDirectSiteUploadClient disabled/unavailable.
+- Do not implement provider wire HTTP request.
+- Do not add provider client.
+- Do not add shared DTOs.
+- Do not add App.Api endpoint.
+- Do not send real video bytes.
+- Do not change UploadReceipt contract.
+
+Suggested implementation files:
+- src/App.Desktop/Services/Upload/DesktopDirectSiteUploadRequest.cs
+- src/App.Desktop/Services/Upload/DesktopDirectSiteUploadResponse.cs
+- tests/Unit/App.Desktop.Tests/DesktopDirectSiteUploadRequestTests.cs
+- tests/Unit/App.Desktop.Tests/DesktopDirectSiteUploadResponseTests.cs
+
+Definition of done:
+- Request model exists and is testable.
+- Response model exists and is testable.
+- Required fields are validated.
+- Error/retry/failure classification is local to App.Desktop if added.
+- ToString / display text does not expose secrets, signed URL query, raw local paths, raw request bodies, or raw response bodies.
+- Valid request/response models do not enable real upload.
+- IDesktopDirectSiteUploadClient remains disabled/unavailable.
+- No App.Api/backend/contracts files are changed.
+- Targeted App.Desktop build/test/format passes.
+
+Validation:
+- dotnet restore src/App.Desktop/App.Desktop.csproj
+- dotnet restore tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj
+- dotnet format whitespace src/App.Desktop/App.Desktop.csproj --verify-no-changes --no-restore
+- dotnet format whitespace tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj --verify-no-changes --no-restore
+- dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal
+- dotnet build tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal
+- dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal --no-build
+- git diff --check
+
+Rollback:
+Revert S2-76 PR.
+
+NO-GO:
+- Do not implement real HTTP upload.
+- Do not add HttpDesktopDirectSiteUploadClient.
+- Do not add shared DTOs.
+- Do not add BuildingBlocks.Contracts types.
+- Do not add App.Api endpoint.
+- Do not add backend/module code.
+- Do not send video bytes through App.Api.
+- Do not add provider credentials or tokens.
+- Do not run live Korobochka smoke for this task.

--- a/src/App.Desktop/Services/Upload/DesktopDirectSiteUploadRequest.cs
+++ b/src/App.Desktop/Services/Upload/DesktopDirectSiteUploadRequest.cs
@@ -1,0 +1,277 @@
+using System.Globalization;
+using System.IO;
+
+namespace App.Desktop.Services.Upload;
+
+public sealed class DesktopDirectSiteUploadRequest
+{
+    private const int MaxBusinessObjectKeyLength = 128;
+    private const int MaxContentTypeLength = 100;
+    private const int MaxDisplayFileNameLength = 255;
+    private const int MaxIdempotencyKeyLength = 128;
+    private const string InvalidDisplay = "<invalid>";
+
+    private static readonly string[] SensitiveFragments =
+    [
+        "authorization",
+        "bearer",
+        "credential",
+        "password",
+        "refresh",
+        "secret",
+        "token"
+    ];
+
+    private DesktopDirectSiteUploadRequest(
+        bool isValid,
+        Guid? preUploadCheckId,
+        string? businessObjectKey,
+        long sizeBytes,
+        string? byteSha256,
+        string? contentType,
+        string? idempotencyKey,
+        Guid? correlationId,
+        string? displayFileName,
+        DesktopDirectSiteUploadTarget uploadTarget)
+    {
+        IsValid = isValid;
+        PreUploadCheckId = preUploadCheckId;
+        BusinessObjectKey = businessObjectKey;
+        SizeBytes = sizeBytes;
+        ByteSha256 = byteSha256;
+        ContentType = contentType;
+        IdempotencyKey = idempotencyKey;
+        CorrelationId = correlationId;
+        DisplayFileName = displayFileName;
+        UploadTarget = uploadTarget;
+    }
+
+    public bool IsValid { get; }
+
+    public bool EnablesRealUpload { get; }
+
+    public Guid? PreUploadCheckId { get; }
+
+    public string? BusinessObjectKey { get; }
+
+    public long SizeBytes { get; }
+
+    public string? ByteSha256 { get; }
+
+    public string? ContentType { get; }
+
+    public string? IdempotencyKey { get; }
+
+    public Guid? CorrelationId { get; }
+
+    public string? DisplayFileName { get; }
+
+    public string? ProviderKey => UploadTarget.ProviderKey;
+
+    public DesktopDirectSiteUploadTarget UploadTarget { get; }
+
+    public string RedactedUploadTarget => UploadTarget.RedactedDisplayUri;
+
+    public string DiagnosticText => ToString();
+
+    public static DesktopDirectSiteUploadRequest Invalid { get; } = new(
+        isValid: false,
+        preUploadCheckId: null,
+        businessObjectKey: null,
+        sizeBytes: 0,
+        byteSha256: null,
+        contentType: null,
+        idempotencyKey: null,
+        correlationId: null,
+        displayFileName: null,
+        DesktopDirectSiteUploadTarget.Unavailable);
+
+    public static DesktopDirectSiteUploadRequest FromMetadata(
+        DesktopDirectSiteUploadTarget? uploadTarget,
+        string? preUploadCheckId,
+        string? businessObjectKey,
+        long sizeBytes,
+        string? byteSha256,
+        string? contentType,
+        string? idempotencyKey,
+        string? correlationId,
+        string? displayFileName)
+    {
+        if (uploadTarget is null || !uploadTarget.IsValid)
+        {
+            return Invalid;
+        }
+
+        Guid? normalizedPreUploadCheckId = NormalizeGuid(preUploadCheckId);
+        string? normalizedBusinessObjectKey = NormalizeBusinessObjectKey(businessObjectKey);
+        string? normalizedSha256 = NormalizeSha256(byteSha256);
+        string? normalizedContentType = NormalizeContentType(contentType);
+        string? normalizedIdempotencyKey = NormalizeSafeToken(idempotencyKey, MaxIdempotencyKeyLength);
+        Guid? normalizedCorrelationId = NormalizeGuid(correlationId);
+        string? normalizedDisplayFileName = NormalizeDisplayFileName(displayFileName);
+
+        if (normalizedPreUploadCheckId is null
+            || normalizedBusinessObjectKey is null
+            || sizeBytes <= 0
+            || normalizedSha256 is null
+            || normalizedContentType is null
+            || normalizedIdempotencyKey is null
+            || normalizedCorrelationId is null
+            || normalizedDisplayFileName is null)
+        {
+            return Invalid;
+        }
+
+        return new DesktopDirectSiteUploadRequest(
+            isValid: true,
+            normalizedPreUploadCheckId,
+            normalizedBusinessObjectKey,
+            sizeBytes,
+            normalizedSha256,
+            normalizedContentType,
+            normalizedIdempotencyKey,
+            normalizedCorrelationId,
+            normalizedDisplayFileName,
+            uploadTarget);
+    }
+
+    public override string ToString()
+    {
+        return $"{nameof(DesktopDirectSiteUploadRequest)} {{ "
+            + $"IsValid = {IsValid}, "
+            + $"EnablesRealUpload = {EnablesRealUpload}, "
+            + $"ProviderKey = {ProviderKey ?? "<none>"}, "
+            + $"UploadTarget = {RedactedUploadTarget}, "
+            + $"HasPreUploadCheckId = {PreUploadCheckId.HasValue}, "
+            + $"BusinessObjectKey = {BusinessObjectKey ?? InvalidDisplay}, "
+            + $"SizeBytes = {SizeBytes.ToString(CultureInfo.InvariantCulture)}, "
+            + $"HasSha256 = {ByteSha256?.Length == 64}, "
+            + $"ContentType = {ContentType ?? InvalidDisplay}, "
+            + $"HasIdempotencyKey = {!string.IsNullOrWhiteSpace(IdempotencyKey)}, "
+            + $"HasCorrelationId = {CorrelationId.HasValue}, "
+            + $"DisplayFileName = {DisplayFileName ?? InvalidDisplay} }}";
+    }
+
+    private static Guid? NormalizeGuid(string? value)
+    {
+        return Guid.TryParse(value?.Trim(), out Guid parsed)
+            ? parsed
+            : null;
+    }
+
+    private static string? NormalizeBusinessObjectKey(string? value)
+    {
+        string? normalized = NormalizeSafeSingleLine(value, MaxBusinessObjectKeyLength, allowSlash: false);
+        return normalized is null || ContainsSensitiveFragment(normalized)
+            ? null
+            : normalized;
+    }
+
+    private static string? NormalizeContentType(string? value)
+    {
+        string? normalized = NormalizeSafeSingleLine(value, MaxContentTypeLength, allowSlash: true);
+        if (normalized is null
+            || ContainsSensitiveFragment(normalized)
+            || normalized.StartsWith('/')
+            || normalized.EndsWith('/')
+            || !normalized.Contains('/', StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        return normalized;
+    }
+
+    private static string? NormalizeDisplayFileName(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        string fileName = Path.GetFileName(value.Trim());
+        string? normalized = NormalizeSafeSingleLine(fileName, MaxDisplayFileNameLength, allowSlash: false);
+        return normalized is null || ContainsSensitiveFragment(normalized)
+            ? null
+            : normalized;
+    }
+
+    private static string? NormalizeSha256(string? value)
+    {
+        if (value is null || value.Length != 64)
+        {
+            return null;
+        }
+
+        foreach (char character in value)
+        {
+            bool isDigit = character is >= '0' and <= '9';
+            bool isLowerHex = character is >= 'a' and <= 'f';
+            if (!isDigit && !isLowerHex)
+            {
+                return null;
+            }
+        }
+
+        return value;
+    }
+
+    private static string? NormalizeSafeToken(string? value, int maxLength)
+    {
+        string? normalized = NormalizeSafeSingleLine(value, maxLength, allowSlash: false);
+        if (normalized is null || ContainsSensitiveFragment(normalized))
+        {
+            return null;
+        }
+
+        foreach (char character in normalized)
+        {
+            if (!char.IsLetterOrDigit(character)
+                && character is not '-' and not '_' and not '.' and not ':')
+            {
+                return null;
+            }
+        }
+
+        return normalized;
+    }
+
+    private static string? NormalizeSafeSingleLine(string? value, int maxLength, bool allowSlash)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        string trimmed = value.Trim();
+        if (trimmed.Length > maxLength)
+        {
+            return null;
+        }
+
+        foreach (char character in trimmed)
+        {
+            if (char.IsControl(character)
+                || character is '\\'
+                || (!allowSlash && character is '/'))
+            {
+                return null;
+            }
+        }
+
+        return trimmed;
+    }
+
+    private static bool ContainsSensitiveFragment(string value)
+    {
+        foreach (string sensitiveFragment in SensitiveFragments)
+        {
+            if (value.Contains(sensitiveFragment, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/App.Desktop/Services/Upload/DesktopDirectSiteUploadResponse.cs
+++ b/src/App.Desktop/Services/Upload/DesktopDirectSiteUploadResponse.cs
@@ -1,0 +1,328 @@
+using System.Globalization;
+
+namespace App.Desktop.Services.Upload;
+
+public sealed class DesktopDirectSiteUploadResponse
+{
+    private const int MaxSafeIdentifierLength = 128;
+    private const string RedactedFailureMessage = "<redacted>";
+
+    private static readonly string[] SensitiveFragments =
+    [
+        "authorization",
+        "bearer",
+        "credential",
+        "password",
+        "refresh",
+        "secret",
+        "token"
+    ];
+
+    private DesktopDirectSiteUploadResponse(
+        bool isValid,
+        DesktopDirectSiteUploadResponseStatus status,
+        string? providerKey,
+        string? providerUploadId,
+        string? externalVideoId,
+        string? storageKey,
+        DateTimeOffset? uploadedAtUtc,
+        long? sizeBytes,
+        string? byteSha256,
+        Guid? correlationId,
+        bool retryable,
+        DesktopDirectSiteUploadFailureKind failureKind,
+        string? failureMessageRedacted)
+    {
+        IsValid = isValid;
+        Status = status;
+        ProviderKey = providerKey;
+        ProviderUploadId = providerUploadId;
+        ExternalVideoId = externalVideoId;
+        StorageKey = storageKey;
+        UploadedAtUtc = uploadedAtUtc;
+        SizeBytes = sizeBytes;
+        ByteSha256 = byteSha256;
+        CorrelationId = correlationId;
+        Retryable = retryable;
+        FailureKind = failureKind;
+        FailureMessageRedacted = failureMessageRedacted;
+    }
+
+    public bool IsValid { get; }
+
+    public bool EnablesRealUpload { get; }
+
+    public bool IsSuccess => IsValid
+        && Status is DesktopDirectSiteUploadResponseStatus.Accepted
+            or DesktopDirectSiteUploadResponseStatus.Completed
+            or DesktopDirectSiteUploadResponseStatus.DuplicateSuspected;
+
+    public DesktopDirectSiteUploadResponseStatus Status { get; }
+
+    public string? ProviderKey { get; }
+
+    public string? ProviderUploadId { get; }
+
+    public string? ExternalVideoId { get; }
+
+    public string? StorageKey { get; }
+
+    public DateTimeOffset? UploadedAtUtc { get; }
+
+    public long? SizeBytes { get; }
+
+    public string? ByteSha256 { get; }
+
+    public Guid? CorrelationId { get; }
+
+    public bool Retryable { get; }
+
+    public DesktopDirectSiteUploadFailureKind FailureKind { get; }
+
+    public string? FailureMessageRedacted { get; }
+
+    public string DiagnosticText => ToString();
+
+    public static DesktopDirectSiteUploadResponse Invalid { get; } = new(
+        isValid: false,
+        DesktopDirectSiteUploadResponseStatus.Unknown,
+        providerKey: null,
+        providerUploadId: null,
+        externalVideoId: null,
+        storageKey: null,
+        uploadedAtUtc: null,
+        sizeBytes: null,
+        byteSha256: null,
+        correlationId: null,
+        retryable: false,
+        DesktopDirectSiteUploadFailureKind.Unknown,
+        failureMessageRedacted: null);
+
+    public static DesktopDirectSiteUploadResponse FromSuccess(
+        string? providerKey,
+        string? providerUploadId,
+        string? externalVideoId,
+        string? storageKey,
+        DesktopDirectSiteUploadResponseStatus status,
+        DateTimeOffset uploadedAtUtc,
+        long sizeBytes,
+        string? byteSha256,
+        string? correlationId)
+    {
+        string? normalizedProviderKey = NormalizeSafeIdentifier(providerKey, allowSlash: false);
+        string? normalizedProviderUploadId = NormalizeSafeIdentifier(providerUploadId, allowSlash: false);
+        string? normalizedExternalVideoId = NormalizeSafeIdentifier(externalVideoId, allowSlash: false);
+        string? normalizedStorageKey = NormalizeSafeIdentifier(storageKey, allowSlash: true);
+        string? normalizedSha256 = NormalizeSha256(byteSha256);
+        Guid? normalizedCorrelationId = NormalizeGuid(correlationId);
+
+        if (normalizedProviderKey is null
+            || normalizedProviderUploadId is null
+            || normalizedExternalVideoId is null
+            || normalizedStorageKey is null
+            || normalizedSha256 is null
+            || normalizedCorrelationId is null
+            || sizeBytes <= 0
+            || status is not (DesktopDirectSiteUploadResponseStatus.Accepted
+                or DesktopDirectSiteUploadResponseStatus.Completed
+                or DesktopDirectSiteUploadResponseStatus.DuplicateSuspected))
+        {
+            return Invalid;
+        }
+
+        return new DesktopDirectSiteUploadResponse(
+            isValid: true,
+            status,
+            normalizedProviderKey,
+            normalizedProviderUploadId,
+            normalizedExternalVideoId,
+            normalizedStorageKey,
+            uploadedAtUtc,
+            sizeBytes,
+            normalizedSha256,
+            normalizedCorrelationId,
+            retryable: false,
+            DesktopDirectSiteUploadFailureKind.None,
+            failureMessageRedacted: null);
+    }
+
+    public static DesktopDirectSiteUploadResponse FromFailure(
+        string? providerKey,
+        DesktopDirectSiteUploadResponseStatus status,
+        bool retryable,
+        DesktopDirectSiteUploadFailureKind failureKind,
+        string? failureMessage,
+        string? correlationId)
+    {
+        string? normalizedProviderKey = NormalizeSafeIdentifier(providerKey, allowSlash: false);
+        Guid? normalizedCorrelationId = NormalizeGuid(correlationId);
+
+        if (normalizedProviderKey is null
+            || normalizedCorrelationId is null
+            || failureKind is DesktopDirectSiteUploadFailureKind.None
+            || status is not (DesktopDirectSiteUploadResponseStatus.Rejected
+                or DesktopDirectSiteUploadResponseStatus.FailedRetryable
+                or DesktopDirectSiteUploadResponseStatus.FailedTerminal
+                or DesktopDirectSiteUploadResponseStatus.Unknown))
+        {
+            return Invalid;
+        }
+
+        return new DesktopDirectSiteUploadResponse(
+            isValid: true,
+            status,
+            normalizedProviderKey,
+            providerUploadId: null,
+            externalVideoId: null,
+            storageKey: null,
+            uploadedAtUtc: null,
+            sizeBytes: null,
+            byteSha256: null,
+            normalizedCorrelationId,
+            retryable,
+            failureKind,
+            RedactFailureMessage(failureMessage));
+    }
+
+    public override string ToString()
+    {
+        return $"{nameof(DesktopDirectSiteUploadResponse)} {{ "
+            + $"IsValid = {IsValid}, "
+            + $"EnablesRealUpload = {EnablesRealUpload}, "
+            + $"Status = {Status}, "
+            + $"ProviderKey = {ProviderKey ?? "<none>"}, "
+            + $"HasProviderUploadId = {!string.IsNullOrWhiteSpace(ProviderUploadId)}, "
+            + $"HasExternalVideoId = {!string.IsNullOrWhiteSpace(ExternalVideoId)}, "
+            + $"HasStorageKey = {!string.IsNullOrWhiteSpace(StorageKey)}, "
+            + $"UploadedAtUtc = {FormatUploadedAtUtc()}, "
+            + $"SizeBytes = {FormatSizeBytes()}, "
+            + $"HasSha256 = {ByteSha256?.Length == 64}, "
+            + $"HasCorrelationId = {CorrelationId.HasValue}, "
+            + $"Retryable = {Retryable}, "
+            + $"FailureKind = {FailureKind}, "
+            + $"FailureMessage = {FailureMessageRedacted ?? "<none>"} }}";
+    }
+
+    private static string? RedactFailureMessage(string? failureMessage)
+    {
+        return string.IsNullOrWhiteSpace(failureMessage)
+            ? null
+            : RedactedFailureMessage;
+    }
+
+    private string FormatUploadedAtUtc()
+    {
+        return UploadedAtUtc?.ToUniversalTime().ToString("O", CultureInfo.InvariantCulture) ?? "<none>";
+    }
+
+    private string FormatSizeBytes()
+    {
+        return SizeBytes?.ToString(CultureInfo.InvariantCulture) ?? "<none>";
+    }
+
+    private static Guid? NormalizeGuid(string? value)
+    {
+        return Guid.TryParse(value?.Trim(), out Guid parsed)
+            ? parsed
+            : null;
+    }
+
+    private static string? NormalizeSafeIdentifier(string? value, bool allowSlash)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        string trimmed = value.Trim();
+        if (trimmed.Length > MaxSafeIdentifierLength
+            || ContainsSensitiveFragment(trimmed)
+            || LooksLikeUri(trimmed)
+            || LooksLikeLocalPath(trimmed))
+        {
+            return null;
+        }
+
+        foreach (char character in trimmed)
+        {
+            if (char.IsControl(character)
+                || character is '\\'
+                || (!allowSlash && character is '/'))
+            {
+                return null;
+            }
+        }
+
+        return trimmed;
+    }
+
+    private static bool LooksLikeUri(string value)
+    {
+        return value.Contains("://", StringComparison.Ordinal)
+            || value.Contains('?', StringComparison.Ordinal)
+            || value.Contains('#', StringComparison.Ordinal);
+    }
+
+    private static bool LooksLikeLocalPath(string value)
+    {
+        return value.Length > 2 && char.IsLetter(value[0]) && value[1] == ':';
+    }
+
+    private static string? NormalizeSha256(string? value)
+    {
+        if (value is null || value.Length != 64)
+        {
+            return null;
+        }
+
+        foreach (char character in value)
+        {
+            bool isDigit = character is >= '0' and <= '9';
+            bool isLowerHex = character is >= 'a' and <= 'f';
+            if (!isDigit && !isLowerHex)
+            {
+                return null;
+            }
+        }
+
+        return value;
+    }
+
+    private static bool ContainsSensitiveFragment(string value)
+    {
+        foreach (string sensitiveFragment in SensitiveFragments)
+        {
+            if (value.Contains(sensitiveFragment, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}
+
+public enum DesktopDirectSiteUploadResponseStatus
+{
+    Accepted,
+    Completed,
+    Rejected,
+    DuplicateSuspected,
+    FailedRetryable,
+    FailedTerminal,
+    Unknown
+}
+
+public enum DesktopDirectSiteUploadFailureKind
+{
+    None,
+    NetworkRetryable,
+    ProviderTemporary,
+    Validation,
+    Unauthorized,
+    ProviderUnavailable,
+    ChecksumMismatch,
+    SizeMismatch,
+    UnsupportedMediaType,
+    Unknown
+}

--- a/tests/Unit/App.Desktop.Tests/DesktopDirectSiteUploadRequestTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopDirectSiteUploadRequestTests.cs
@@ -1,0 +1,159 @@
+using App.Desktop.Boundaries;
+using App.Desktop.Composition;
+using App.Desktop.Services.Auth;
+using App.Desktop.Services.GroupTree;
+using App.Desktop.Services.Upload;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace App.Desktop.Tests;
+
+public sealed class DesktopDirectSiteUploadRequestTests
+{
+    [Fact]
+    public void MissingRequiredFieldsKeepRequestInvalid()
+    {
+        DesktopDirectSiteUploadRequest request = DesktopDirectSiteUploadRequest.FromMetadata(
+            CreateTarget(),
+            preUploadCheckId: null,
+            businessObjectKey: "",
+            sizeBytes: 0,
+            byteSha256: "",
+            contentType: "",
+            idempotencyKey: "",
+            correlationId: "",
+            displayFileName: "");
+
+        Assert.False(request.IsValid);
+        Assert.False(request.EnablesRealUpload);
+        Assert.Null(request.ProviderKey);
+        AssertSafe(request.DiagnosticText);
+    }
+
+    [Fact]
+    public void UnsafeProviderTargetKeepsRequestInvalid()
+    {
+        DesktopDirectSiteUploadTarget target = DesktopDirectSiteUploadTarget.FromMetadata(
+            "token-provider",
+            "https://upload.korobochka.local/upload",
+            "POST",
+            correlationId: null);
+
+        DesktopDirectSiteUploadRequest request = CreateRequest(target);
+
+        Assert.False(request.IsValid);
+        Assert.False(request.EnablesRealUpload);
+        Assert.Same(DesktopDirectSiteUploadTarget.Unavailable, request.UploadTarget);
+        AssertSafe(request.ToString());
+    }
+
+    [Fact]
+    public void LocalPathInputIsReducedToDisplayFileNameAndDiagnosticsAreSafe()
+    {
+        string localPath = string.Concat("D:", "\\", "capture", "\\", "clip.mp4");
+
+        DesktopDirectSiteUploadRequest request = DesktopDirectSiteUploadRequest.FromMetadata(
+            CreateTarget(),
+            Guid.NewGuid().ToString("D"),
+            "business-object-001",
+            1024,
+            Sha256,
+            "video/mp4",
+            "idem-001",
+            Guid.NewGuid().ToString("D"),
+            localPath);
+
+        Assert.True(request.IsValid);
+        Assert.Equal("clip.mp4", request.DisplayFileName);
+        Assert.DoesNotContain(localPath, request.DiagnosticText, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("D:\\capture", request.DiagnosticText, StringComparison.OrdinalIgnoreCase);
+        AssertSafe(request.DiagnosticText);
+    }
+
+    [Fact]
+    public void SignedTargetQueryIsRedactedFromRequestDiagnostics()
+    {
+        string endpointUri = new UriBuilder("https", "upload.korobochka.local")
+        {
+            Path = "upload/video",
+            Query = "query=redacted-test-value"
+        }.Uri.ToString();
+
+        DesktopDirectSiteUploadTarget target = DesktopDirectSiteUploadTarget.FromMetadata(
+            "korobochka-direct",
+            endpointUri,
+            "PUT",
+            Guid.NewGuid().ToString("D"));
+
+        DesktopDirectSiteUploadRequest request = CreateRequest(target);
+
+        Assert.True(request.IsValid);
+        Assert.Contains("?<redacted>", request.RedactedUploadTarget, StringComparison.Ordinal);
+        Assert.DoesNotContain("redacted-test-value", request.DiagnosticText, StringComparison.OrdinalIgnoreCase);
+        AssertSafe(request.ToString());
+    }
+
+    [Fact]
+    public void ValidRequestIsLocalValueObjectOnly()
+    {
+        DesktopDirectSiteUploadRequest request = CreateRequest(CreateTarget());
+
+        Assert.True(request.IsValid);
+        Assert.False(request.EnablesRealUpload);
+        Assert.Equal("korobochka-direct", request.ProviderKey);
+        Assert.Equal("video.mp4", request.DisplayFileName);
+        Assert.Equal("video/mp4", request.ContentType);
+        Assert.Equal(Sha256, request.ByteSha256);
+        AssertSafe(request.DiagnosticText);
+    }
+
+    [Fact]
+    public void ValidRequestDoesNotReplaceDisabledDirectSiteUploadClient()
+    {
+        _ = CreateRequest(CreateTarget());
+
+        using ServiceProvider services = DesktopCompositionRoot.BuildServices(
+            DesktopAuthOptions.FromControlPlaneBaseAddress("https://control-plane.local"),
+            DesktopUploadSectionOptions.Disabled,
+            DesktopGroupTreeOptions.EnabledForLiveControlPlane,
+            DesktopDirectSiteProviderOptions.FromEnvironmentValues(
+                "korobochka-direct",
+                "https://upload.korobochka.local"));
+
+        Assert.IsType<DisabledDesktopDirectSiteUploadClient>(
+            services.GetRequiredService<IDesktopDirectSiteUploadClient>());
+    }
+
+    private const string Sha256 = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    private static DesktopDirectSiteUploadTarget CreateTarget()
+    {
+        return DesktopDirectSiteUploadTarget.FromMetadata(
+            "korobochka-direct",
+            "https://upload.korobochka.local/upload/video",
+            "POST",
+            Guid.NewGuid().ToString("D"));
+    }
+
+    private static DesktopDirectSiteUploadRequest CreateRequest(DesktopDirectSiteUploadTarget target)
+    {
+        return DesktopDirectSiteUploadRequest.FromMetadata(
+            target,
+            Guid.NewGuid().ToString("D"),
+            "business-object-001",
+            1024,
+            Sha256,
+            "video/mp4",
+            "idem-001",
+            Guid.NewGuid().ToString("D"),
+            "video.mp4");
+    }
+
+    private static void AssertSafe(string text)
+    {
+        Assert.DoesNotContain("redacted-test-value", text, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("D:\\capture", text, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("raw request", text, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("raw response", text, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/tests/Unit/App.Desktop.Tests/DesktopDirectSiteUploadResponseTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DesktopDirectSiteUploadResponseTests.cs
@@ -1,0 +1,145 @@
+using App.Desktop.Services.Upload;
+
+namespace App.Desktop.Tests;
+
+public sealed class DesktopDirectSiteUploadResponseTests
+{
+    [Fact]
+    public void SuccessCreatesSafeRedactedDiagnostics()
+    {
+        DateTimeOffset uploadedAtUtc = new(2026, 5, 11, 10, 0, 0, TimeSpan.Zero);
+
+        DesktopDirectSiteUploadResponse response = DesktopDirectSiteUploadResponse.FromSuccess(
+            "korobochka-direct",
+            "provider-upload-001",
+            "external-video-001",
+            "site/video-001",
+            DesktopDirectSiteUploadResponseStatus.Completed,
+            uploadedAtUtc,
+            2048,
+            Sha256,
+            Guid.NewGuid().ToString("D"));
+
+        Assert.True(response.IsValid);
+        Assert.True(response.IsSuccess);
+        Assert.False(response.EnablesRealUpload);
+        Assert.False(response.Retryable);
+        Assert.Equal(DesktopDirectSiteUploadFailureKind.None, response.FailureKind);
+        AssertSafe(response.DiagnosticText);
+    }
+
+    [Fact]
+    public void FailureClassificationIsLocalAndSafe()
+    {
+        DesktopDirectSiteUploadResponse response = DesktopDirectSiteUploadResponse.FromFailure(
+            "korobochka-direct",
+            DesktopDirectSiteUploadResponseStatus.FailedRetryable,
+            retryable: true,
+            DesktopDirectSiteUploadFailureKind.ProviderTemporary,
+            "temporary provider failure with raw response body",
+            Guid.NewGuid().ToString("D"));
+
+        Assert.True(response.IsValid);
+        Assert.False(response.IsSuccess);
+        Assert.False(response.EnablesRealUpload);
+        Assert.True(response.Retryable);
+        Assert.Equal(DesktopDirectSiteUploadFailureKind.ProviderTemporary, response.FailureKind);
+        Assert.Equal("<redacted>", response.FailureMessageRedacted);
+        Assert.DoesNotContain("temporary provider failure", response.DiagnosticText, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("raw response body", response.DiagnosticText, StringComparison.OrdinalIgnoreCase);
+        AssertSafe(response.ToString());
+    }
+
+    [Fact]
+    public void UnsafeProviderKeyOrMetadataKeepsResponseInvalid()
+    {
+        DesktopDirectSiteUploadResponse response = DesktopDirectSiteUploadResponse.FromSuccess(
+            "token-provider",
+            "provider-upload-001",
+            "external-video-001",
+            "site/video-001",
+            DesktopDirectSiteUploadResponseStatus.Completed,
+            DateTimeOffset.UtcNow,
+            2048,
+            Sha256,
+            Guid.NewGuid().ToString("D"));
+
+        Assert.False(response.IsValid);
+        Assert.False(response.EnablesRealUpload);
+        Assert.Null(response.ProviderKey);
+        AssertSafe(response.DiagnosticText);
+    }
+
+    [Fact]
+    public void SignedUriLikeValuesAreNotExposedByResponse()
+    {
+        string providerUploadId = new UriBuilder("https", "upload.korobochka.local")
+        {
+            Path = "receipt",
+            Query = "query=redacted-test-value"
+        }.Uri.ToString();
+
+        DesktopDirectSiteUploadResponse response = DesktopDirectSiteUploadResponse.FromSuccess(
+            "korobochka-direct",
+            providerUploadId,
+            "external-video-001",
+            "site/video-001",
+            DesktopDirectSiteUploadResponseStatus.Completed,
+            DateTimeOffset.UtcNow,
+            2048,
+            Sha256,
+            Guid.NewGuid().ToString("D"));
+
+        Assert.False(response.IsValid);
+        Assert.False(response.EnablesRealUpload);
+        Assert.DoesNotContain("redacted-test-value", response.DiagnosticText, StringComparison.OrdinalIgnoreCase);
+        AssertSafe(response.ToString());
+    }
+
+    [Fact]
+    public void RawBodyInputIsNotStoredOrDisplayed()
+    {
+        DesktopDirectSiteUploadResponse response = DesktopDirectSiteUploadResponse.FromFailure(
+            "korobochka-direct",
+            DesktopDirectSiteUploadResponseStatus.FailedTerminal,
+            retryable: false,
+            DesktopDirectSiteUploadFailureKind.Unknown,
+            "raw response body should not be visible",
+            Guid.NewGuid().ToString("D"));
+
+        Assert.True(response.IsValid);
+        Assert.False(response.EnablesRealUpload);
+        Assert.Equal("<redacted>", response.FailureMessageRedacted);
+        Assert.DoesNotContain("raw response body", response.DiagnosticText, StringComparison.OrdinalIgnoreCase);
+        AssertSafe(response.DiagnosticText);
+    }
+
+    [Fact]
+    public void ResponseToStringIsSafe()
+    {
+        DesktopDirectSiteUploadResponse response = DesktopDirectSiteUploadResponse.FromFailure(
+            "korobochka-direct",
+            DesktopDirectSiteUploadResponseStatus.Rejected,
+            retryable: false,
+            DesktopDirectSiteUploadFailureKind.Validation,
+            "validation detail that must stay redacted",
+            Guid.NewGuid().ToString("D"));
+
+        string text = response.ToString();
+
+        Assert.True(response.IsValid);
+        Assert.Contains("FailureMessage = <redacted>", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("validation detail", text, StringComparison.OrdinalIgnoreCase);
+        AssertSafe(text);
+    }
+
+    private const string Sha256 = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    private static void AssertSafe(string text)
+    {
+        Assert.DoesNotContain("redacted-test-value", text, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("D:\\capture", text, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("raw request", text, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("raw response body", text, StringComparison.OrdinalIgnoreCase);
+    }
+}


### PR DESCRIPTION
## Related issue / task card

Task card:
docs/task-cards/S2-76_desktop-direct-site-provider-request-response-models-task-card.txt

Follow-up from:
- S2-71 PR #140 desktop direct-site provider probe
- S2-72 PR #141 provider boundary design
- S2-73 PR #142 provider config/options boundary
- S2-74 PR #143 request/response contract design
- S2-75 PR #144 upload target / redacted diagnostics boundary

Closes: N/A

## Purpose

Add App.Desktop-local direct-site provider request/response model value objects for a future provider implementation.

This is still not a real upload implementation.

## Coder

Coder 2 / Desktop Client

## Task ID

S2-76

## Module

- [ ] repo/process
- [ ] backend/platform
- [ ] infra/deploy
- [ ] shared contracts
- [ ] web
- [ ] mobile
- [ ] docs
- [x] desktop

## Scope

App.Desktop-local request/response model value objects only.

Implemented:
- App.Desktop-local direct-site upload request model
- App.Desktop-local direct-site upload response model
- local failure/status classification
- redacted diagnostics/display text
- tests for validation and redaction behavior

Explicitly not implemented:
- no real HTTP upload
- no HttpDesktopDirectSiteUploadClient
- no provider wire HTTP request
- no provider client
- no shared DTO / BuildingBlocks.Contracts model
- no App.Api endpoint
- no video bytes sent anywhere
- no UploadReceipt contract change

## Changed areas

- docs/task-cards/S2-76_desktop-direct-site-provider-request-response-models-task-card.txt
- src/App.Desktop/Services/Upload/DesktopDirectSiteUploadRequest.cs
- src/App.Desktop/Services/Upload/DesktopDirectSiteUploadResponse.cs
- tests/Unit/App.Desktop.Tests/DesktopDirectSiteUploadRequestTests.cs
- tests/Unit/App.Desktop.Tests/DesktopDirectSiteUploadResponseTests.cs

No App.Api, App.Worker, App.Web, App.Mobile.Android, App.UI.Shared, Modules, BuildingBlocks.Contracts, workflow, infra, deploy, or migration changes.

## Contracts

- [x] no contract change
- [ ] shared DTO changed
- [ ] API request/response changed
- [ ] internal event changed

Details:

No BuildingBlocks.Contracts or API contract changes. S2-76 models are App.Desktop-local only.

## Validation

- dotnet restore src/App.Desktop/App.Desktop.csproj: PASS
- dotnet restore tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj: PASS
- dotnet format whitespace src/App.Desktop/App.Desktop.csproj --verify-no-changes --no-restore: PASS
- dotnet format whitespace tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj --verify-no-changes --no-restore: PASS
- dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal: PASS
- dotnet build tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal: PASS
- dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal --no-build: PASS, 237 passed
- git diff --check: PASS

## NO-GO / Deferred

- No real direct-site upload implementation.
- No HttpDesktopDirectSiteUploadClient.
- No App.Api endpoint.
- No backend/module code.
- No BuildingBlocks.Contracts changes.
- No video bytes through App.Api.
- No provider credentials or tokens.
- No live Korobochka smoke.

## Security notes

Diagnostics are redacted. No password/accessToken/refreshToken/Authorization/provider credential/signed URL secret values are added.

The request/response models must not expose provider credentials, signed URL secrets, raw local paths, raw request bodies, or raw response bodies.

## Notes for reviewers

Review focus: models remain App.Desktop-local; diagnostics are redacted; real upload remains disabled/deferred; no App.Api/backend/contracts changes.

Recent commits:
ad3c504 feat(desktop): add direct site provider request response models
59f3c7e docs(desktop): add S2-76 direct site provider request response models task card
