### PR TITLE
Feature/s2 77 desktop direct site provider client boundary

### DIFF
--- a/docs/task-cards/S2-77_desktop-direct-site-provider-client-boundary-task-card.txt
+++ b/docs/task-cards/S2-77_desktop-direct-site-provider-client-boundary-task-card.txt
@@ -1,0 +1,138 @@
+TASK CARD: S2-77 Desktop Direct Site Provider Client Boundary
+
+Module:
+App.Desktop / direct-site provider client boundary
+
+Owner:
+Coder 2 / Desktop Client
+
+Client form:
+desktop standalone
+
+Type:
+narrow runtime implementation task after S2-76 request/response models
+
+Goal:
+Add an App.Desktop-local provider client boundary and disabled/no-live implementation for future direct-site provider integration.
+
+This task must not implement real byte upload.
+
+Background:
+S2-71 found no approved direct-site provider/config/contract.
+S2-72 defined provider boundary requirements.
+S2-73 added provider config/options boundary.
+S2-74 documented request/response contract design.
+S2-75 added upload target value object and redacted diagnostics.
+S2-76 added App.Desktop-local request/response models.
+S2-77 adds a client boundary only, keeping real provider transport disabled.
+
+Allowed changed areas for implementation:
+- src/App.Desktop/**
+- tests/Unit/App.Desktop.Tests/**
+- docs/task-cards/S2-77_desktop-direct-site-provider-client-boundary-task-card.txt
+
+Forbidden changed areas:
+- src/App.Api/**
+- src/Modules/**
+- src/BuildingBlocks/Contracts/**
+- src/App.Web/**
+- src/App.Mobile.Android/**
+- src/App.UI.Shared/**
+- src/App.Worker/**
+- DB migrations
+- .github/workflows/**
+- deploy scripts
+- docs/ops/**
+- committed screenshots or runtime artifacts
+
+Contracts:
+No shared contract change.
+No BuildingBlocks.Contracts DTO.
+No App.Api request/response DTO.
+Client boundary is App.Desktop-local only.
+
+Feature flag / env guard:
+Use only App.Desktop-side config/options boundary from S2-73.
+Do not add credentials, tokens, signed URL generation, or live provider secret behavior.
+
+Migration:
+No migration.
+
+Events:
+None.
+
+Offline behavior:
+No runtime offline upload behavior change.
+Real provider upload remains unavailable offline unless later explicitly designed.
+
+Security:
+- Do not print or log password.
+- Do not print or log accessToken.
+- Do not print or log refreshToken.
+- Do not print or log Authorization header.
+- Do not print or log provider credential values.
+- Do not print or log signed URL query secrets.
+- Do not print or log raw local file paths.
+- Do not print or log raw request/response bodies.
+- Do not include screenshots or runtime artifacts.
+
+Implementation scope:
+- Add App.Desktop-local provider client interface or boundary.
+- Add disabled/unavailable provider client implementation.
+- The disabled client may accept App.Desktop-local request/response models only as local values.
+- Disabled client must not send video bytes.
+- Disabled client must not use HttpClient or HTTP upload primitives.
+- Disabled client must return safe unavailable/failure classification.
+- Disabled client diagnostics must be redacted.
+- Composition may register the disabled provider client if needed.
+- Existing IDesktopDirectSiteUploadClient remains disabled/unavailable.
+- Do not add HttpDesktopDirectSiteUploadClient.
+- Do not implement provider wire HTTP request.
+- Do not implement real provider response parsing.
+- Do not add shared DTOs.
+- Do not add App.Api endpoint.
+- Do not change UploadReceipt contract.
+
+Suggested implementation files:
+- src/App.Desktop/Services/Upload/IDesktopDirectSiteProviderClient.cs
+- src/App.Desktop/Services/Upload/DisabledDesktopDirectSiteProviderClient.cs
+- tests/Unit/App.Desktop.Tests/DisabledDesktopDirectSiteProviderClientTests.cs
+- existing DesktopCompositionRootTests.cs if composition registration is changed
+
+Definition of done:
+- Provider client boundary exists and is testable.
+- Disabled provider client exists and is testable.
+- Disabled provider client returns unavailable/failure response without network activity.
+- Disabled provider client diagnostics are redacted.
+- No HTTP upload primitives are added.
+- No HttpDesktopDirectSiteUploadClient is added.
+- Valid request/response models do not enable real upload.
+- Existing IDesktopDirectSiteUploadClient remains disabled/unavailable.
+- No App.Api/backend/contracts files are changed.
+- Targeted App.Desktop build/test/format passes.
+
+Validation:
+- dotnet restore src/App.Desktop/App.Desktop.csproj
+- dotnet restore tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj
+- dotnet format whitespace src/App.Desktop/App.Desktop.csproj --verify-no-changes --no-restore
+- dotnet format whitespace tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj --verify-no-changes --no-restore
+- dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal
+- dotnet build tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal
+- dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal --no-build
+- git diff --check
+
+Rollback:
+Revert S2-77 PR.
+
+NO-GO:
+- Do not implement real HTTP upload.
+- Do not add HttpDesktopDirectSiteUploadClient.
+- Do not use HttpClient / SendAsync / PostAsync / PutAsync / MultipartFormDataContent / StreamContent for upload.
+- Do not add shared DTOs.
+- Do not add BuildingBlocks.Contracts types.
+- Do not add App.Api endpoint.
+- Do not add backend/module code.
+- Do not send video bytes through App.Api.
+- Do not send video bytes anywhere.
+- Do not add provider credentials or tokens.
+- Do not run live Korobochka smoke for this task.

--- a/src/App.Desktop/Composition/DesktopCompositionRoot.cs
+++ b/src/App.Desktop/Composition/DesktopCompositionRoot.cs
@@ -92,6 +92,7 @@ public static class DesktopCompositionRoot
         services.AddSingleton(effectiveUploadSectionOptions);
         services.AddSingleton(effectiveGroupTreeOptions);
         services.AddSingleton(directSiteProviderOptions);
+        services.AddSingleton<IDesktopDirectSiteProviderClient, DisabledDesktopDirectSiteProviderClient>();
         services.AddSingleton<IDesktopShellLifecycle, PlaceholderDesktopShellLifecycle>();
         services.AddSingleton<IDesktopSessionStore, DisabledDesktopSessionStore>();
         services.AddSingleton<DesktopSessionState>();

--- a/src/App.Desktop/Services/Upload/DisabledDesktopDirectSiteProviderClient.cs
+++ b/src/App.Desktop/Services/Upload/DisabledDesktopDirectSiteProviderClient.cs
@@ -1,0 +1,38 @@
+namespace App.Desktop.Services.Upload;
+
+public sealed class DisabledDesktopDirectSiteProviderClient : IDesktopDirectSiteProviderClient
+{
+    private const string DisabledFailureMessage = "Direct-site provider client is disabled.";
+
+    public bool EnablesRealUpload { get; }
+
+    public string DiagnosticText => ToString();
+
+    public ValueTask<DesktopDirectSiteUploadResponse> UploadAsync(
+        DesktopDirectSiteUploadRequest request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!request.IsValid || request.ProviderKey is null || request.CorrelationId is null)
+        {
+            return ValueTask.FromResult(DesktopDirectSiteUploadResponse.Invalid);
+        }
+
+        return ValueTask.FromResult(DesktopDirectSiteUploadResponse.FromFailure(
+            request.ProviderKey,
+            DesktopDirectSiteUploadResponseStatus.FailedTerminal,
+            retryable: false,
+            DesktopDirectSiteUploadFailureKind.ProviderUnavailable,
+            DisabledFailureMessage,
+            request.CorrelationId.Value.ToString("D")));
+    }
+
+    public override string ToString()
+    {
+        return $"{nameof(DisabledDesktopDirectSiteProviderClient)} {{ "
+            + $"EnablesRealUpload = {EnablesRealUpload}, "
+            + "Status = Disabled, Diagnostics = <redacted> }}";
+    }
+}

--- a/src/App.Desktop/Services/Upload/IDesktopDirectSiteProviderClient.cs
+++ b/src/App.Desktop/Services/Upload/IDesktopDirectSiteProviderClient.cs
@@ -1,0 +1,8 @@
+namespace App.Desktop.Services.Upload;
+
+public interface IDesktopDirectSiteProviderClient
+{
+    ValueTask<DesktopDirectSiteUploadResponse> UploadAsync(
+        DesktopDirectSiteUploadRequest request,
+        CancellationToken cancellationToken);
+}

--- a/tests/Unit/App.Desktop.Tests/DisabledDesktopDirectSiteProviderClientTests.cs
+++ b/tests/Unit/App.Desktop.Tests/DisabledDesktopDirectSiteProviderClientTests.cs
@@ -1,0 +1,164 @@
+using App.Desktop.Boundaries;
+using App.Desktop.Composition;
+using App.Desktop.Services.Auth;
+using App.Desktop.Services.GroupTree;
+using App.Desktop.Services.Upload;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace App.Desktop.Tests;
+
+public sealed class DisabledDesktopDirectSiteProviderClientTests
+{
+    [Fact]
+    public async Task UploadAsyncReturnsUnavailableFailureForValidRequest()
+    {
+        var client = new DisabledDesktopDirectSiteProviderClient();
+        DesktopDirectSiteUploadRequest request = CreateRequest(CreateTargetWithSignedQuery(), "video.mp4");
+
+        DesktopDirectSiteUploadResponse response = await client.UploadAsync(request, CancellationToken.None);
+
+        Assert.True(response.IsValid);
+        Assert.False(response.IsSuccess);
+        Assert.False(response.EnablesRealUpload);
+        Assert.Equal(DesktopDirectSiteUploadResponseStatus.FailedTerminal, response.Status);
+        Assert.Equal(DesktopDirectSiteUploadFailureKind.ProviderUnavailable, response.FailureKind);
+        Assert.False(response.Retryable);
+        Assert.Equal("<redacted>", response.FailureMessageRedacted);
+        AssertSafe(response.DiagnosticText);
+    }
+
+    [Fact]
+    public async Task UploadAsyncKeepsInvalidRequestInvalidWithoutUpload()
+    {
+        var client = new DisabledDesktopDirectSiteProviderClient();
+
+        DesktopDirectSiteUploadResponse response = await client.UploadAsync(
+            DesktopDirectSiteUploadRequest.Invalid,
+            CancellationToken.None);
+
+        Assert.False(response.IsValid);
+        Assert.False(response.EnablesRealUpload);
+        Assert.Equal(DesktopDirectSiteUploadResponseStatus.Unknown, response.Status);
+        Assert.Equal(DesktopDirectSiteUploadFailureKind.Unknown, response.FailureKind);
+        AssertSafe(response.DiagnosticText);
+    }
+
+    [Fact]
+    public async Task UploadAsyncDoesNotExposeSignedQueryOrLocalPath()
+    {
+        var client = new DisabledDesktopDirectSiteProviderClient();
+        string localPath = string.Concat("D:", "\\", "capture", "\\", "clip.mp4");
+        DesktopDirectSiteUploadRequest request = CreateRequest(CreateTargetWithSignedQuery(), localPath);
+
+        DesktopDirectSiteUploadResponse response = await client.UploadAsync(request, CancellationToken.None);
+        string diagnosticText = response.ToString();
+
+        Assert.True(response.IsValid);
+        Assert.DoesNotContain("query-secret-marker", diagnosticText, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(localPath, diagnosticText, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("D:\\capture", diagnosticText, StringComparison.OrdinalIgnoreCase);
+        AssertSafe(diagnosticText);
+    }
+
+    [Fact]
+    public async Task UploadAsyncDoesNotExposeSensitiveOrRawBodyMarkers()
+    {
+        var client = new DisabledDesktopDirectSiteProviderClient();
+        DesktopDirectSiteUploadRequest request = CreateRequest(CreateTargetWithSignedQuery(), "clip.mp4");
+
+        DesktopDirectSiteUploadResponse response = await client.UploadAsync(request, CancellationToken.None);
+        string diagnosticText = response.DiagnosticText;
+
+        Assert.True(response.IsValid);
+        Assert.DoesNotContain("sample-password-marker", diagnosticText, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("sample-access-token-marker", diagnosticText, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("sample-refresh-token-marker", diagnosticText, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("sample-authorization-marker", diagnosticText, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("sample-provider-credential-marker", diagnosticText, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("raw request body marker", diagnosticText, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("raw response body marker", diagnosticText, StringComparison.OrdinalIgnoreCase);
+        AssertSafe(diagnosticText);
+    }
+
+    [Fact]
+    public void DiagnosticsAndToStringRemainRedacted()
+    {
+        var client = new DisabledDesktopDirectSiteProviderClient();
+
+        string diagnosticText = client.DiagnosticText;
+
+        Assert.False(client.EnablesRealUpload);
+        Assert.Contains("Status = Disabled", diagnosticText, StringComparison.Ordinal);
+        Assert.Contains("Diagnostics = <redacted>", diagnosticText, StringComparison.Ordinal);
+        AssertSafe(diagnosticText);
+    }
+
+    [Fact]
+    public void CompositionResolvesDisabledProviderClientAndKeepsSiteUploadDisabled()
+    {
+        using ServiceProvider services = DesktopCompositionRoot.BuildServices(
+            DesktopAuthOptions.FromControlPlaneBaseAddress("https://control-plane.local"),
+            DesktopUploadSectionOptions.Disabled,
+            DesktopGroupTreeOptions.EnabledForLiveControlPlane,
+            DesktopDirectSiteProviderOptions.FromEnvironmentValues(
+                "korobochka-direct",
+                "https://upload.korobochka.local"));
+
+        DesktopDirectSiteProviderOptions options = services.GetRequiredService<DesktopDirectSiteProviderOptions>();
+
+        Assert.True(options.IsProviderConfigPresent);
+        Assert.True(options.IsProviderConfigValid);
+        Assert.False(options.IsDirectSiteUploadAvailable);
+        Assert.IsType<DisabledDesktopDirectSiteProviderClient>(
+            services.GetRequiredService<IDesktopDirectSiteProviderClient>());
+        Assert.IsType<DisabledDesktopDirectSiteUploadClient>(
+            services.GetRequiredService<IDesktopDirectSiteUploadClient>());
+    }
+
+    private const string Sha256 = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    private static DesktopDirectSiteUploadTarget CreateTargetWithSignedQuery()
+    {
+        string endpointUri = new UriBuilder("https", "upload.korobochka.local")
+        {
+            Path = "upload/video",
+            Query = "signature=query-secret-marker"
+        }.Uri.ToString();
+
+        return DesktopDirectSiteUploadTarget.FromMetadata(
+            "korobochka-direct",
+            endpointUri,
+            "POST",
+            Guid.NewGuid().ToString("D"));
+    }
+
+    private static DesktopDirectSiteUploadRequest CreateRequest(
+        DesktopDirectSiteUploadTarget target,
+        string displayFileName)
+    {
+        return DesktopDirectSiteUploadRequest.FromMetadata(
+            target,
+            Guid.NewGuid().ToString("D"),
+            "business-object-001",
+            1024,
+            Sha256,
+            "video/mp4",
+            "idem-001",
+            Guid.NewGuid().ToString("D"),
+            displayFileName);
+    }
+
+    private static void AssertSafe(string text)
+    {
+        Assert.DoesNotContain("query-secret-marker", text, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("D:\\capture", text, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("raw request", text, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("raw response", text, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("sample-password-marker", text, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("sample-access-token-marker", text, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("sample-refresh-token-marker", text, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("sample-authorization-marker", text, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("sample-provider-credential-marker", text, StringComparison.OrdinalIgnoreCase);
+    }
+}


### PR DESCRIPTION
## Related issue / task card

Task card:
docs/task-cards/S2-77_desktop-direct-site-provider-client-boundary-task-card.txt

## Purpose

Add an App.Desktop-local direct-site provider client boundary plus disabled/no-live implementation for future provider integration.

This is still not a real upload implementation.

## Scope

Implemented:
- App.Desktop-local IDesktopDirectSiteProviderClient boundary
- DisabledDesktopDirectSiteProviderClient unavailable implementation
- composition registration to disabled provider client
- tests for disabled response, redacted diagnostics, and composition safety

Explicitly not implemented:
- no real HTTP upload
- no HttpDesktopDirectSiteUploadClient
- no provider wire HTTP request
- no provider response parsing
- no shared DTO / BuildingBlocks.Contracts model
- no App.Api endpoint
- no video bytes sent anywhere
- no live Korobochka smoke
- no out-of-scope analyzer warning fixes

## Changed files

- docs/task-cards/S2-77_desktop-direct-site-provider-client-boundary-task-card.txt
- src/App.Desktop/Composition/DesktopCompositionRoot.cs
- src/App.Desktop/Services/Upload/DisabledDesktopDirectSiteProviderClient.cs
- src/App.Desktop/Services/Upload/IDesktopDirectSiteProviderClient.cs
- tests/Unit/App.Desktop.Tests/DisabledDesktopDirectSiteProviderClientTests.cs

## Contracts / platform impact

- [x] no BuildingBlocks.Contracts change
- [x] no App.Api change
- [x] no backend/module change
- [x] no App.Web/App.Mobile.Android/App.UI.Shared/App.Worker change
- [x] no deploy workflow or DB migration change

## Validation

- dotnet restore src/App.Desktop/App.Desktop.csproj: PASS
- dotnet restore tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj: PASS
- dotnet format whitespace src/App.Desktop/App.Desktop.csproj --verify-no-changes --no-restore: PASS
- dotnet format whitespace tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj --verify-no-changes --no-restore: PASS
- dotnet build src/App.Desktop/App.Desktop.csproj -nologo -v minimal: PASS
- dotnet build tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal: PASS
- dotnet test tests/Unit/App.Desktop.Tests/App.Desktop.Tests.csproj -nologo -v minimal --no-build: PASS, 243 passed
- git diff --check: PASS

Existing out-of-scope analyzer warnings are not fixed in this PR.

## Security / NO-GO

- No real direct-site upload implementation.
- No HttpDesktopDirectSiteUploadClient.
- No HttpClient / HttpRequestMessage / SendAsync / PostAsync / PutAsync / MultipartFormDataContent / StreamContent upload implementation.
- No App.Api endpoint.
- No backend/module code.
- No BuildingBlocks.Contracts changes.
- No video bytes through App.Api.
- No video bytes sent anywhere.
- No provider credentials or tokens.
- No live Korobochka smoke.
- Diagnostics are redacted; no provider credentials, signed URL secrets, raw local paths, raw request bodies, or raw response bodies are exposed.

## Notes for reviewers

Review focus:
- provider client boundary remains App.Desktop-local
- implementation is disabled/unavailable only
- existing IDesktopDirectSiteUploadClient remains disabled/unavailable
- real upload remains blocked/deferred

Recent commits:
ea05648 feat(desktop): add disabled direct site provider client boundary
13fd7c0 docs(desktop): add S2-77 direct site provider client boundary task card